### PR TITLE
Sec release

### DIFF
--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -95,7 +95,7 @@ def copyReplace(origFile, workFile, searchString, replString):
 
 def getSimulation(cfg, rel, entResInfo):
     """ Get a list of all simulations that shall be performed according to simTypeList in configuration file;
-        and a dictionary with information on release area 
+        and a dictionary with information on release area
 
 
     Parameters
@@ -197,7 +197,7 @@ def com1DFAMain(cfg, avaDir):
     workDir, outDir = iD.initialiseRunDirs(avaDir, modName)
 
     # Load input data
-    dem, rels, ent, res, entResInfo = gI.getInputDataCom1DFAPy(avaDir, cfgGen, flagDev=False)
+    dem, rels, ent, res, entResInfo = gI.getInputData(avaDir, cfgGen, flagDev=False)
 
     # Parameter variation
     if cfgPar.getboolean('parameterVar'):

--- a/avaframe/com1DFAPy/com1DFA.py
+++ b/avaframe/com1DFAPy/com1DFA.py
@@ -1015,8 +1015,6 @@ def DFAIterate(cfg, particles, fields, dem):
         massTotal.append(particles['mTot'])
         timeM.append(t)
         # make sure the array is not empty
-        if dtSave.size == 0:
-            dtSave = [2*cfgGen.getfloat('tEnd')]
         if t >= dtSave[0]:
             Tsave.append(t)
             log.info('Saving results for time step t = %f s', t)
@@ -1028,7 +1026,10 @@ def DFAIterate(cfg, particles, fields, dem):
             log.debug(('cpu time Neighbour = %s s' % (Tcpu['Neigh'] / nIter)))
             log.debug(('cpu time Fields = %s s' % (Tcpu['Field'] / nIter)))
             fieldsList, particlesList = appendFieldsParticles(fieldsList, particlesList, particles, fields, resTypes)
-            dtSave = dtSave[1:]
+            if dtSave.size == 0:
+                dtSave = [2*cfgGen.getfloat('tEnd')]
+            else:
+                dtSave = dtSave[1:]
 
         if cfgGen.getboolean('cflTimeStepping'):
             # overwrite the dt value in the cfg
@@ -1808,7 +1809,7 @@ def mergeParticleDict(particles1, particles2):
 
     Returns
     -------
-    particles1 : dict
+    particles : dict
         merged particles dictionary
 
     """

--- a/avaframe/com1DFAPy/com1DFA.py
+++ b/avaframe/com1DFAPy/com1DFA.py
@@ -293,9 +293,10 @@ def prepareInputData(demFile, relFile, inputSimFiles):
         secondaryReleaseLine = None
 
     # get line from entrainement area polygon
-    if entFiles:
-        entLine = shpConv.readLine(entFiles, '', demOri)
-        entrainmentArea = os.path.splitext(os.path.basename(entFiles))[0]
+    entFile = inputSimFiles['entFile']
+    if entFile:
+        entLine = shpConv.readLine(entFile, '', demOri)
+        entrainmentArea = os.path.splitext(os.path.basename(entFile))[0]
         entLine['fileName'] = [entrainmentArea]
     else:
         entLine = None
@@ -558,7 +559,7 @@ def initializeSimulation(cfg, demOri, inputSimLines, logName, relThField, outDir
     rhoEnt = cfgGen.getfloat('rhoEnt')
     hEnt = cfgGen.getfloat('hEnt')
     entLine = inputSimLines['entLine']
-    entrMassRaster, reportAreaInfo = initializeMassEnt(demOri, simTypeActual, entLine, reportAreaInfo)
+    entrMassRaster, reportAreaInfo = initializeMassEnt(demOri, simTypeActual, entLine, relRaster, reportAreaInfo)
     resLine = inputSimLines['resLine']
     cResRaster, reportAreaInfo = initializeResistance(cfgGen, demOri, simTypeActual, resLine, reportAreaInfo)
     # surfacic entrainment mass available (unit kg/m²)

--- a/avaframe/com1DFAPy/com1DFA.py
+++ b/avaframe/com1DFAPy/com1DFA.py
@@ -125,7 +125,7 @@ def com1DFAMain(cfg, avaDir, relThField):
             relFiles = releaseLine['file']
             # ------------------------
             #  Start time step computation
-            Tsave, particlesList, fieldsList, infoDict = DFAIterate(cfgGen, particles, secondaryReleaseParticles, fields, dem)
+            Tsave, particlesList, fieldsList, infoDict = DFAIterate(cfg, particles, secondaryReleaseParticles, fields, dem)
 
             # write mass balance to File
             writeMBFile(infoDict, avaDir, logName)
@@ -1008,7 +1008,7 @@ def DFAIterate(cfg, particles, secondaryReleaseParticles, fields, dem):
                 cfgGen, particles, fields, dt, dem, Tcpu)
         else:
             particles, secondaryReleaseParticles, fields, Tcpu = computeEulerTimeStep(
-                cfg, particles, secondaryReleaseParticles, fields, dt, dem, Tcpu)
+                cfgGen, particles, secondaryReleaseParticles, fields, dt, dem, Tcpu)
 
         Tcpu['nSave'] = nSave
         particles['t'] = t

--- a/avaframe/com1DFAPy/com1DFA.py
+++ b/avaframe/com1DFAPy/com1DFA.py
@@ -233,12 +233,14 @@ def getSimulation(cfg, rel, inputSimFiles):
 
     if 'ent' in simTypeList or 'entres' in simTypeList:
         if entResInfo['flagEnt'] == 'No':
-            log.error('No entrainment file found')
-            raise FileNotFoundError
+            message = 'No entrainment file found'
+            log.error(message)
+            raise FileNotFoundError(message)
     if 'res' in simTypeList or 'entres' in simTypeList:
         if entResInfo['flagRes'] == 'No':
-            log.error('No resistance file found')
-            raise FileNotFoundError
+            message = 'No resistance file found'
+            log.error(message)
+            raise FileNotFoundError(message)
 
     return relName, simTypeList, relDict, releaseSecondaryDict, badName
 
