### PR TITLE
Update aimec to compare sims from different comMods

### DIFF
--- a/avaframe/ana3AIMEC/ana3AIMECCfg.ini
+++ b/avaframe/ana3AIMEC/ana3AIMECCfg.ini
@@ -29,7 +29,7 @@ interpMethod = bilinear
 distance = 10
 
 # simulation results of which computational module, multiple possible separated by |
-comModules = 
+comModules = com1DFA|com1DFAPy
 
 #---------------------------------------
 

--- a/avaframe/ana3AIMEC/ana3AIMECCfg.ini
+++ b/avaframe/ana3AIMEC/ana3AIMECCfg.ini
@@ -29,7 +29,7 @@ interpMethod = bilinear
 distance = 10
 
 # simulation results of which computational module, multiple possible separated by |
-comModules = com1DFA
+comModules = 
 
 #---------------------------------------
 

--- a/avaframe/ana3AIMEC/ana3AIMECCfg.ini
+++ b/avaframe/ana3AIMEC/ana3AIMECCfg.ini
@@ -28,8 +28,8 @@ interpMethod = bilinear
 # resampling step [m]
 distance = 10
 
-# simulation results of which computational module, multiple possible separated by |
-comModules = com1DFA|com1DFAPy
+# computational module for comparison separated by |
+comModules =
 
 #---------------------------------------
 

--- a/avaframe/ana3AIMEC/ana3AIMECCfg.ini
+++ b/avaframe/ana3AIMEC/ana3AIMECCfg.ini
@@ -28,6 +28,9 @@ interpMethod = bilinear
 # resampling step [m]
 distance = 10
 
+# simulation results of which computational module, multiple possible separated by |
+comModules = com1DFA
+
 #---------------------------------------
 
 

--- a/avaframe/ana3AIMEC/dfa2Aimec.py
+++ b/avaframe/ana3AIMEC/dfa2Aimec.py
@@ -95,13 +95,13 @@ def extractMBInfo(avaDir, countStart=0):
 
         # Write mass balance info files
         for k in range(len(indRun)-1):
-            savename = os.path.join(os.getcwd(), avaDir, 'Work', 'ana3AIMEC', 'com1DFA', 'dfa_mass_balance', '%06d.txt' % (countFile + 1))
-            with open(savename, 'w') as MBFile:
+            saveName = os.path.join(os.getcwd(), avaDir, 'Work', 'ana3AIMEC', 'com1DFA', 'dfa_mass_balance', '%06d.txt' % (countFile + 1))
+            with open(saveName, 'w') as MBFile:
                 MBFile.write('time, current, entrained\n')
                 for m in range(indRun[k], indRun[k] + indRun[k+1] - indRun[k]-1):
                     MBFile.write('%.02f,    %.06f,    %.06f\n' %
                                  (logDict['time'][m], logDict['mass'][m], logDict['entrMass'][m]))
-            log.info('Saved to dfa_mass_balance/%s ' % (os.path.basename(savename)))
+            log.info('Saved to dfa_mass_balance/%s ' % (os.path.basename(saveName)))
             countFile = countFile + 1
 
     return countFile
@@ -115,9 +115,9 @@ def getMBInfo(avaDir, countStart=0):
 
     countFile = countStart
     for mFile in mbNames:
-        savename = os.path.join(avaDir, 'Work', 'ana3AIMEC', 'com1DFA', 'dfa_mass_balance', '%06d.txt' % (countFile + 1))
-        shutil.copy(mFile, savename)
-        log.info('%s copied to %s' % (mFile, savename))
+        saveName = os.path.join(avaDir, 'Work', 'ana3AIMEC', 'com1DFA', 'dfa_mass_balance', '%06d.txt' % (countFile + 1))
+        shutil.copy(mFile, saveName)
+        log.info('%s copied to %s' % (mFile, saveName))
         countFile = countFile + 1
 
     return countFile

--- a/avaframe/com1DFAPy/DFAfunctionsCython.pyx
+++ b/avaframe/com1DFAPy/DFAfunctionsCython.pyx
@@ -306,6 +306,7 @@ def computeForceC(cfg, particles, fields, dem, dT):
       # update mass
       m = m + dm
       mass[j] = m
+      dM[j] = dm
       # update surfacic entrainment mass available
       entrMassCell = entrMassCell - dm/areaCell
       if entrMassCell < 0:
@@ -592,6 +593,7 @@ def updatePositionC(cfg, particles, dem, force):
   particles['x'] = np.asarray(XNew)
   particles['y'] = np.asarray(YNew)
   particles['z'] = np.asarray(ZNew)
+  particles['massEntrained'] = np.asarray(massEntrained)
   log.debug('Entrained DFA mass: %s kg', np.asarray(massEntrained))
   particles['kineticEne'] = TotkinEneNew
   particles['potentialEne'] = TotpotEneNew

