### PR TITLE
Remove defaultCellSize setting; fixes #207

### DIFF
--- a/avaframe/com1DFA/CreateProject.cint
+++ b/avaframe/com1DFA/CreateProject.cint
@@ -5,8 +5,7 @@ int MAXSTRLEN = 512;
 void CreateProject(char Com1DFAProjectDir[], char DhmFile[],
                    char DhmName[], char RelFile[][512],
                    char EntFile[][512],
-                   char ResFile[][512],
-                   char cellsize[]) {
+                   char ResFile[][512]) {
   int i;
   char name[512];
   char Dhm[512];
@@ -31,7 +30,6 @@ void CreateProject(char Com1DFAProjectDir[], char DhmFile[],
 
   // choose DHM
   sprintf(Dhm, "%s", DhmFile);
-  set("Project/DHMs", "SimulationDefaultCellSize", cellsize);
   set("Project/DHMs", "Import", Dhm);
   sprintf(name,"Project/DHMs/%s_simulation",DhmName);
   set(name, "Active", "1");
@@ -97,7 +95,6 @@ int main()
   char DhmPath[512], DhmName[512], DhmFile[512];
   char SimName[512];
   char ReleaseFile[512];
-  char CellSize[128];
   char RelFiles[512];
   char EntFiles[512];
   char ResFiles[512];
@@ -109,14 +106,13 @@ int main()
   strcpy(Com1DFAProjectDir, "##PROJECTDIR##");
   strcpy(DhmFile,  "##DHMFILE##");
   strcpy(DhmName,  "##DHMNAME##");
-  strcpy(CellSize,  "##CELLSIZE##");
   strcpy(RelFiles,"##RELFILE##");
   strcpy(EntFiles,"##ENTFILE##");
   strcpy(ResFiles,"##RESFILE##");
 
   // --- Calls
   CreateProject(Com1DFAProjectDir, DhmFile,
-                DhmName, RelFiles, EntFiles,  ResFiles, CellSize);
+                DhmName, RelFiles, EntFiles,  ResFiles);
 
   printf("[BatchCom1DFA] Project %s created!\n", Com1DFAProjectDir);
   return 0;

--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -135,11 +135,7 @@ def com1DFAMain(cfg, avaDir):
         entrainmentArea = os.path.splitext(os.path.basename(ent))[0]
         resistanceArea = os.path.splitext(os.path.basename(res))[0]
 
-    # Get cell size from DEM header
-    demData = aU.readASCheader(dem)
-    cellSize = demData.cellsize
-
-     # Parameter variation
+    # Parameter variation
     if cfgPar.getboolean('flagVarPar'):
         varPar = cfgPar['varPar']
     else:
@@ -175,7 +171,6 @@ def com1DFAMain(cfg, avaDir):
         copyReplace(templateFile, workFile, '##PROJECTDIR##', projDir)
         copyReplace(workFile, workFile, '##DHMFILE##', dem)
         copyReplace(workFile, workFile, '##DHMNAME##', demName)
-        copyReplace(workFile, workFile, '##CELLSIZE##', cellSize)
         copyReplace(workFile, workFile, '##RELFILE##', rel)
         copyReplace(workFile, workFile, '##ENTFILE##', ent)
         copyReplace(workFile, workFile, '##RESFILE##', res)


### PR DESCRIPTION
Remove the defaultCellSize setting. 
This set defaultCellSize to the cellsize originating in the DEM asc file! Up to the real cases this was not problem as the cellsize in the DEM is 5, however with the real cases, problems arose due to slight differences. 

*This behaviour is not (yet) wanted, as we require com1DFA to be simulated at the (calibrated) 5m resolution.* 

Will allow #235 to proceed.  