@@ -1379,21 +1381,19 @@ def prepareArea(releaseLine, dem, relThList='', combine=True):
             RasterList.append(Raster)
         else:
             Raster = polygon2Raster(dem['header'], avapath, Raster, relTh='')
-            return Raster
 
-    # if relTh provided by a field or function - create release Raster with ones
+    # if RasterList not empty check for overlap between features
     Raster = np.zeros(np.shape(dem['rasterData']))
     for rast in RasterList:
         ind1 = Raster > 0
         ind2 = rast > 0
         indMatch = np.logical_and(ind1, ind2)
-        try:
+        # if there is an overlap, raise error
+        if indMatch.any():
             message = 'Release area features are overlaping - this is not allowed'
-            assert indMatch.any() == False, message
-            Raster = Raster + rast
-        except AssertionError:
-            log.error('%s' % message)
-            raise
+            log.error(message)
+            raise AssertionError(message)
+        Raster = Raster + rast
     if combine:
         return Raster
     else:

--- a/avaframe/com1DFAPy/com1DFA.py
+++ b/avaframe/com1DFAPy/com1DFA.py
@@ -1808,7 +1808,7 @@ def mergeParticleDict(particles1, particles2):
     return particles1
 
 
-def savePartToPickle(dictList, outDir):
+def savePartToPickle(dictList, outDir, logName):
     """ Save each dictionary from a list to a pickle in outDir; works also for one dictionary instead of list
 
         Parameters
@@ -1817,6 +1817,8 @@ def savePartToPickle(dictList, outDir):
             list of dictionaries or single dictionary
         outDir: str
             path to output directory
+        logName : str
+            simulation Id
     """
 
     if isinstance(dictList, list):

--- a/avaframe/com1DFAPy/com1DFA.py
+++ b/avaframe/com1DFAPy/com1DFA.py
@@ -1014,6 +1014,9 @@ def DFAIterate(cfg, particles, fields, dem):
         massEntrained.append(particles['massEntrained'])
         massTotal.append(particles['mTot'])
         timeM.append(t)
+        # make sure the array is not empty
+        if dtSave.size == 0:
+            dtSave = [2*cfgGen.getfloat('tEnd')]
         if t >= dtSave[0]:
             Tsave.append(t)
             log.info('Saving results for time step t = %f s', t)
@@ -1025,10 +1028,7 @@ def DFAIterate(cfg, particles, fields, dem):
             log.debug(('cpu time Neighbour = %s s' % (Tcpu['Neigh'] / nIter)))
             log.debug(('cpu time Fields = %s s' % (Tcpu['Field'] / nIter)))
             fieldsList, particlesList = appendFieldsParticles(fieldsList, particlesList, particles, fields, resTypes)
-            if len(dtSave) > 1:
-                dtSave = dtSave[1:]
-            else:
-                dtSave = [2*cfgGen.getfloat('tEnd')]
+            dtSave = dtSave[1:]
 
         if cfgGen.getboolean('cflTimeStepping'):
             # overwrite the dt value in the cfg