--- a/avaframe/com1DFAPy/com1DFA.py
+++ b/avaframe/com1DFAPy/com1DFA.py
@@ -111,7 +111,7 @@ def com1DFAMain(cfg, avaDir, relTh):
             relFiles = releaseLine['file']
             # ------------------------
             #  Start time step computation
-            Tsave, T, U, Z, S, Particles, Fields, infoDict = DFAIterate(cfgGen, particles, fields, dem)
+            Tsave, Particles, Fields, infoDict = DFAIterate(cfgGen, particles, fields, dem)
 
             # write mass balance to File
             writeMBFile(infoDict, avaDir, logName)
@@ -799,11 +799,6 @@ def DFAIterate(cfg, particles, fields, dem):
     # Initialise Lists to save fields
     Particles = [copy.deepcopy(particles)]
     Fields = [copy.deepcopy(fields)]
-    # save Z, S, U, T at each time step for developping purpouses
-    Z = np.empty((0, 0))
-    S = np.empty((0, 0))
-    U = np.empty((0, 0))
-    T = np.empty((0, 0))
     Tsave = [0]
 
     if featLF:
@@ -849,14 +844,8 @@ def DFAIterate(cfg, particles, fields, dem):
             particles, fields, Tcpu = computeEulerTimeStep(
                 cfg, particles, fields, dt, dem, Tcpu)
 
-
-        T = np.append(T, t)
         Tcpu['nSave'] = nSave
         particles['t'] = t
-        # Save desired parameters and export to Lists for saving interval
-        U = np.append(U, DFAtls.norm(particles['ux'][0], particles['uy'][0], particles['uz'][0]))
-        Z = np.append(Z, particles['z'][0])
-        S = np.append(S, particles['s'][0])
         iterate = particles['iterate']
 
         # write mass balance info
@@ -894,7 +883,7 @@ def DFAIterate(cfg, particles, fields, dem):
 
     infoDict = {'massEntrained': massEntrained, 'timeStep': timeM, 'massTotal': massTotal, 'Tcpu': Tcpu}
 
-    return Tsave, T, U, Z, S, Particles, Fields, infoDict
+    return Tsave, Particles, Fields, infoDict
 
 
 def writeMBFile(infoDict, avaDir, logName):

--- a/avaframe/in3Utils/fileHandlerUtils.py
+++ b/avaframe/in3Utils/fileHandlerUtils.py
@@ -204,7 +204,7 @@ def getTimeIndex(cfg, Fields):
     return tStepsOk
 
 
-def getDFAData(avaDir, workDir, suffix, comModule='com1DFA', nameDir=''):
+def getDFAData(avaDir, workDir, suffix, comModule='com1DFA', nameDir='', countStart=0):
     """ Export the required data from com1DFA output to Aimec Work directory and rename,
         if nameDir='', data from com1DFA output copied to workDir without renaming
 
@@ -226,8 +226,8 @@ def getDFAData(avaDir, workDir, suffix, comModule='com1DFA', nameDir=''):
     # Lead all infos on simulations
     inputDir = os.path.join(avaDir, 'Outputs', comModule, 'peakFiles')
     data = makeSimDict(inputDir)
-
-    countsuf = 0
+    nFiles = len(data['files'])
+    countsuf = countStart
     for m in range(len(data['files'])):
         if data['resType'][m] == suffix:
             if nameDir == '':
@@ -237,6 +237,7 @@ def getDFAData(avaDir, workDir, suffix, comModule='com1DFA', nameDir=''):
                 log.info('%s   : %s/%s/%06d.txt' % (data['files'][m], workDir, nameDir, countsuf+1))
             countsuf = countsuf + 1
 
+    return nFiles
 
 def getRefData(testDir, outputDir, suffix, nameDir=''):
     """ Grab reference data and save to outputDir

