### PR TITLE
Add new bench structure

### DIFF
--- a/avaframe/com1DFAPy/com1DFA.py
+++ b/avaframe/com1DFAPy/com1DFA.py
@@ -600,8 +600,18 @@ def initializeParticles(cfg, relRaster, dem, logName=''):
         else:
             inDirPart = os.path.join(avaDir, 'Outputs', 'com1DFA')
 
-        partDirName = logName
-        inDirPart = os.path.join(inDirPart, 'particles', partDirName)
+        inDirPart = glob.glob(inDirPart + os.sep + 'particles' + os.sep + '*' + cfg['releaseScenario'] + '_' + '*' + '*' + cfg['simTypeActual'] + '*')
+        if inDirPart == []:
+            messagePart = 'Initialise particles from file - no particles file found for releaseScenario: %s and simType: %s' % \
+                            (cfg['releaseScenario'], cfg['simTypeActual'])
+            log.error(messagePart)
+            raise FileNotFoundError(messagePart)
+        elif len(inDirPart) > 1:
+            log.warning('More than one file found for Initialise particle from file: took %s' % indirPart[0])
+            inDirPart = inDirPart[0]
+        else:
+            inDirPart = inDirPart[0]
+
         log.info('Initial particle distribution read from file!! %s' % (inDirPart))
         Particles, TimeStepInfo = readPartFromPickle(inDirPart)
         particles = Particles[0]
@@ -1398,7 +1408,7 @@ def polygon2Raster(demHeader, Line, relTh=''):
     # for this we need to know if the path is clockwise or counter clockwise
     # to decide if the radius should be positif or negatif in contains_points
     is_ccw = geoTrans.isCounterClockWise(path)
-    r = 0.001
+    r = 0.000
     r = r*is_ccw - r*(1-is_ccw)
     x = np.linspace(0, ncols-1, ncols)
     y = np.linspace(0, nrows-1, nrows)
@@ -1714,7 +1724,7 @@ def exportFields(cfg, Tsave, fieldsList, demOri, outDir, logName):
             IOf.writeResultToAsc(demOri['header'], resField, outFile, flip=True)
             if countTime == numberTimes:
                 log.info('Results parameter: %s has been exported to Outputs/peakFiles for time step: %.2f - FINAL time step ' % (resType, Tsave[countTime]))
-                dataName = logName + '_' + resType + '_' + '.asc'
+                dataName = logName + '_' + resType + '.asc'
                 # create directory
                 outDirPeakAll = os.path.join(outDir, 'peakFiles')
                 fU.makeADir(outDirPeakAll)
@@ -1821,7 +1831,7 @@ def prepareVarSimDict(standardCfg, inputSimFiles, variationDict):
             cfgSimObject = cfgUtils.convertDictToConfigParser(cfgSim)
             # create unique hash for simulation configuration
             simHash = cfgUtils.cfgHash(cfgSimObject)
-            simName = relName + '_' + row._asdict()['simTypeList'] + '_dfa_' + simHash
+            simName = relName + '_' + row._asdict()['simTypeList'] + '_' + cfgSim['GENERAL']['modelType'] + '_' + simHash
             simDict[simName] = {'simHash': simHash, 'releaseScenario': relName,
                                 'simType': row._asdict()['simTypeList'], 'relFile': rel,
                                 'cfgSim': cfgSimObject}

--- a/avaframe/com1DFAPy/com1DFACfg.ini
+++ b/avaframe/com1DFAPy/com1DFACfg.ini
@@ -148,6 +148,8 @@ seed = 12345
 #++++++++++++++++ simulation type
 # list of simulations that shall be performed (null, ent, res, entres, available (use all available input data))
 simTypeList = available
+# model type
+modelType = dfa
 
 [VISUALISATION]
 # if particle properties shall be exported to csv files

