### PR TITLE
Add export of particle dictionaries as pickles

### DIFF
--- a/avaframe/com1DFAPy/com1DFA.py
+++ b/avaframe/com1DFAPy/com1DFA.py
@@ -1113,11 +1113,20 @@ def savePartToPickle(dictList, outDir):
         for dict in dictList:
             pickle.dump(dict, open(os.path.join(outDir, "particles%f.p" % dict['t']), "wb"))
     else:
-        pickle.dump(dictList, open(os.path.join(outDir, "particles.p"), "wb"))
+        pickle.dump(dictList, open(os.path.join(outDir, "particles%f.p" % dictList['t']), "wb"))
 
 
 def readPartFromPickle(inDir, flagAvaDir=False):
-    """ Read pickles within a directory and return List of dicionaries read from pickle """
+    """ Read pickles within a directory and return List of dicionaries read from pickle
+
+        Parameters
+        -----------
+        inDir: str
+            path to input directory
+        flagAvaDir: bool
+            if True inDir corresponds to an avalanche directory and pickles are
+            saved to avaDir/Outputs/com1DFAPy/particles 
+    """
 
     if flagAvaDir:
         inDir = os.path.join(inDir, 'Outputs', 'com1DFAPy', 'particles')

--- a/avaframe/com1DFAPy/com1DFA.py
+++ b/avaframe/com1DFAPy/com1DFA.py
@@ -1100,10 +1100,21 @@ def removePart(particles, mask, nRemove):
 
 
 def savePartToPickle(dictList, outDir):
-    """ Save dictionary to pickle """
+    """ Save each dictionary from a list to a pickle in outDir; works also for one dictionary instead of list
 
-    for dict in dictList:
-        pickle.dump(dict, open(os.path.join(outDir, "particles%f.p" % dict['t']), "wb"))
+        Parameters
+        ---------
+        dictList: list or dict
+            list of dictionaries or single dictionary
+        outDir: str
+            path to output directory
+    """
+    if len(dictList) > 1:
+        for dict in dictList:
+            pickle.dump(dict, open(os.path.join(outDir, "particles%f.p" % dict['t']), "wb"))
+    else:
+        pickle.dump(dictList, open(os.path.join(outDir, "particles.p"), "wb"))
+
 
 def readPartFromPickle(inDir, flagAvaDir=False):
     """ Read pickles within a directory and return List of dicionaries read from pickle """
@@ -1116,10 +1127,13 @@ def readPartFromPickle(inDir, flagAvaDir=False):
 
     # initialise list of particle dictionaries
     Particles = []
+    TimeStepInfo = []
     for particles in PartDicts:
-        Particles.append(pickle.load(open(particles, "rb")))
+        particles = pickle.load(open(particles, "rb"))
+        Particles.append(particles)
+        TimeStepInfo.append(particles['t'])
 
-    return Particles
+    return Particles, TimeStepInfo
 
 
 def exportFields(cfgGen, Tsave, Fields, relFile, demOri, outDir):

--- a/avaframe/com1DFAPy/com1DFA.py
+++ b/avaframe/com1DFAPy/com1DFA.py
@@ -6,6 +6,7 @@ import logging
 import time
 import os
 import numpy as np
+import glob
 import math
 import copy
 import pickle
@@ -1103,6 +1104,22 @@ def savePartToPickle(dictList, outDir):
 
     for dict in dictList:
         pickle.dump(dict, open(os.path.join(outDir, "particles%f.p" % dict['t']), "wb"))
+
+def readPartFromPickle(inDir, flagAvaDir=False):
+    """ Read pickles within a directory and return List of dicionaries read from pickle """
+
+    if flagAvaDir:
+        inDir = os.path.join(inDir, 'Outputs', 'com1DFAPy', 'particles')
+
+    # search for all pickles within directory
+    PartDicts = glob.glob(os.path.join(inDir, '*.p'))
+
+    # initialise list of particle dictionaries
+    Particles = []
+    for particles in PartDicts:
+        Particles.append(pickle.load(open(particles, "rb")))
+
+    return Particles
 
 
 def exportFields(cfgGen, Tsave, Fields, relFile, demOri, outDir):

--- a/avaframe/com1DFAPy/com1DFA.py
+++ b/avaframe/com1DFAPy/com1DFA.py
@@ -8,6 +8,7 @@ import os
 import numpy as np
 import math
 import copy
+import pickle
 import matplotlib.pyplot as plt
 import matplotlib.patheffects as PathEffects
 import matplotlib as mpl
@@ -1095,6 +1096,13 @@ def removePart(particles, mask, nRemove):
     particles['partInCell'] = particles['partInCell'][mask]
 
     return particles
+
+
+def savePartToPickle(dictList, outDir):
+    """ Save dictionary to pickle """
+
+    for dict in dictList:
+        pickle.dump(dict, open(os.path.join(outDir, "particles%f.p" % dict['t']), "wb"))
 
 
 def exportFields(cfgGen, Tsave, Fields, relFile, demOri, outDir):

--- a/avaframe/com1DFAPy/com1DFA.py
+++ b/avaframe/com1DFAPy/com1DFA.py
@@ -1125,7 +1125,7 @@ def readPartFromPickle(inDir, flagAvaDir=False):
             path to input directory
         flagAvaDir: bool
             if True inDir corresponds to an avalanche directory and pickles are
-            saved to avaDir/Outputs/com1DFAPy/particles 
+            read from avaDir/Outputs/com1DFAPy/particles 
     """
 
     if flagAvaDir:

--- a/avaframe/com1DFAPy/runCom1DFA.py
+++ b/avaframe/com1DFAPy/runCom1DFA.py
@@ -106,6 +106,10 @@ def runCom1DFAPy(avaDir='', cfgFile='', relTh='', flagAnalysis=True):
     tcpuDFA = time.time() - startTime
     log.info(('cpu time DFA = %s s' % (tcpuDFA)))
 
+    # export particles dictionaries of saving time steps
+    outDirData = os.path.join(outDir, 'particles')
+    fU.makeADir(outDirData)
+    com1DFA.savePartToPickle(Particles, outDirData)
 
     if flagAnalysis:
         # +++++++++POSTPROCESS++++++++++++++++++++++++


### PR DESCRIPTION
exports a pickle for each particle dictionary (for each dtSave) to Outputs/com1DFAPy/particles 

* particle dicionaries can be read with readPartFromPickle which returns a list of particle dictionaries and a list of corresponding time steps