--- a/avaframe/in3Utils/fileHandlerUtils.py
+++ b/avaframe/in3Utils/fileHandlerUtils.py
@@ -227,15 +227,15 @@ def getDFAData(avaDir, workDir, suffix, comModule='com1DFA', nameDir='', countSt
     inputDir = os.path.join(avaDir, 'Outputs', comModule, 'peakFiles')
     data = makeSimDict(inputDir)
     nFiles = len(data['files'])
-    countsuf = countStart
+    countSuf = countStart
     for m in range(len(data['files'])):
         if data['resType'][m] == suffix:
             if nameDir == '':
                 shutil.copy(data['files'][m], workDir)
             else:
-                shutil.copy(data['files'][m], '%s/%s/%06d.txt' % (workDir, nameDir, countsuf+1))
-                log.info('%s   : %s/%s/%06d.txt' % (data['files'][m], workDir, nameDir, countsuf+1))
-            countsuf = countsuf + 1
+                shutil.copy(data['files'][m], '%s/%s/%06d.txt' % (workDir, nameDir, countSuf+1))
+                log.info('%s   : %s/%s/%06d.txt' % (data['files'][m], workDir, nameDir, countSuf+1))
+            countSuf = countSuf + 1
 
     return nFiles
 

--- a/avaframe/in3Utils/fileHandlerUtils.py
+++ b/avaframe/in3Utils/fileHandlerUtils.py
@@ -204,7 +204,7 @@ def getTimeIndex(cfg, Fields):
     return tStepsOk
 
 
-def getDFAData(avaDir, workDir, suffix, comModule='com1DFA', nameDir='', countStart=0):
+def getDFAData(avaDir, workDir, suffix, comModule='com1DFA', nameDir=''):
     """ Export the required data from com1DFA output to Aimec Work directory and rename,
         if nameDir='', data from com1DFA output copied to workDir without renaming
 
@@ -226,8 +226,7 @@ def getDFAData(avaDir, workDir, suffix, comModule='com1DFA', nameDir='', countSt
     # Lead all infos on simulations
     inputDir = os.path.join(avaDir, 'Outputs', comModule, 'peakFiles')
     data = makeSimDict(inputDir)
-    nFiles = len(data['files'])
-    countSuf = countStart
+    countSuf = 0
     for m in range(len(data['files'])):
         if data['resType'][m] == suffix:
             if nameDir == '':
@@ -236,8 +235,7 @@ def getDFAData(avaDir, workDir, suffix, comModule='com1DFA', nameDir='', countSt
                 shutil.copy(data['files'][m], '%s/%s/%06d.txt' % (workDir, nameDir, countSuf+1))
                 log.info('%s   : %s/%s/%06d.txt' % (data['files'][m], workDir, nameDir, countSuf+1))
             countSuf = countSuf + 1
-
-    return nFiles
+            
 
 def getRefData(testDir, outputDir, suffix, nameDir=''):
     """ Grab reference data and save to outputDir

--- a/avaframe/out3Plot/outQuickPlot.py
+++ b/avaframe/out3Plot/outQuickPlot.py
@@ -295,8 +295,8 @@ def quickPlotSimple(avaDir, inputDir, cfg):
     log.info('input dataset #2 is %s' % name2)
 
     # Load data
-    raster = IOf.readRaster(datafiles[1])
-    rasterRef = IOf.readRaster(datafiles[0])
+    raster = IOf.readRaster(datafiles[0])
+    rasterRef = IOf.readRaster(datafiles[1])
     data1, data2 = geoTrans.resizeData(raster, rasterRef)
     header = IOf.readASCheader(datafiles[0])
     cellSize = header.cellsize

--- a/avaframe/runAna3AIMECCompMods.py
+++ b/avaframe/runAna3AIMECCompMods.py
@@ -18,7 +18,7 @@ from avaframe.in3Utils import logUtils
 
 # -----------Required settings-----------------
 # log file name; leave empty to use default runLog.log
-logName = 'runAna3AIMEC'
+logName = 'runAna3AIMECCompMods'
 
 # ---------------------------------------------
 # Load avalanche directory from general configuration file
@@ -43,18 +43,20 @@ cfgUtils.writeCfgFile(avalancheDir, ana3AIMEC, cfg)
 cfgSetup = cfg['AIMECSETUP']
 
 # Setup input from com1DFA
-dfa2Aimec.mainDfa2Aimec(avalancheDir, cfgSetup)
+simNames = dfa2Aimec.dfaComp2Aimec(avalancheDir, cfgSetup)
 
-# Extract input file locations
-cfgPath = ana3AIMEC.readAIMECinputs(avalancheDir, dirName='com1DFA')
+for sim in simNames:
 
-startTime = time.time()
+    # Extract input file locations
+    cfgPath = ana3AIMEC.readAIMECinputs(avalancheDir, dirName=sim)
 
-log.info("Running ana3AIMEC model on test case DEM \n %s \n with profile \n %s ",
-         cfgPath['demSource'], cfgPath['profileLayer'])
-# Run AIMEC postprocessing
-ana3AIMEC.mainAIMEC(cfgPath, cfg)
+    startTime = time.time()
 
-endTime = time.time()
+    log.info("Running ana3AIMEC model on test case DEM \n %s \n with profile \n %s ",
+             cfgPath['demSource'], cfgPath['profileLayer'])
+    # Run AIMEC postprocessing
+    ana3AIMEC.mainAIMEC(cfgPath, cfg)
 
-log.info(('Took %s seconds to calculate.' % (endTime - startTime)))
+    endTime = time.time()
+
+    log.info(('Took %s seconds to calculate.' % (endTime - startTime)))


### PR DESCRIPTION
* add writing of mass_simName.txt file for com1DFAPy 
* save entrained mass from com1DFAPy
* export peakFiles for final time step to Outputs/com1DFAPy/peakFiles and other time steps to subfolder timeSteps within peakFiles
* add option to compare only two simulations, so matching simulations from two modules 
* add cleaning of avaDir from all ana3Aimec files