### PR TITLE
Clean module files in output and work

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,5 @@
 [run]
+source = avaframe
 plugins = Cython.Coverage
 omit = */tests/*
        *run*.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [run]
 source = avaframe
 plugins = Cython.Coverage
-omit = */tests/*
-       *run*.py
+omit = */test_*
+       */__init__.py

--- a/.github/workflows/runTestSinglePython.yml
+++ b/.github/workflows/runTestSinglePython.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
@@ -37,7 +39,7 @@ jobs:
         if [ -f avaframe/com1DFAPy/DFAfunctionsCython.pyx ]; then python avaframe/com1DFAPy/setup.py build_ext --inplace --define CYTHON_TRACE; fi
     - name: Test with pytest
       run: |
-        pytest -rP --cov=./ --cov-report=xml --cov-config=.coveragerc
+        pytest --cov --cov-report=xml --cov-config=.coveragerc
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/avaframe/in3Utils/initializeProject.py
+++ b/avaframe/in3Utils/initializeProject.py
@@ -62,13 +62,11 @@ def cleanModuleFiles(avaDir, module):
 
     # output dir
     outDir =  os.path.join(avaDir, 'Outputs')
+    workDir =  os.path.join(avaDir, 'Work')
 
     log.info("Cleaning module %s in folder: %s ", modName, outDir)
     _checkForFolderAndDelete(outDir, modName)
-
-    # Try to remove Work folder, only pass FileNotFoundError, i.e. folder
-    # does not exist
-    _checkForFolderAndDelete(avaDir, 'Work')
+    _checkForFolderAndDelete(workDir, modName)
 
     return 'SUCCESS'
 
@@ -153,6 +151,8 @@ def createFolderStruct(pathAvaName):
         checkMakeDir(Inputs, cuDir)
 
     checkMakeDir(pathAvaName, 'Outputs')
+
+    checkMakeDir(pathAvaName, 'Work')
 
 
 def checkMakeDir(base, dirName):

--- a/avaframe/in3Utils/initializeProject.py
+++ b/avaframe/in3Utils/initializeProject.py
@@ -19,16 +19,8 @@ def _checkForFolderAndDelete(baseDir, folderName):
     except FileNotFoundError:
         log.debug("No %s folder found.", folderName)
 
-
-def cleanSingleAvaDir(avaDir, keep=None, deleteOutput=True):
-    '''
-    Clean a single avalanche directory of the work and output directories
-    Expects a avalanche directory name as string
-    and optional:
-    a log name to keep (and not delete)
-    Boolean to be able to avoid deletion of Outputs (true by default)
-    '''
-
+def _checkAvaDirVariable(avaDir):
+    '''Check for empty or nonString avaDir variable'''
     # check for empty avaDir name, abort if empty
     if not avaDir:
         log.warning("AvaDir variable is undefined, returning. ")
@@ -39,6 +31,60 @@ def cleanSingleAvaDir(avaDir, keep=None, deleteOutput=True):
     if not isString:
         log.warning("AvaDir is not a string, returning")
         return 'AvaDir is NOT a string'
+
+    return 'SUCCESS'
+
+def cleanModuleFiles(avaDir, module):
+    '''Cleans all generated files from the provided module in the outputs
+    folder. Also deletes the complete work folder
+
+    Parameters
+    ----------
+    avaDir : path/string
+        Avalanche directory path
+    module : module object
+        The module do delete.
+        e.g. from avaframe.com2AB import com2AB
+        leads to cleanModuleFiles(com2AB)
+        whereas
+        from avaframe.com2AB import com2AB as c2
+        leads to cleanModuleFiles(c2)
+    '''
+
+    # check for empty or non string variable
+    result = _checkAvaDirVariable(avaDir)
+    if not 'SUCCESS' in result:
+        return result
+
+    # get filename of module
+    modName = os.path.basename(module.__file__)
+    modName = os.path.splitext(modName)[0]
+
+    # output dir
+    outDir =  os.path.join(avaDir, 'Outputs')
+
+    log.info("Cleaning module %s in folder: %s ", modName, outDir)
+    _checkForFolderAndDelete(outDir, modName)
+
+    # Try to remove Work folder, only pass FileNotFoundError, i.e. folder
+    # does not exist
+    _checkForFolderAndDelete(avaDir, 'Work')
+
+    return 'SUCCESS'
+
+def cleanSingleAvaDir(avaDir, keep=None, deleteOutput=True):
+    '''
+    Clean a single avalanche directory of the work and output directories
+    Expects a avalanche directory name as string
+    and optional:
+    a log name to keep (and not delete)
+    Boolean to be able to avoid deletion of Outputs (true by default)
+    '''
+
+    # check for empty or non string variable
+    result = _checkAvaDirVariable(avaDir)
+    if not 'Success' in result:
+        return result
 
     # Info to user
     log.debug("Cleaning folder: %s ", avaDir)

--- a/avaframe/in3Utils/initializeProject.py
+++ b/avaframe/in3Utils/initializeProject.py
@@ -83,7 +83,7 @@ def cleanSingleAvaDir(avaDir, keep=None, deleteOutput=True):
 
     # check for empty or non string variable
     result = _checkAvaDirVariable(avaDir)
-    if not 'Success' in result:
+    if not 'SUCCESS' in result:
         return result
 
     # Info to user

--- a/avaframe/tests/test_initializeProject.py
+++ b/avaframe/tests/test_initializeProject.py
@@ -3,7 +3,43 @@ Tests for initialize and clean project routines
 '''
 import os
 from avaframe.in3Utils import initializeProject as initProj
+from avaframe.com2AB import com2AB as c2
 
+def test_cleanModuleFiles(tmp_path):
+
+    # Make sure cleanModuleFile catches:
+    # - empty variable
+    undefVar = initProj.cleanModuleFiles('','Module')
+    assert undefVar == 'AvaDir is empty'
+
+    # - non string variable
+    notAString = initProj.cleanModuleFiles(2,'Module')
+    assert notAString == 'AvaDir is NOT a string'
+
+    # create test directories
+    # then delete and check again
+    avaDir = tmp_path / "avaTestDir"
+    initProj.initializeFolderStruct(avaDir)
+
+    # make test dirs in outputs
+    for dirName in ['com2AB','com1DFA','TestDir']:
+        testDir = os.path.join(avaDir, 'Outputs', dirName)
+        os.makedirs(testDir)
+
+    # make test dirs in work
+    for dirName in ['com2AB','com1DFA','TestDir']:
+        testDir = os.path.join(avaDir, 'Work', dirName)
+        os.makedirs(testDir)
+
+    outputDir = os.path.join(avaDir,'Outputs')
+    workDir = os.path.join(avaDir,'Work')
+
+    # call the function
+    initProj.cleanModuleFiles(str(avaDir),c2)
+
+    # only 2 directories should remain in Work and Output
+    assert len(os.listdir(workDir)) == 2
+    assert len(os.listdir(outputDir)) == 2
 
 def test_cleanSingleAvaDir(tmp_path):
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,3 +9,6 @@ coverage:
     patch:
       default:
         informational: true
+
+ignore:
+  - "**/run*.py"


### PR DESCRIPTION
Providing a module (similar to cfgUtils) leads to the removal of the related files from outputs and work of an avalanche directory