--- a/avaframe/com1DFAPy/deriveParameterSet.py
+++ b/avaframe/com1DFAPy/deriveParameterSet.py
@@ -34,31 +34,28 @@ def getVariationDict(avaDir, fullCfg, modDict):
 
     """
 
+    # look for parameters that are different than default in section GENERAL
+    section = 'GENERAL'
     variations = {}
-    # loop through all sections of the defCfg
-    for section in fullCfg.sections():
-        # look for parameters that are different than default in section GENERAL
-        if section == 'GENERAL':
-            variations[section] = {}
-            for key in fullCfg.items(section):
-                # output saving options not relevant for parameter variation!
-                fullValue = key[1]
-                if key[0] != 'resType' and key[0] != 'tSteps':
-                    # if yes and if this value is different add this key to
-                    # the parameter variation dict
-                    if ':' in fullValue or '|' in fullValue:
-                        locValue = fU.splitIniValueToArraySteps(fullValue)
-                        variations[section][key[0]] = locValue
-                        defValue = modDict[section][key[0]][1]
-                        log.info('%s: %s (default value was: %s)' % (key[0], locValue, defValue))
+    for key in fullCfg.items(section):
+        # output saving options not relevant for parameter variation!
+        fullValue = key[1]
+        if key[0] != 'resType' and key[0] != 'tSteps':
+            # if yes and if this value is different add this key to
+            # the parameter variation dict
+            if ':' in fullValue or '|' in fullValue:
+                locValue = fU.splitIniValueToArraySteps(fullValue)
+                variations[key[0]] = locValue
+                defValue = modDict[section][key[0]][1]
+                log.info('%s: %s (default value was: %s)' % (key[0], locValue, defValue))
 
     # print modified parameters
     for sec in modDict:
         for value in modDict[sec]:
-            if sec != 'GENERAL':
+            if sec != section:
                 log.info('%s: %s (default value was: %s)' % (value, modDict[sec][value][0], modDict[sec][value][1]))
             else:
-                if value not in variations[sec]:
+                if value not in variations:
                     log.info('%s: %s (default value was: %s)' % (value, modDict[sec][value][0], modDict[sec][value][1]))
 
 

--- a/avaframe/com1DFAPy/runCom1DFA.py
+++ b/avaframe/com1DFAPy/runCom1DFA.py
@@ -72,11 +72,11 @@ def runCom1DFAPy(avaDir='', cfgFile='', relThField='', variationDict=''):
     inputSimFiles = gI.getInputDataCom1DFAPy(avalancheDir, modCfg['FLAGS'])
 
     # write full configuration file to file
-    cfgUtils.writeCfgFile(avalancheDir, com1DFAPy, modCfg, fileName='overallConfiguration')
+    cfgUtils.writeCfgFile(avalancheDir, com1DFAPy, modCfg, fileName='originConfiguration')
 
     # create a list of simulations
     # if need to reproduce exactely the hash - need to be strings with exactely the same number of digits!!
-    simDict = com1DFA.prepareVarSimDict(modCfg, inputSimFiles, variationDict['GENERAL'])
+    simDict = com1DFA.prepareVarSimDict(modCfg, inputSimFiles, variationDict)
 
     log.info('The following simulations will be performed')
     for key in simDict:

--- a/avaframe/out3Plot/outQuickPlot.py
+++ b/avaframe/out3Plot/outQuickPlot.py
@@ -301,6 +301,8 @@ def quickPlot(avaDir, testDir, suffix, val, parameter, cfg, cfgPlot, rel='', sim
                     findComp = False
                 elif data['modelType'][m] == cfgPlot['PLOT']['refModel']:
                     indSuffix[1] = m
+        if findComp:
+            log.error('No matching files found')
 
         # Load data
         raster = IOf.readRaster(data['files'][indSuffix[0]])

--- a/avaframe/runAna3AIMECCompMods.py
+++ b/avaframe/runAna3AIMECCompMods.py
@@ -40,19 +40,24 @@ cfgUtils.writeCfgFile(avalancheDir, ana3AIMEC, cfg)
 
 cfgSetup = cfg['AIMECSETUP']
 
-# Setup input from com1DFA
-pathDictList = dfa2Aimec.dfaComp2Aimec(avalancheDir, cfgSetup)
+compList = [['relKot', 'null'], ['relKot', 'ent']]
 
-for simN in pathDictList:
+for comp in compList:
 
-    pathDict = pathDictList[simN]
+    # get config
+    rel = comp[0]
+    simType = comp[1]
+
+    print('NEW')
+    # Setup input from com1DFA
+    pathDict = dfa2Aimec.dfaComp2Aimec(avalancheDir, cfg, rel, simType)
 
     # TODO: define referenceFile
     pathDict['numSim'] = len(pathDict['ppr'])
     pathDict['referenceFile'] = 0
 
     # Extract input file locations
-    pathDict = aimecTools.readAIMECinputs(avalancheDir, pathDict, dirName=simN)
+    pathDict = aimecTools.readAIMECinputs(avalancheDir, pathDict, dirName=rel+'_'+simType)
 
     startTime = time.time()
 

--- a/avaframe/runStandardTests.py
+++ b/avaframe/runStandardTests.py
@@ -130,7 +130,7 @@ for test in testList:
         pathDictList = dfa2Aimec.dfaComp2Aimec(avaDir, cfgAimecSetup)
 
         for pathD in pathDictList:
-            if pathD == reportD['simName']['name']:
+            if simType in pathD and rel in pathD:
                 pathDict = pathDictList[pathD]
 
         log.info('reference file comes from: %s' % pathDict['compType'][1])


### PR DESCRIPTION
due to renaming of simulations with simHash - finding matching simulations for com1DFA and com1DFAPy results not possible based on simulation names anymore

* check for common simulations based on releaseScenario and simType 
* adjust dfa2Aimec - return pathDict for only 2 matching simulations based on releaseScenario and simType (previously pathDictList was returned) 
- if multiple simulations fit the criteria regarding releseScenario and simType, first one found is taken! 
* introduce filterSims function in order to filter the simulations by any parameter that is part of the model configuration (ini file) - return simName 
* adjust all runStandardTests.py, runStandardTestsPy.py, runAna3AimecCompMods.py, runComparisonModules.py