### PR TITLE
add global units fix #125

### DIFF
--- a/avaframe/com1DFA/com1DFACfg.ini
+++ b/avaframe/com1DFA/com1DFACfg.ini
@@ -41,7 +41,3 @@ RelTh = 1.00000
 [REPORT]
 # which result parameters shall be included as plots in report
 plotFields = ppr_pfd
-# units for output variables
-unitppr = kPa
-unitpfd = m
-unitpv = ms-1

--- a/avaframe/out1Peak/outPlotAllPeak.py
+++ b/avaframe/out1Peak/outPlotAllPeak.py
@@ -107,7 +107,7 @@ def plotAllFields(avaDir, inputDir, outDir, cfg=''):
         nx = data.shape[1]
         Ly = ny*cellSize
         Lx = nx*cellSize
-        unit = cfgPlotUtils['unit%s' % peakFiles['resType'][m]]
+        unit = cfgPlotUtils['unit%s' % cfg['GENERAL']['peakVar']]
 
         # Figure  shows the result parameter data
         fig = plt.figure(figsize=(figW, figH))

--- a/avaframe/out1Peak/outPlotAllPeak.py
+++ b/avaframe/out1Peak/outPlotAllPeak.py
@@ -46,7 +46,7 @@ def plotAllPeakFields(avaDir, cfg, cfgFLAGS, modName='com1DFA'):
 
         # Load data
         data = np.loadtxt(fileName, skiprows=6)
-        unit = cfg['REPORT']['unit%s' % peakFiles['resType'][m]]
+        unit = cfgPlotUtils['unit%s' % peakFiles['resType'][m]]
 
         # Set extent of peak file
         cellSize = peakFiles['cellSize'][m]
@@ -107,7 +107,7 @@ def plotAllFields(avaDir, inputDir, outDir, cfg=''):
         nx = data.shape[1]
         Ly = ny*cellSize
         Lx = nx*cellSize
-        unit = cfg['GENERAL']['unit']
+        unit = cfgPlotUtils['unit%s' % peakFiles['resType'][m]]
 
         # Figure  shows the result parameter data
         fig = plt.figure(figsize=(figW, figH))

--- a/avaframe/out3Plot/outAIMEC.py
+++ b/avaframe/out3Plot/outAIMEC.py
@@ -83,7 +83,7 @@ def visuTransfo(rasterTransfo, inputData, cfgPath, cfgFlags):
 
     ax1.set_title('XY Domain')
     ax1.legend(loc=4)
-    plotUtils.putAvaNameOnPlot(ax1, cfgPath['projectName'])
+    putAvaNameOnPlot(ax1, cfgPath['projectName'])
 
     ax2 = plt.subplot(122)
 
@@ -95,7 +95,7 @@ def visuTransfo(rasterTransfo, inputData, cfgPath, cfgFlags):
 
     ax2.set_title('sl Domain' + '\n' + 'Black = out of raster')
     ax2.legend(loc=4)
-    addColorBar(im, ax2, ticks, 'kPa')
+    addColorBar(im, ax2, ticks, cfgPlotUtils['unitppr'])
 
     outFileName = '_'.join([projectName, dirName, 'DomainTransformation'])
     saveAndOrPlot(cfgPath, cfgFlags, outFileName, fig)
@@ -149,8 +149,8 @@ def visuRunout(rasterTransfo, resAnalysis, plim, newRasters, cfgPath, cfgFlags):
 
     ax1.set_title('Peak Pressure 2D plot for the reference')
     ax1.legend(loc=4)
-    plotUtils.putAvaNameOnPlot(ax1, cfgPath['projectName'])
-    addColorBar(im, ax1, ticks, 'kPa')
+    putAvaNameOnPlot(ax1, cfgPath['projectName'])
+    addColorBar(im, ax1, ticks, cfgPlotUtils['unitppr'])
 
     ax2 = plt.subplot(122)
 
@@ -201,7 +201,7 @@ def visuSimple(rasterTransfo, resAnalysis, newRasters, cfgPath, cfgFlags):
     # prepare for plot
     Cmap = [cmapPres, cmapDepth, cmapSpeed]
     Title = ['Peak Pressure', 'Peak Flow Depth', 'Peak Speed']
-    Unit = [' [kPa]', ' [m]', ' [m/s]']
+    Unit = [cfgPlotUtils['unitppr'], cfgPlotUtils['unitpfd'], cfgPlotUtils['unitpv']]
     Data = np.array(([None] * 3))
     Data[0] = rasterdataPres
     Data[1] = rasterdataDepth
@@ -228,7 +228,7 @@ def visuSimple(rasterTransfo, resAnalysis, newRasters, cfgPath, cfgFlags):
         ax.set_title(title)
         ax.legend(loc=4)
         addColorBar(im, ax, ticks, unit)
-        plotUtils.putAvaNameOnPlot(ax, cfgPath['projectName'])
+        putAvaNameOnPlot(ax, cfgPath['projectName'])
 
     outFileName = '_'.join([projectName, dirName,'plim',
                             str(int(plim)), 'referenceFields'])
@@ -275,11 +275,11 @@ def visuComparison(rasterTransfo, resAnalysis, inputs, cfgPath, cfgFlags):
 
     ax1.set_title('Reference Peak Pressure in the RunOut area' +
                   '\n' + 'Pressure threshold: %.1f kPa' % plim)