--- a/avaframe/com1DFAPy/com1DFA.py
+++ b/avaframe/com1DFAPy/com1DFA.py
@@ -576,8 +576,8 @@ def initializeSimulation(cfg, demOri, inputSimLines, logName, relThField, outDir
     entrMassRaster = geoTrans.checkOverlap(entrMassRaster, relRaster, 'Entrainment', 'Release', crop=True)
     # check for overlap with the secondary release area
     if secondaryReleaseInfo:
-        for secRelRatser in secondaryReleaseInfo['rasterList']:
-            entrMassRaster = geoTrans.checkOverlap(entrMassRaster, secRelRatser, 'Entrainment', 'Secondary release ', crop=True)
+        for secRelRaster in secondaryReleaseInfo['rasterList']:
+            entrMassRaster = geoTrans.checkOverlap(entrMassRaster, secRelRaster, 'Entrainment', 'Secondary release ', crop=True)
     # surfacic entrainment mass available (unit kg/m²)
     fields['entrMassRaster'] = entrMassRaster*rhoEnt*hEnt
     entreainableMass = np.nansum(fields['entrMassRaster']*dem['areaRaster'])

--- a/avaframe/com1DFAPy/com1DFA.py
+++ b/avaframe/com1DFAPy/com1DFA.py
@@ -1026,7 +1026,7 @@ def DFAIterate(cfg, particles, fields, dem):
             log.debug(('cpu time Neighbour = %s s' % (Tcpu['Neigh'] / nIter)))
             log.debug(('cpu time Fields = %s s' % (Tcpu['Field'] / nIter)))
             fieldsList, particlesList = appendFieldsParticles(fieldsList, particlesList, particles, fields, resTypes)
-            if dtSave.size == 0:
+            if dtSave.size == 1:
                 dtSave = [2*cfgGen.getfloat('tEnd')]
             else:
                 dtSave = dtSave[1:]
@@ -1787,13 +1787,14 @@ def splitPart(cfg, particles, dem):
             particles['uy'] = np.append(particles['uy'], particles['uy'][ind]*np.ones((nAdd)))
             particles['uz'] = np.append(particles['uz'], particles['uz'][ind]*np.ones((nAdd)))
             particles['m'] = np.append(particles['m'], mNew*np.ones((nAdd)))
-            particles['mTot'] = np.sum(particles['m'])
+            particles['m'][ind] = mNew
             particles['h'] = np.append(particles['h'], particles['h'][ind]*np.ones((nAdd)))
             particles['inCellDEM'] = np.append(particles['inCellDEM'], particles['inCellDEM'][ind]*np.ones((nAdd)))
             particles['indXDEM'] = np.append(particles['indXDEM'], particles['indXDEM'][ind]*np.ones((nAdd)))
             particles['indYDEM'] = np.append(particles['indYDEM'], particles['indYDEM'][ind]*np.ones((nAdd)))
             particles['partInCell'] = np.append(particles['partInCell'], particles['partInCell'][ind]*np.ones((nAdd)))
 
+        particles['mTot'] = np.sum(particles['m'])
     return particles
 
 

--- a/avaframe/com1DFAPy/com1DFACfg.ini
+++ b/avaframe/com1DFAPy/com1DFACfg.ini
@@ -76,11 +76,11 @@ methodMeshNormal = 1
 # subgridMixingFactor
 subgridMixingFactor = 100.
 
-# release depth
+# release thickness
 relTh = 1.
 # Add secondary release area
 secRelArea = False
-# secondary area release depth
+# secondary area release thickness
 secondaryRelTh = 0.5
 
 #++++++++++++Time stepping parameters

--- a/avaframe/com1DFAPy/com1DFACfg.ini
+++ b/avaframe/com1DFAPy/com1DFACfg.ini
@@ -78,6 +78,8 @@ subgridMixingFactor = 100.
 
 # release depth
 relTh = 1.
+# secondary area release depth
+secondaryRelTh = 0.5
 
 #++++++++++++Time stepping parameters
 # fixed time step [s]

--- a/avaframe/com1DFAPy/com1DFACfg.ini
+++ b/avaframe/com1DFAPy/com1DFACfg.ini
@@ -78,6 +78,8 @@ subgridMixingFactor = 100.
 
 # release depth
 relTh = 1.
+# Add secondary release area
+secRelArea = False
 # secondary area release depth
 secondaryRelTh = 0.5
 

--- a/avaframe/in1Data/getInput.py
+++ b/avaframe/in1Data/getInput.py
@@ -84,8 +84,6 @@ def getInputData(avaDir, cfg, flagDev=False):
         list of full path to DEM .asc file
     relFiles : list
         list of full path to release area scenario .shp files
-    secondaryReleaseFile : str
-        full path to secondary release area .shp file
     entFile : str
         full path to entrainment area .shp file
     resFile : str
@@ -154,10 +152,10 @@ def getInputDataCom1DFAPy(avaDir, cfg, flagDev=False):
 
     Returns
     -------
-    demFile[0] : str (first element of list)
-        list of full path to DEM .asc file
     inputSimFiles: dict
         dictionary with all the input files:
+        demFile : str (first element of list)
+            list of full path to DEM .asc file
         relFiles : list
             list of full path to release area scenario .shp files
         secondaryReleaseFile : str
@@ -168,6 +166,7 @@ def getInputDataCom1DFAPy(avaDir, cfg, flagDev=False):
             full path to resistance area .shp file
         entResInfo : flag dict
             flag if Yes entrainment and/or resistance areas found and used for simulation
+            flag True if a Secondary Release file found and activated
     """
 
     # Set directories for inputs, outputs and current work
@@ -201,7 +200,7 @@ def getInputDataCom1DFAPy(avaDir, cfg, flagDev=False):
     log.info('Release area files are: %s' % relFiles)
 
     # Initialise secondary release areas
-    secondaryReleaseFile, entResInfo['flagSecondaryRelease'] = getAndCheckInputFiles(inputDir, 'SECREL', 'Secondary release', flag=cfg.getboolean('GENERAL', 'secRelArea'))
+    secondaryReleaseFile, entResInfo['flagSecondaryRelease'] = getAndCheckInputFiles(inputDir, 'SECREL', 'Secondary release')
 
     # Initialise resistance areas
     resFile, entResInfo['flagRes'] = getAndCheckInputFiles(inputDir, 'RES', 'Resistance')
@@ -213,16 +212,15 @@ def getInputDataCom1DFAPy(avaDir, cfg, flagDev=False):
     demFile = getDEMPath(avaDir)
 
     # return DEM, first item of release, entrainment and resistance areas
-    inputSimFiles = {'relFiles': relFiles, 'secondaryReleaseFile': secondaryReleaseFile,
+    inputSimFiles = {'demFile': demFile, 'relFiles': relFiles, 'secondaryReleaseFile': secondaryReleaseFile,
                      'entFile': entFile, 'resFile': resFile, 'entResInfo': entResInfo}
-    return demFile, inputSimFiles
+    return inputSimFiles
 
 
-def getAndCheckInputFiles(inputDir, folder, inputType, flag=False):
+def getAndCheckInputFiles(inputDir, folder, inputType):
     """Fetch input shape files and check them
 
     Raises error if there is more than one shape file.
-    If the flag is set to true, raise an error if there is no shape file
 
     Parameters
     ----------
@@ -232,8 +230,6 @@ def getAndCheckInputFiles(inputDir, folder, inputType, flag=False):
         subfolder name where the shape file should be located (SECREL, ENT or RES)
     inputType : str
         type of input (used for the logging messages). Secondary release or Entrainment or Resistance
-    flag : bool
-        optional (false as default) - if True: raise error if there is no shape file
 
     Returns
     -------
@@ -246,12 +242,7 @@ def getAndCheckInputFiles(inputDir, folder, inputType, flag=False):
     # Initialise secondary release areas
     OutputFile = glob.glob(inputDir+os.sep + folder + os.sep+'*.shp')
     if len(OutputFile) < 1:
-        if flag:
-            message = 'No %s area file found' % (inputType)
-            log.error(message)
-            raise FileNotFoundError(message)
-        else:
-            OutputFile = None
+        OutputFile = None
     elif len(OutputFile) > 1:
         message = 'There shouldn\'t be more than one %s .shp file in %s/%s/' % (inputType, inputDir, folder)
         log.error(message)
@@ -259,7 +250,5 @@ def getAndCheckInputFiles(inputDir, folder, inputType, flag=False):
     else:
         available = 'Yes'
         OutputFile = OutputFile[0]
-        if flag:
-            log.info('%s area file is: %s' % (inputType, OutputFile))
 
     return OutputFile, available

--- a/avaframe/in1Data/getInput.py
+++ b/avaframe/in1Data/getInput.py
@@ -163,7 +163,6 @@ def getInputData(avaDir, cfg, flagDev=False):
     return demFile, relFiles, entFiles[0], resFiles[0], entResInfo
 
 
-
 def getInputDataCom1DFAPy(avaDir, cfg, flagDev=False):
     """ Fetch input datasets required for simulation, duplicated function because
         simulation type set differently in com1DFAPy compared to com1DFA:
@@ -184,7 +183,7 @@ def getInputDataCom1DFAPy(avaDir, cfg, flagDev=False):
         list of full path to DEM .asc file
     relFiles : list
         list of full path to release area scenario .shp files
-    relSecondaryFile[0] : str (fist element of list)
+    secondaryReleaseFile[0] : str (fist element of list)
         list of full path to secondary release area .shp files
     entFiles[0] : str (fist element of list)
         list of full path to entrainment area .shp files
@@ -224,14 +223,14 @@ def getInputDataCom1DFAPy(avaDir, cfg, flagDev=False):
     log.info('Release area files are: %s' % relFiles)
 
     # Initialise secondary release areas
-    relSecondaryFile = glob.glob(inputDir+os.sep + 'SECREL' + os.sep+'*.shp')
-    if len(relSecondaryFile) < 1:
+    secondaryReleaseFile = glob.glob(inputDir+os.sep + 'SECREL' + os.sep+'*.shp')
+    if len(secondaryReleaseFile) < 1:
         log.debug('No secondary release area file found')
-        relSecondaryFile.append('')  # Kept this for future enhancements
+        secondaryReleaseFile.append('')  # Kept this for future enhancements
     else:
         try:
             message = 'There shouldn\'t be more than one entrainment .shp file in ' + inputDir + '/SECREL/'
-            assert len(relSecondaryFile) < 2, message
+            assert len(secondaryReleaseFile) < 2, message
         except AssertionError:
             raise
         entResInfo['flagSecondaryRelease'] = 'Yes'
@@ -266,4 +265,4 @@ def getInputDataCom1DFAPy(avaDir, cfg, flagDev=False):
     demFile = getDEMPath(avaDir)
 
     # return DEM, first item of release, entrainment and resistance areas
-    return demFile, relFiles, relSecondaryFile[0], entFiles[0], resFiles[0], entResInfo
+    return demFile, relFiles, secondaryReleaseFile[0], entFiles[0], resFiles[0], entResInfo

--- a/avaframe/in1Data/getInput.py
+++ b/avaframe/in1Data/getInput.py
@@ -283,6 +283,7 @@ def getAndCheckInputFiles(inputDir, folder, inputType, flag=False):
     else:
         available = 'Yes'
         OutputFile = OutputFile[0]
-        log.info('%s area file is: %s' % (inputType, OutputFile))
+        if flag:
+            log.info('%s area file is: %s' % (inputType, OutputFile))
 
     return OutputFile, available

--- a/avaframe/in1Data/getInput.py
+++ b/avaframe/in1Data/getInput.py
@@ -203,10 +203,10 @@ def getInputDataCom1DFAPy(avaDir, cfg, flagDev=False):
     if flagDev is True:
         releaseDir = 'devREL'
         relFiles = glob.glob(inputDir+os.sep + releaseDir+os.sep + '*.shp')
-    elif cfg['releaseScenario'] != '':
+    elif cfg['FLAGS']['releaseScenario'] != '':
         releaseDir = 'REL'
         relFiles = []
-        releaseFiles = cfg['releaseScenario'].split('|')
+        releaseFiles = cfg['FLAGS']['releaseScenario'].split('|')
         for rel in releaseFiles:
             if '.shp' in rel:
                 relf = os.path.join(inputDir, releaseDir, rel)
@@ -224,16 +224,18 @@ def getInputDataCom1DFAPy(avaDir, cfg, flagDev=False):
 
     # Initialise secondary release areas
     secondaryReleaseFile = glob.glob(inputDir+os.sep + 'SECREL' + os.sep+'*.shp')
-    if len(secondaryReleaseFile) < 1:
-        log.debug('No secondary release area file found')
+    if (len(secondaryReleaseFile) < 1) and cfg.getboolean('GENERAL', 'secRelArea'):
+        log.info('No secondary release area file found')
         secondaryReleaseFile.append('')  # Kept this for future enhancements
-    else:
+    elif cfg.getboolean('GENERAL', 'secRelArea'):
         try:
             message = 'There shouldn\'t be more than one entrainment .shp file in ' + inputDir + '/SECREL/'
             assert len(secondaryReleaseFile) < 2, message
         except AssertionError:
             raise
         entResInfo['flagSecondaryRelease'] = 'Yes'
+    else:
+        secondaryReleaseFile = [None]
 
     # Initialise resistance areas
     resFiles = glob.glob(inputDir+os.sep + 'RES' + os.sep+'*.shp')
@@ -265,4 +267,6 @@ def getInputDataCom1DFAPy(avaDir, cfg, flagDev=False):
     demFile = getDEMPath(avaDir)
 
     # return DEM, first item of release, entrainment and resistance areas
-    return demFile, relFiles, secondaryReleaseFile[0], entFiles[0], resFiles[0], entResInfo
+    inputSimFiles = {'relFiles': relFiles, 'secondaryReleaseFile': secondaryReleaseFile[0],
+                     'entFile': entFiles[0], 'resFile': resFiles[0], 'entResInfo': entResInfo}
+    return demFile, inputSimFiles

--- a/avaframe/in1Data/getInput.py
+++ b/avaframe/in1Data/getInput.py
@@ -56,11 +56,10 @@ def getDEMPath(avaDir):
     """
 
     demFile = glob.glob(os.path.join(avaDir, 'Inputs', '*.asc'))
-    try:
-        assert len(demFile) == 1, 'There should be exactly one topography .asc file in ' + \
-            avaDir + '/Inputs/'
-    except AssertionError:
-        raise
+    if not len(demFile) == 1:
+        message = 'There should be exactly one topography .asc file in %s/Inputs/' % (avaDir)
+        log.error(message)
+        raise AssertionError(message)
 
     return demFile[0]
 
@@ -181,23 +180,25 @@ def getInputDataCom1DFAPy(avaDir, cfg, flagDev=False):
     -------
     demFile[0] : str (first element of list)
         list of full path to DEM .asc file
-    relFiles : list
-        list of full path to release area scenario .shp files
-    secondaryReleaseFile[0] : str (fist element of list)
-        list of full path to secondary release area .shp files
-    entFiles[0] : str (fist element of list)
-        list of full path to entrainment area .shp files
-    resFiles[0] : str (first element of list)
-        list of full path to resistance area .shp files
-    flagEntRes : bool
-        flag if True entrainment and/or resistance areas found and used for simulation
+    inputSimFiles: dict
+        dictionary with all the input files:
+        relFiles : list
+            list of full path to release area scenario .shp files
+        secondaryReleaseFile : str
+            full path to secondary release area .shp file
+        entFile : str
+            full path to entrainment area .shp file
+        resFile : str
+            full path to resistance area .shp file
+        entResInfo : flag dict
+            flag if Yes entrainment and/or resistance areas found and used for simulation
     """
 
     # Set directories for inputs, outputs and current work
     inputDir = os.path.join(avaDir, 'Inputs')
 
     # Set flag if there is an entrainment or resistance area
-    entResInfo= {'flagEntRes': False, 'flagEnt': 'No', 'flagRes': 'No'}
+    entResInfo= {'flagEnt': 'No', 'flagRes': 'No'}
 
     # Initialise release areas, default is to look for shapefiles
     if flagDev is True:
@@ -212,10 +213,10 @@ def getInputDataCom1DFAPy(avaDir, cfg, flagDev=False):
                 relf = os.path.join(inputDir, releaseDir, rel)
             else:
                 relf = os.path.join(inputDir, releaseDir, '%s.shp' % (rel))
-            if os.path.isfile(relf) is True:
-                relFiles.append(relf)
-            else:
-                log.error('No release scenario called: %s' % (relf))
+            if not os.path.isfile(relf):
+                message = 'No release scenario called: %s' % (relf)
+                log.error(message)
+                raise FileNotFoundError(message)
         log.debug('Release area file is specified to be: %s' % relFiles)
     else:
         releaseDir = 'REL'
@@ -223,53 +224,64 @@ def getInputDataCom1DFAPy(avaDir, cfg, flagDev=False):
     log.info('Release area files are: %s' % relFiles)
 
     # Initialise secondary release areas
-    secondaryReleaseFile = glob.glob(inputDir+os.sep + 'SECREL' + os.sep+'*.shp')
-    if (len(secondaryReleaseFile) < 1) and cfg.getboolean('GENERAL', 'secRelArea'):
-        log.warning('No secondary release area file found')
-        secondaryReleaseFile.append('')  # Kept this for future enhancements
-    elif cfg.getboolean('GENERAL', 'secRelArea'):
-        try:
-            message = 'There shouldn\'t be more than one secondary release .shp file in ' + inputDir + '/SECREL/'
-            assert len(secondaryReleaseFile) < 2, message
-        except AssertionError:
-            raise
-        entResInfo['flagSecondaryRelease'] = 'Yes'
-        log.info('Secondary release area file is: %s' % secondaryReleaseFile)
-    else:
-        secondaryReleaseFile = [None]
+    secondaryReleaseFile, entResInfo['flagSecondaryRelease'] = getAndCheckInputFiles(inputDir, 'SECREL', 'Secondary release', flag=cfg.getboolean('GENERAL', 'secRelArea'))
 
     # Initialise resistance areas
-    resFiles = glob.glob(inputDir+os.sep + 'RES' + os.sep+'*.shp')
-    if len(resFiles) < 1:
-        log.debug('No resistance file found')
-        resFiles.append('')  # Kept this for future enhancements
-    else:
-        try:
-            message = 'There shouldn\'t be more than one resistance .shp file in ' + inputDir + '/RES/'
-            assert len(resFiles) < 2, message
-        except AssertionError:
-            raise
-        entResInfo['flagRes'] = 'Yes'
-        log.info('Resistance area file is: %s' % resFiles)
+    resFile, entResInfo['flagRes'] = getAndCheckInputFiles(inputDir, 'RES', 'Resistance')
 
     # Initialise entrainment areas
-    entFiles = glob.glob(inputDir+os.sep + 'ENT' + os.sep+'*.shp')
-    if len(entFiles) < 1:
-        log.debug('No entrainment file found')
-        entFiles.append('')  # Kept this for future enhancements
-    else:
-        try:
-            message = 'There shouldn\'t be more than one entrainment .shp file in ' + inputDir + '/ENT/'
-            assert len(entFiles) < 2, message
-        except AssertionError:
-            raise
-        entResInfo['flagEnt'] = 'Yes'
-        log.info('Entrainment area file is: %s' % entFiles)
+    entFile, entResInfo['flagEnt'] = getAndCheckInputFiles(inputDir, 'ENT', 'Entrainment')
 
     # Initialise DEM
     demFile = getDEMPath(avaDir)
 
     # return DEM, first item of release, entrainment and resistance areas
-    inputSimFiles = {'relFiles': relFiles, 'secondaryReleaseFile': secondaryReleaseFile[0],
-                     'entFile': entFiles[0], 'resFile': resFiles[0], 'entResInfo': entResInfo}
+    inputSimFiles = {'relFiles': relFiles, 'secondaryReleaseFile': secondaryReleaseFile,
+                     'entFile': entFile, 'resFile': resFile, 'entResInfo': entResInfo}
     return demFile, inputSimFiles
+
+
+def getAndCheckInputFiles(inputDir, folder, inputType, flag=False):
+    """Fetch input shape files and check them
+
+    Raises error if there is more than one shape file.
+    If the flag is set to true, raise an error if there is no shape file
+
+    Parameters
+    ----------
+    inputDir : str
+        path to avalanche input directory
+    folder : str
+        subfolder name where the shape file should be located (SECREL, ENT or RES)
+    inputType : str
+        type of input (used for the logging messages). Secondary release or Entrainment or Resistance
+    flag : bool
+        optional (false as default) - if True: raise error if there is no shape file
+
+    Returns
+    -------
+    OutputFile: str
+        path to file checked
+    available: str
+        Yes or No depending of if there is a shape file available (if No, OutputFile is None)
+    """
+    available = 'No'
+    # Initialise secondary release areas
+    OutputFile = glob.glob(inputDir+os.sep + folder + os.sep+'*.shp')
+    if len(OutputFile) < 1:
+        if flag:
+            message = 'No %s area file found' % (inputType)
+            log.error(message)
+            raise FileNotFoundError(message)
+        else:
+            OutputFile = None
+    elif len(OutputFile) > 1:
+        message = 'There shouldn\'t be more than one %s .shp file in %s/%s/' % (inputType, inputDir, folder)
+        log.error(message)
+        raise AssertionError(message)
+    else:
+        available = 'Yes'
+        OutputFile = OutputFile[0]
+        log.info('%s area file is: %s' % (inputType, OutputFile))
+
+    return OutputFile, available

--- a/avaframe/in1Data/getInput.py
+++ b/avaframe/in1Data/getInput.py
@@ -184,6 +184,8 @@ def getInputDataCom1DFAPy(avaDir, cfg, flagDev=False):
         list of full path to DEM .asc file
     relFiles : list
         list of full path to release area scenario .shp files
+    relSecondaryFile[0] : str (fist element of list)
+        list of full path to secondary release area .shp files
     entFiles[0] : str (fist element of list)
         list of full path to entrainment area .shp files
     resFiles[0] : str (first element of list)
@@ -221,6 +223,19 @@ def getInputDataCom1DFAPy(avaDir, cfg, flagDev=False):
         relFiles = sorted(glob.glob(inputDir+os.sep + releaseDir+os.sep + '*.shp'))
     log.info('Release area files are: %s' % relFiles)
 
+    # Initialise secondary release areas
+    relSecondaryFile = glob.glob(inputDir+os.sep + 'SECREL' + os.sep+'*.shp')
+    if len(relSecondaryFile) < 1:
+        log.debug('No secondary release area file found')
+        relSecondaryFile.append('')  # Kept this for future enhancements
+    else:
+        try:
+            message = 'There shouldn\'t be more than one entrainment .shp file in ' + inputDir + '/SECREL/'
+            assert len(relSecondaryFile) < 2, message
+        except AssertionError:
+            raise
+        entResInfo['flagSecondaryRelease'] = 'Yes'
+
     # Initialise resistance areas
     resFiles = glob.glob(inputDir+os.sep + 'RES' + os.sep+'*.shp')
     if len(resFiles) < 1:
@@ -251,4 +266,4 @@ def getInputDataCom1DFAPy(avaDir, cfg, flagDev=False):
     demFile = getDEMPath(avaDir)
 
     # return DEM, first item of release, entrainment and resistance areas
-    return demFile, relFiles, entFiles[0], resFiles[0], entResInfo
+    return demFile, relFiles, relSecondaryFile[0], entFiles[0], resFiles[0], entResInfo

--- a/avaframe/in1Data/getInput.py
+++ b/avaframe/in1Data/getInput.py
@@ -217,6 +217,7 @@ def getInputDataCom1DFAPy(avaDir, cfg, flagDev=False):
                 message = 'No release scenario called: %s' % (relf)
                 log.error(message)
                 raise FileNotFoundError(message)
+            relFiles.append(relf)
         log.debug('Release area file is specified to be: %s' % relFiles)
     else:
         releaseDir = 'REL'

--- a/avaframe/in1Data/getInput.py
+++ b/avaframe/in1Data/getInput.py
@@ -225,15 +225,16 @@ def getInputDataCom1DFAPy(avaDir, cfg, flagDev=False):
     # Initialise secondary release areas
     secondaryReleaseFile = glob.glob(inputDir+os.sep + 'SECREL' + os.sep+'*.shp')
     if (len(secondaryReleaseFile) < 1) and cfg.getboolean('GENERAL', 'secRelArea'):
-        log.info('No secondary release area file found')
+        log.warning('No secondary release area file found')
         secondaryReleaseFile.append('')  # Kept this for future enhancements
     elif cfg.getboolean('GENERAL', 'secRelArea'):
         try:
-            message = 'There shouldn\'t be more than one entrainment .shp file in ' + inputDir + '/SECREL/'
+            message = 'There shouldn\'t be more than one secondary release .shp file in ' + inputDir + '/SECREL/'
             assert len(secondaryReleaseFile) < 2, message
         except AssertionError:
             raise
         entResInfo['flagSecondaryRelease'] = 'Yes'
+        log.info('Secondary release area file is: %s' % secondaryReleaseFile)
     else:
         secondaryReleaseFile = [None]
 
@@ -249,6 +250,7 @@ def getInputDataCom1DFAPy(avaDir, cfg, flagDev=False):
         except AssertionError:
             raise
         entResInfo['flagRes'] = 'Yes'
+        log.info('Resistance area file is: %s' % resFiles)
 
     # Initialise entrainment areas
     entFiles = glob.glob(inputDir+os.sep + 'ENT' + os.sep+'*.shp')
@@ -262,6 +264,7 @@ def getInputDataCom1DFAPy(avaDir, cfg, flagDev=False):
         except AssertionError:
             raise
         entResInfo['flagEnt'] = 'Yes'
+        log.info('Entrainment area file is: %s' % entFiles)
 
     # Initialise DEM
     demFile = getDEMPath(avaDir)

--- a/avaframe/in3Utils/fileHandlerUtils.py
+++ b/avaframe/in3Utils/fileHandlerUtils.py
@@ -211,12 +211,12 @@ def splitTimeValueToArrayInterval(cfgGen):
         else:
             items = np.arange(float(itemsInput[0]), endTime, float(itemsInput[1]))
     elif cfgValues == '':
-        items = np.array([endTime])
+        items = np.array([2*endTime])
     else:
         itemsL = cfgValues.split('|')
         items = np.array(itemsL, dtype=float)
         items = np.sort(items)
-        
+
     # make sure that 0 is not in the array (initial time step is any ways saved)
     if items[0] == 0:
         items = np.delete(items, 0)

--- a/avaframe/in3Utils/fileHandlerUtils.py
+++ b/avaframe/in3Utils/fileHandlerUtils.py
@@ -222,7 +222,7 @@ def splitTimeValueToArrayInterval(cfgGen):
         items = np.delete(items, 0)
     # make sure the array is not empty
     if items.size == 0:
-        items = np.array([endTime])
+        items = np.array([2*endTime])
 
     return items
 

--- a/avaframe/in3Utils/fileHandlerUtils.py
+++ b/avaframe/in3Utils/fileHandlerUtils.py
@@ -221,6 +221,7 @@ def splitTimeValueToArrayInterval(cfgGen):
     if items[0] == 0:
         items = np.delete(items, 0)
     # make sure the array is not empty
+    # ToDo : make it work without this arbitrary 2*timeEnd
     if items.size == 0:
         items = np.array([2*endTime])
 

--- a/avaframe/in3Utils/geoTrans.py
+++ b/avaframe/in3Utils/geoTrans.py
@@ -634,7 +634,7 @@ def areaPoly(X, Y):
     return sum
 
 
-def checkOverlap(toCheckRaster, refRaster, name, crop=False):
+def checkOverlap(toCheckRaster, refRaster, nameToCheck, nameRef, crop=False):
     """Check if two raster overlap
 
     Parameters
@@ -655,10 +655,11 @@ def checkOverlap(toCheckRaster, refRaster, name, crop=False):
     if mask.any():
         if crop:
             toCheckRaster[mask] = 0
-            message = name + ' area features are overlaping - removing the overlaping part'
-            log.warning('%s' % message)
+            message = '%s area feature overlaping with %s - removing the overlaping part' % (nameToCheck, nameRef)
+            log.warning(message)
         else:
-            message = name + ' area features are overlaping - this is not allowed'
-            log.error('%s' % message)
+            message = '%s area features overlapingwith %s - this is not allowed' % (nameToCheck, nameRef)
+            log.error(message)
+            AssertionError(message)
 
     return toCheckRaster

--- a/avaframe/in3Utils/geoTrans.py
+++ b/avaframe/in3Utils/geoTrans.py
@@ -658,7 +658,7 @@ def checkOverlap(toCheckRaster, refRaster, nameToCheck, nameRef, crop=False):
             message = '%s area feature overlapping with %s - removing the overlapping part' % (nameToCheck, nameRef)
             log.warning(message)
         else:
-            message = '%s area features overlapingwith %s - this is not allowed' % (nameToCheck, nameRef)
+            message = '%s area features overlapping with %s - this is not allowed' % (nameToCheck, nameRef)
             log.error(message)
             AssertionError(message)
 

--- a/avaframe/in3Utils/geoTrans.py
+++ b/avaframe/in3Utils/geoTrans.py
@@ -655,7 +655,7 @@ def checkOverlap(toCheckRaster, refRaster, nameToCheck, nameRef, crop=False):
     if mask.any():
         if crop:
             toCheckRaster[mask] = 0
-            message = '%s area feature overlaping with %s - removing the overlaping part' % (nameToCheck, nameRef)
+            message = '%s area feature overlapping with %s - removing the overlapping part' % (nameToCheck, nameRef)
             log.warning(message)
         else:
             message = '%s area features overlapingwith %s - this is not allowed' % (nameToCheck, nameRef)

--- a/avaframe/in3Utils/geoTrans.py
+++ b/avaframe/in3Utils/geoTrans.py
@@ -655,10 +655,10 @@ def checkOverlap(toCheckRaster, refRaster, nameToCheck, nameRef, crop=False):
     if mask.any():
         if crop:
             toCheckRaster[mask] = 0
-            message = '%s area feature overlapping with %s - removing the overlapping part' % (nameToCheck, nameRef)
+            message = '%s area feature overlapping with %s area - removing the overlapping part' % (nameToCheck, nameRef)
             log.warning(message)
         else:
-            message = '%s area features overlapping with %s - this is not allowed' % (nameToCheck, nameRef)
+            message = '%s area features overlapping with %s area - this is not allowed' % (nameToCheck, nameRef)
             log.error(message)
             AssertionError(message)
 

--- a/avaframe/in3Utils/initializeProject.py
+++ b/avaframe/in3Utils/initializeProject.py
@@ -19,6 +19,7 @@ def _checkForFolderAndDelete(baseDir, folderName):
     except FileNotFoundError:
         log.debug("No %s folder found.", folderName)
 
+
 def _checkAvaDirVariable(avaDir):
     '''Check for empty or nonString avaDir variable'''
     # check for empty avaDir name, abort if empty
@@ -33,6 +34,7 @@ def _checkAvaDirVariable(avaDir):
         return 'AvaDir is NOT a string'
 
     return 'SUCCESS'
+
 
 def cleanModuleFiles(avaDir, module, alternativeName=''):
     '''Cleans all generated files from the provided module in the outputs
@@ -73,6 +75,7 @@ def cleanModuleFiles(avaDir, module, alternativeName=''):
     _checkForFolderAndDelete(workDir, modName)
 
     return 'SUCCESS'
+
 
 def cleanSingleAvaDir(avaDir, keep=None, deleteOutput=True):
     '''
@@ -148,7 +151,7 @@ def createFolderStruct(pathAvaName):
 
     Inputs = checkMakeDir(pathAvaName, 'Inputs')
 
-    inputsSubDirs = ['RES', 'REL', 'ENT',
+    inputsSubDirs = ['RES', 'REL', 'SECREL', 'ENT',
                      'POINTS', 'LINES']
 
     for cuDir in inputsSubDirs:

--- a/avaframe/out3Plot/outAIMEC.py
+++ b/avaframe/out3Plot/outAIMEC.py
@@ -150,7 +150,7 @@ def visuRunoutComp(rasterTransfo, resAnalysis, newRasters, cfgSetup, cfgPath, cf
         ax.plot(meanVal[1, :], s, '-b', label='Mean Simulation')
 
         ax.set_title(titleVal + 'distribution along path')
-        ax.legend(loc=1)
+        ax.legend(loc='best' )
         ax.set_ylabel('s [m]')
         ax.set_ylim([s.min(), s.max()])
         ax.set_xlim(auto=True)

--- a/avaframe/out3Plot/outAIMEC.py
+++ b/avaframe/out3Plot/outAIMEC.py
@@ -150,7 +150,7 @@ def visuRunoutComp(rasterTransfo, resAnalysis, newRasters, cfgSetup, cfgPath, cf
         ax.plot(meanVal[1, :], s, '-b', label='Mean Simulation')
 
         ax.set_title(titleVal + 'distribution along path')
-        ax.legend(loc=4)
+        ax.legend(loc=1)
         ax.set_ylabel('s [m]')
         ax.set_ylim([s.min(), s.max()])
         ax.set_xlim(auto=True)

--- a/avaframe/runStandardTestsPy.py
+++ b/avaframe/runStandardTestsPy.py
@@ -59,6 +59,7 @@ for test in testList:
     avaName = os.path.basename(avaDir)
     standardCfg = os.path.join('..', 'benchmarks', test['NAME'], '%s_com1DFACfgPy.ini' % test['AVANAME'])
     cfg = cfgUtils.getModuleConfig(com1DFA, standardCfg)
+    cfg['GENERAL']['secRelArea'] = 'False'
     cfg['GENERAL']['frictModel'] = 'samosAT'
     cfg['GENERAL']['sphKernelRadius'] = '5.'
     cfg['GENERAL']['massPerParticleDeterminationMethod'] = 'MPPDH'

--- a/avaframe/tests/test_fileHandlerUtils.py
+++ b/avaframe/tests/test_fileHandlerUtils.py
@@ -146,7 +146,7 @@ def test_splitTimeValueToArrayInterval():
     cfgValuesList2 = np.asarray([5., 10., 15.])
 
     cfgValues3 = ''
-    cfgValuesList3 = np.asarray([20.])
+    cfgValuesList3 = np.asarray([40.])
 
     cfg = configparser.ConfigParser()
     cfg['GENERAL'] = {'tEnd': '20'}

--- a/avaframe/tests/test_in1Data.py
+++ b/avaframe/tests/test_in1Data.py
@@ -6,10 +6,8 @@
  """
 
 #  Load modules
-import numpy as np
 import os
 from avaframe.in1Data import getInput
-import pytest
 import configparser
 import shutil
 

--- a/avaframe/tests/test_in1Data.py
+++ b/avaframe/tests/test_in1Data.py
@@ -23,24 +23,21 @@ def test_getInputData(tmp_path):
     avaData = os.path.join(dirPath, '..', 'data', avaName, 'Inputs')
     shutil.copytree(avaData, avaInputs)
 
-    # flags for entrainment and resistance
-    flagEnt = True
-    flagRes = True
-
     # Initialise input in correct format
     cfg = configparser.ConfigParser()
     cfg['GENERAL'] = {'flagEnt': 'True', 'flagRes': 'True', 'flagDev': 'False', 'releaseScenario': ''}
     cfgGen = cfg['GENERAL']
 
     # call function to be tested
-    dem, rels, ent, res, flagEntRes = getInput.getInputData(avaDir, cfgGen)
+    dem, rels, ent, res, entResInfo = getInput.getInputData(avaDir, cfgGen)
     # second option
     cfg['GENERAL']['releaseScenario'] = 'release1HS'
-    dem2, rels2, ent2, res2, flagEntRes2 = getInput.getInputData(avaDir, cfgGen)
+    dem2, rels2, ent2, res2, entResInfo2 = getInput.getInputData(avaDir, cfgGen)
     # Test
     assert dem == os.path.join(avaDir, 'Inputs', 'DEM_HS_Topo.asc')
     assert rels == [os.path.join(avaDir, 'Inputs', 'REL', 'release1HS.shp'), os.path.join(avaDir, 'Inputs', 'REL', 'release2HS.shp'), os.path.join(avaDir, 'Inputs', 'REL', 'release3HS.shp')]
     assert rels2 == [os.path.join(avaDir, 'Inputs', 'REL', 'release1HS.shp')]
     assert res == ''
     assert ent == os.path.join(avaDir, 'Inputs', 'ENT', 'entrainment1HS.shp')
-    assert flagEntRes['flagEntRes'] == True
+    assert entResInfo['flagEnt'] == "Yes"
+    assert entResInfo['flagRes'] == "No"

--- a/docs/moduleCom1DFA.rst
+++ b/docs/moduleCom1DFA.rst
@@ -28,6 +28,7 @@ and the following files are optional:
 
 * entrainment area as shapefile (in Inputs/ENT)
 * resistance area as shapefile (in Inputs/RES)
+* secondary release area as shapefile (in Inputs/SECREL)
 
 The simulation settings area defined in the configuration file ``com1DFACfg.ini``:
 

--- a/docs/moduleIn3Utils.rst
+++ b/docs/moduleIn3Utils.rst
@@ -233,11 +233,12 @@ This function creates the folder structure required to perform avalanche simulat
 
 		NameOfAvalanche/
 			Inputs/
+				ENT/		- entrainment areas
+				LINES/		- avalanche paths
+				POINTS/		- split points
 				REL/		- release area scenario
 				RES/		- resistance areas
-				ENT/		- entrainment areas
-				POINTS/		- split points
-				LINES/		- avalanche paths
+				SECREL/ - secondary release areas
 				.asc		- DEM
 			Outputs/
 			Work/


### PR DESCRIPTION
Enable secondary release area: 
- possible to provide a sec release shp file in SECREL folder (only one allowed features should not overlap)
- read the secondary release feature and initialize it (done at the same time as the primary release (maybe we want to do this only if the release is hit?)
- add particles to the computation as soon as the sec rel area is hit by the flowing avalanche

I also fixed the small bug for exporting time step results that was not working for particles

fix #402 