### PR TITLE
Make report pandoc conversion to pdf compatible

### DIFF
--- a/avaframe/ana4Prob/probAna.py
+++ b/avaframe/ana4Prob/probAna.py
@@ -28,6 +28,7 @@ def probAnalysis(avaDir, cfg, cfgMain, inputDir='', outDir=''):
     if inputDir == '':
         inputDir = os.path.join(avaDir, 'Outputs', 'com1DFA', 'peakFiles')
         outDir = os.path.join(avaDir, 'Outputs', 'ana4Prob')
+        fU.makeADir(outDir)
 
     # Load all infos on simulations
     peakFiles = fU.makeSimDict(inputDir, cfgMain['PARAMETERVAR']['varPar'], avaDir)

--- a/avaframe/log2Report/generateCompareReport.py
+++ b/avaframe/log2Report/generateCompareReport.py
@@ -77,6 +77,7 @@ def writeCompareReport(reportFile, reportD, benchD, avaName, cfgRep):
             if value != 'type':
                 # pfile.write('##### Topic:  %s \n' % value)
                 pfile.write('%s \n' % (benchD['Test Info'][value]))
+                pfile.write(' \n')
 
         # Create lists to write tables
         parameterList, valuesSim, valuesBench = makeLists(reportD['Simulation Parameters'], benchD['Simulation Parameters'])
@@ -84,6 +85,7 @@ def writeCompareReport(reportFile, reportD, benchD, avaName, cfgRep):
         # PARAMETER BLOCK
         # Table listing all the simulation parameters
         pfile.write('#### Simulation Parameters \n')
+        pfile.write(' \n')
         pfile.write('| Parameter | Reference | Simulation | \n')
         pfile.write('| --------- | --------- | ---------- | \n')
         countValue = 0
@@ -105,9 +107,11 @@ def writeCompareReport(reportFile, reportD, benchD, avaName, cfgRep):
 
         # IMAGE BLOCK
         pfile.write('#### Comparison Plots \n')
+        pfile.write(' \n')
         for value in reportD['Simulation Results']:
             if value != 'type':
                 pfile.write('##### Figure:   %s \n' % value)
+                pfile.write(' \n')
                 maxDiff = max(abs(float(reportD['Simulation Difference'][value][2])),
                                  abs(float(reportD['Simulation Difference'][value][0])))
                 maxVal = float(reportD['Simulation Stats'][value][0])
@@ -117,7 +121,10 @@ def writeCompareReport(reportFile, reportD, benchD, avaName, cfgRep):
                                  reportD['Simulation Difference'][value][1], reportD['Simulation Difference'][value][2])
                     pfile.write(' %s \n' % textString1)
                     pfile.write(' %s \n' % textString2)
+                    pfile.write(' \n')
                 pfile.write('![%s](%s) \n' % (value, reportD['Simulation Results'][value]))
+                pfile.write('\ \n')
+                pfile.write(' \n')
 
         pfile.write(' \n')
         pfile.write('------------------------------------------------------------------------- \n')

--- a/avaframe/log2Report/generateReport.py
+++ b/avaframe/log2Report/generateReport.py
@@ -66,6 +66,7 @@ def writeReportFile(reportD, pfile):
             # Table listing the key : value pairs in columns
             if reportD[key][subKey] == 'columns':
                 pfile.write('### %s \n' % key)
+                pfile.write(' \n')
                 for value in reportD[key]:
                     if value != 'type':
                         pfile.write('| %s ' % value)

--- a/avaframe/log2Report/generateReport.py
+++ b/avaframe/log2Report/generateReport.py
@@ -43,17 +43,20 @@ def writeReportFile(reportD, pfile):
                 for value in reportD[key]:
                     if value != 'type':
                         pfile.write('# %s \n' % reportD[key][value])
+                        pfile.write(' \n')
                         break
             # Simulation name
             if reportD[key][subKey] == 'simName':
                 for value in reportD[key]:
                     if value != 'type':
                         pfile.write('### Simulation name: *%s* \n' % reportD[key][value])
+                        pfile.write(' \n')
 
             # PARAMETER BLOCK
             # Table listing all the key : value pairs in rows
             if reportD[key][subKey] == 'list':
                 pfile.write('### %s \n' % key)
+                pfile.write(' \n')
                 pfile.write('| Parameters | Values | \n')
                 pfile.write('| ---------- | ------ | \n')
                 for value in reportD[key]:
@@ -80,18 +83,25 @@ def writeReportFile(reportD, pfile):
             # IMAGE BLOCK
             if reportD[key][subKey] == 'image':
                 pfile.write('### %s \n' % key)
+                pfile.write(' \n')
                 for value in reportD[key]:
                     if value != 'type':
                         pfile.write('##### Figure:   %s \n' % value)
+                        pfile.write(' \n')
                         pfile.write('![%s](%s) \n' % (value, reportD[key][value]))
+                        pfile.write('\ \n')
+                        pfile.write(' \n')
 
             # TEXT BLOCK
             if reportD[key][subKey] == 'text':
                 pfile.write('### %s \n' % key)
+                pfile.write(' \n')
                 for value in reportD[key]:
                     if value != 'type':
                         pfile.write('##### Topic:  %s \n' % value)
+                        pfile.write(' \n')
                         pfile.write('%s \n' % (reportD[key][value]))
+                        pfile.write(' \n')
 
 
 def writeReport(outDir, reportDictList, cfgFLAGS, plotDict=''):

--- a/avaframe/out3Plot/outQuickPlot.py
+++ b/avaframe/out3Plot/outQuickPlot.py
@@ -133,7 +133,7 @@ def generatePlot(dataDict, avaName, outDir, cfg, plotDict):
     plotDict['stats'].append(np.amax(data2))
     plotDict['stats'].append(np.amin(data2))
 
-    fig.close('all')
+    plt.close('all')
 
     return plotDict
 

--- a/avaframe/tests/test_generateReport.py
+++ b/avaframe/tests/test_generateReport.py
@@ -46,8 +46,8 @@ def test_writeReport(tmp_path):
 
     # Test
     assert lineVals[0] == '# This is my report title \n'
-    assert lineVals[4] == '| ---------- | ------ | \n'
-    assert lineVals[5] == '| release area | release1HS2 | \n'
-    assert lineVals[14] == '| Additional snow-covered area | \n'
-    assert lineVals[15] == '| ----------| \n'
-    assert lineVals[-1] == '![Peak Pressure Field of my test](release1HS2_entres_dfa_0.750_pfd.png) \n'
+    assert lineVals[7] == '| ---------- | ------ | \n'
+    assert lineVals[8] == '| release area | release1HS2 | \n'
+    assert lineVals[19] == '| Additional snow-covered area | \n'
+    assert lineVals[20] == '| ----------| \n'
+    assert lineVals[-3] == '![Peak Pressure Field of my test](release1HS2_entres_dfa_0.750_pfd.png) \n'


### PR DESCRIPTION
* and adjust to plt.close('all') 
* introduce empty lines in the generation of markdown reports 
 fixes #196 