-    addColorBar(im, ax1, ticks, 'kPa')
+    addColorBar(im, ax1, ticks, cfgPlotUtils['unitppr'])
 
     y_lim = s[indRunoutPoint+20]+np.nanmax(resAnalysis['runout'][0])
     ax1.set_ylim([s[indRunoutPoint], y_lim])
-    plotUtils.putAvaNameOnPlot(ax1, cfgPath['projectName'])
+    putAvaNameOnPlot(ax1, cfgPath['projectName'])
     ax2 = plt.subplot(122)
     colorsList = [[0, 0, 1], [1, 1, 1], [1, 0, 0]]
     cmap = matplotlib.colors.ListedColormap(colorsList)
@@ -455,7 +455,7 @@ def resultVisu(cfgPath, cfgFlags, rasterTransfo, resAnalysis, plim):
     ax1.tick_params(axis='y', colors=color[-3])
     ax1.set_xlabel(''.join(['s [m] - runout with ', str(plim),
                             ' kPa threshold']))
-    plotUtils.putAvaNameOnPlot(ax1, cfgPath['projectName'])
+    putAvaNameOnPlot(ax1, cfgPath['projectName'])
     if plotDensity:  # estimate 2D histogram --> create pcolormesh
         nbins = 100
         H, xedges, yedges = np.histogram2d(runout, data, bins=nbins)
@@ -510,7 +510,7 @@ def resultVisu(cfgPath, cfgFlags, rasterTransfo, resAnalysis, plim):
     ax1.set_title('Normalized difference compared to reference')
     ax1.set_ylabel('True positive rate')
     ax1.set_xlabel('False positive rate')
-    plotUtils.putAvaNameOnPlot(ax1, cfgPath['projectName'])
+    putAvaNameOnPlot(ax1, cfgPath['projectName'])
     if plotDensity:  # estimate 2D histogram --> create pcolormesh
         nbins = 100
         H, xedges, yedges = np.histogram2d(rFP, rTP, bins=nbins)

--- a/avaframe/out3Plot/outQuickPlot.py
+++ b/avaframe/out3Plot/outQuickPlot.py
@@ -179,7 +179,7 @@ def quickPlot(avaDir, suffix, val, parameter, cfg, cfgPlot, rel='', simType='nul
         data = fU.makeSimDict(workDir, '', avaDir)
 
     cellSize = data['cellSize'][0]
-    unit = cfgPlot['PLOT']['unit%s' % suffix]
+    unit = cfgPlotUtils['unit%s' % suffix]
 
     # check if release Area and simType area provided
     if rel != '':
@@ -189,7 +189,6 @@ def quickPlot(avaDir, suffix, val, parameter, cfg, cfgPlot, rel='', simType='nul
         relAreas = set(data['releaseArea'])
     if parameter == 'simType':
         simType = val
-
 
     for rel in relAreas:
 

--- a/avaframe/out3Plot/outQuickPlotCfg.ini
+++ b/avaframe/out3Plot/outQuickPlotCfg.ini
@@ -10,9 +10,5 @@ values = null
 parameter = simType
 # output variable to be plotted
 outputVariable = ppr_pfd_pv
-# units for output variables
-unitppr = kPa
-unitpfd = m
-unitpv = ms-1
 # name of reference model type for simulation files
 refModel = ref

--- a/avaframe/out3Plot/plotUtils.py
+++ b/avaframe/out3Plot/plotUtils.py
@@ -26,6 +26,7 @@ log = logging.getLogger(__name__)
 # Load all input Parameters from config file
 # get the configuration of an already imported module
 cfg = cfgUtils.getModuleConfig(plotUtils)
+cfgPlotUtils = cfg['UNITS']
 cfg = cfg['MAIN']
 
 # define seaborn style and color maps
@@ -207,7 +208,7 @@ def addColorBar(im, ax2, ticks, myUnit):
     '''
     cbar = ax2.figure.colorbar(im, ax=ax2, ticks=ticks)
     cbar.outline.set_visible(False)
-    cbar.ax.set_title(myUnit)
+    cbar.ax.set_title('[$' + myUnit + '$]')
 
 
 def putAvaNameOnPlot(ax, avaDir):

--- a/avaframe/out3Plot/plotUtilsCfg.ini
+++ b/avaframe/out3Plot/plotUtilsCfg.ini
@@ -23,7 +23,7 @@ tickLabelSize = small
 # set output extension {png, ps, pdf, svg}
 # this is not working at the moment, see issue #208
 # only png is allowed
-savefigFormat = png 
+savefigFormat = png
 
 # define figure resolution (dpi)
 figResolution = 150
@@ -35,3 +35,9 @@ usetex = False
 
 # plotting with a discrete (contCmap = False) or continuous colormap (contCmap = True)?
 contCmap = False
+
+[UNITS]
+# units for output variables
+unitppr = kPa
+unitpfd = m
+unitpv = m.s^{-1}


### PR DESCRIPTION
Defining units in the plotUtils.ini
Those units can then be accessed by the cfgPlotUtils['unitppr'] (unitpv or unitpfd)
This is now used in aimec, outPeakPlot and outSimplePlot when callind addColorBar
fix #125 