### PR TITLE
Change order of com1DFACfg.ini

### DIFF
--- a/avaframe/ana3AIMEC/ana3AIMEC.py
+++ b/avaframe/ana3AIMEC/ana3AIMEC.py
@@ -426,7 +426,7 @@ def postProcessAIMEC(rasterTransfo, newRasters, cfgSetup, cfgPath, cfgFlags):
 
     if flagMass:
         # perform mass analysis
-        fnameMass = cfgPath['mb']
+        fnameMass = cfgPath['massBal']
         releaseMass, entrainedMass, entMassFlowArray, totalMassArray, finalMass, relativMassDiff, grIndex, grGrad, time = aT.analyzeMass(fnameMass)
         resAnalysis['relMass'] = releaseMass
         resAnalysis['entMass'] = entrainedMass

--- a/avaframe/ana3AIMEC/dfa2Aimec.py
+++ b/avaframe/ana3AIMEC/dfa2Aimec.py
@@ -76,42 +76,42 @@ def extractCom1DFAMBInfo(avaDir, pathDict, simNameInput=''):
                     MBFile.write('%.02f,    %.06f,    %.06f\n' %
                                  (logDict['time'][m], logDict['mass'][m], logDict['entrMass'][m]))
             if simNameInput != '':
-                pathDict['mb'].append(saveName)
+                pathDict['massBal'].append(saveName)
             else:
-                pathDict['mb'].append(saveName)
+                pathDict['massBal'].append(saveName)
             log.debug('Mass file saved to %s ' % (saveName))
-            log.info('Added to pathDict[mb] %s ' % (saveName))
+            log.info('Added to pathDict[massBal] %s ' % (saveName))
             countFile = countFile + 1
 
     return pathDict
 
 
 def getMBInfo(avaDir, pathDict, comMod, simName=''):
-    """ Get MB info """
+    """ Get mass balance info """
 
     # Get info from ExpLog
     if simName != '':
         mbFile = os.path.join(avaDir, 'Outputs', comMod, 'mass_%s.txt' % simName)
-        pathDict['mb'].append(mbFile)
-        log.info('Added to pathDict[mb] %s' % (mbFile))
+        pathDict['massBal'].append(mbFile)
+        log.info('Added to pathDict[massBal] %s' % (mbFile))
 
     else:
         mbFiles = glob.glob(os.path.join(avaDir, 'Outputs', comMod, 'mass*.txt'))
         mbNames = sorted(set(mbFiles), key=lambda s: (s.split("_")[1], s.split("_")[2], s.split("_")[4]))
 
         for mFile in mbNames:
-            pathDict['mb'].append(mFile)
-            log.debug('Added to pathDict[mb] %s' % (mFile))
+            pathDict['massBal'].append(mFile)
+            log.debug('Added to pathDict[massBal] %s' % (mFile))
 
     return pathDict
 
 def getRefMB(testName, pathDict, simName):
-    """ Get MB info """
+    """ Get mass balance info """
 
     # Get info from ExpLog
     mbFile = os.path.join('..', 'benchmarks', testName, 'mass_%s.txt' % simName)
-    pathDict['mb'].append(mbFile)
-    log.info('Added to pathDict[mb] %s' % (mbFile))
+    pathDict['massBal'].append(mbFile)
+    log.info('Added to pathDict[massBal] %s' % (mbFile))
 
     return pathDict
 
@@ -143,7 +143,7 @@ def dfaComp2Aimec(avaDir, cfg, rel, simType):
     cfgSetup = cfg['AIMECSETUP']
 
     # initialise empty pathDict for all required files
-    pathDict = {'ppr': [], 'pfd': [], 'pfv': [], 'mb': []}
+    pathDict = {'ppr': [], 'pfd': [], 'pfv': [], 'massBal': []}
     # get directories where simulation results can be found for both modules
     inputDirRef, inputDirComp, pathDict, refModule = getCompDirs(avaDir, cfgSetup, pathDict)
 
@@ -253,7 +253,7 @@ def dfaBench2Aimec(avaDir, cfg, simNameRef, simNameComp):
     cfgSetup = cfg['AIMECSETUP']
 
     # initialise empty pathDict for all required files
-    pathDict = {'ppr': [], 'pfd': [], 'pfv': [], 'mb': []}
+    pathDict = {'ppr': [], 'pfd': [], 'pfv': [], 'massBal': []}
     # get directories where simulation results can be found for both modules
     inputDirRef, inputDirComp, pathDict, refModule = getCompDirs(avaDir, cfgSetup, pathDict)
 
@@ -315,7 +315,7 @@ def mainDfa2Aimec(avaDir, comModule='com1DFA'):
     """ Exports the required data from com1DFA to be used by Aimec """
 
     # path dictionary for Aimec
-    pathDict = {'ppr': [], 'pfd': [], 'pfv': [], 'mb': []}
+    pathDict = {'ppr': [], 'pfd': [], 'pfv': [], 'massBal': []}
 
     # Setup input from com1DFA and save file paths to dictionary
     suffix = ['pfd', 'ppr', 'pfv']

--- a/avaframe/com1DFAPy/com1DFA.py
+++ b/avaframe/com1DFAPy/com1DFA.py
@@ -912,12 +912,10 @@ def DFAIterate(cfg, particles, fields, dem):
     sphOption = cfgGen.getint('sphOption')
     log.info('using sphOption %s:' % sphOption)
     # desired output fields
-    resTypesString = cfgGen['resType']
-    resTypes = resTypesString.split('_')
+    resTypes = fU.splitIniValueToArraySteps(cfgGen['resType'])
     # make sure to save all desiered resuts for first and last time step for
     # the report
-    resTypesReportString = cfg['REPORT']['plotFields']
-    resTypesReport = resTypesReportString.split('_')
+    resTypesReport = fU.splitIniValueToArraySteps(cfg['REPORT']['plotFields'])
     resTypesLast = list(set(resTypes + resTypesReport))
     # derive friction type
     # turn friction model into integer
@@ -1698,14 +1696,12 @@ def exportFields(cfg, Tsave, fieldsList, demOri, outDir, logName):
 
     """
 
-    resTypesString = cfg['GENERAL']['resType']
-    resTypesGen = resTypesString.split('_')
+    resTypesGen = fU.splitIniValueToArraySteps(cfg['GENERAL']['resType'])
     if resTypesGen == ['']:
         resTypesGen = []
     if 'particles' in resTypesGen:
         resTypesGen.remove('particles')
-    resTypesReportString = cfg['REPORT']['plotFields']
-    resTypesReport = resTypesReportString.split('_')
+    resTypesReport = fU.splitIniValueToArraySteps(cfg['REPORT']['plotFields'])
     numberTimes = len(Tsave)-1
     countTime = 0
     for timeStep in Tsave:

--- a/avaframe/com1DFAPy/com1DFACfg.ini
+++ b/avaframe/com1DFAPy/com1DFACfg.ini
@@ -4,21 +4,58 @@
 
 
 [GENERAL]
-# acceleration of gravity [m/s²]
-gravAcc = 9.81
+#++++++++++++++++ Simulation type
+# list of simulations that shall be performed (null, ent, res, entres, available (use all available input data))
+simTypeList = available
+# model type - only for file naming (dfa - dense flow avalanche)
+modelType = dfa
+
+#+++++++++++++ Output++++++++++++
+# desired result Parameters (ppr, pfd, pfv, FD, FV, P, particles) - separated by |
+resType = ppr|pfd|pfv
+# saving time step, i.e.  time in seconds (first and last time step are always saved)
+# option 1: give an interval with start:interval in seconds (tStep = 0:5 - this will save desired results every 5 seconds for the full simulation)
+# option 2: explicitly list all desired time steps (closest to actual computational time step) separated by | (example tSteps = 1|50.2|100)
+# NOTE: initial and last time step are always saved!
+tSteps = 1
+
+#++++++++++++++++ particle Initialisation +++++++++
+# if true use file (import particles initial distribution from file)
+initialiseParticlesFromFile = False
+particleFile =
+# seed for random generator
+seed = 12345
+
+#+++++++++SNOW properties
 # density of snow [kg/m³]
 rho = 200
+# density of entrained snow [kg/m³]
 rhoEnt = 100
-# mass per particle [kg]
-massPerPart = 1250
-# release thickness per particle
-deltaTh = 0.25
-# minimum flow depth [m]
-hmin = 0.05
-# curvature acceleration coefficient
-# take curvature term into account in the gravity acceleration term
-# 0 if deactivated, 1 if activated
-curvAcceleration = 1
+# release thickness
+relTh = 1.
+# Add secondary release area
+secRelArea = False
+# secondary area release thickness
+secondaryRelTh = 0.5
+
+
+#++++++++++++Time stepping parameters
+# fixed time step [s]
+dt = 0.1
+# End time [s]
+tEnd = 400
+# to use a variable time step (defined by the CFL number)
+cflTimeStepping = False
+# courant number
+cMax = 0.5
+# to constrain the lower margin of the allowed time step
+constrainCFL = False
+# max time step in case of small velocities
+maxdT = 0.5
+# min time step in case of high velocity
+mindT = 0.01
+# stopCriterion (0.01, stops when ke<0.01*pke)
+stopCrit = 0.01
 
 #+++++++++++++SPH parameters
 # SPH gradient option
@@ -35,9 +72,10 @@ minRKern = 0.001
 sphKernelRadius = 5
 # number of particles defined by: MPPDIR= mass per particle direct, MPPDH= mass per particles through release thickness
 massPerParticleDeterminationMethod = MPPDH
-
-velMagMin = 1.0e-6
-depMin = 1.0e-6
+# mass per particle [kg]
+massPerPart = 1250
+# release thickness per particle
+deltaTh = 0.25
 
 
 #+++++++++++++Mesh and interpolation
@@ -46,7 +84,8 @@ depMin = 1.0e-6
 #                       -1: equal weights interpolation
 #                       -2: bilinear interpolation
 interpOption = 2
-
+# minimum flow depth [m]
+hmin = 0.05
 # remesh the input DEM
 # expected mesh size [m]
 meshCellSize = 5
@@ -73,36 +112,20 @@ meshCellSizeThreshold = 0.001
 #                       -8: 8 triangles method
 methodMeshNormal = 1
 
+
+#+++++++++++++Flow model parameters+++++++++
 # subgridMixingFactor
 subgridMixingFactor = 100.
+# acceleration of gravity [m/s²]
+gravAcc = 9.81
+velMagMin = 1.0e-6
+depMin = 1.0e-6
+# curvature acceleration coefficient
+# take curvature term into account in the gravity acceleration term
+# 0 if deactivated, 1 if activated
+curvAcceleration = 1
 
-# release thickness
-relTh = 1.
-# Add secondary release area
-secRelArea = False
-# secondary area release thickness
-secondaryRelTh = 0.5
-
-#++++++++++++Time stepping parameters
-# fixed time step [s]
-dt = 0.1
-# End time [s]
-tEnd = 400
-# to use a variable time step (defined by the CFL number)
-cflTimeStepping = False
-# courant number
-cMax = 0.5
-# max time step in case of small velocities
-maxdT = 0.5
-# to constrain the lower margin of the allowed time step
-constrainCFL = False
-# min time step in case of high velocity
-mindT = 0.01
-
-# stopCriterion (0.01, stops when ke<0.01*pke)
-stopCrit = 0.01
-
-
+#++++++++++++Friction model
 # friction type (samosAT, Coulomb)
 frictModel = samosAT
 #+++++++++++++SamosAt friction model
@@ -121,38 +144,15 @@ cw = 0.5
 dRes = 0.3
 # spacing between obstacles
 sres = 5
-#++++++++++++ entrainment Erosion Energy
+#++++++++++++ Entrainment Erosion Energy
 hEnt = 0.3
 entEroEnergy = 5000
 entShearResistance = 0
 entDefResistance = 0
 
 
-#+++++++++++++ Output
-# desired result Parameters (ppr, pfd, pfv, FD, FV, P, particles)
-resType = ppr_pfd_pfv
-# saving time step, i.e.  time in seconds (first and last time step are always saved)
-# option 1: give an interval with start:interval in seconds (tStep = 0:5 - this will save desired results every 5 seconds for the full simulation)
-# option 2: explicitly list all desired time steps (closest to actual computational time step) separated by | (example tSteps = 1|50.2|100)
-# NOTE: initial and last time step are always saved!
-tSteps = 1
-
-
-#++++++++++++++++ particle Initialisation
-# if true use file (import particles initial distribution from file)
-initialiseParticlesFromFile = False
-particleFile =
-# seed for random generator
-seed = 12345
-
-#++++++++++++++++ simulation type
-# list of simulations that shall be performed (null, ent, res, entres, available (use all available input data))
-simTypeList = available
-# model type
-modelType = dfa
-
 [VISUALISATION]
-# if particle properties shall be exported to csv files
+# if particle properties shall be exported to csv files - requires to save particles in OUTPUTS
 writePartToCSV = False
 # particle properties to be saved to csv (options: ux, uy, uz, velocityMagnitude,..)
 particleProperties = velocityMagnitude|m
@@ -166,8 +166,8 @@ releaseScenario =
 
 
 [REPORT]
-# which result parameters shall be included as plots in report
-plotFields = ppr_pfd_pfv
+# which result parameters shall be included as plots in report,  - separated by |
+plotFields = ppr|pfd|pfv
 # units for output variables
 unitppr = kPa
 unitpfd = m

--- a/avaframe/tests/test_ana3AIMEC.py
+++ b/avaframe/tests/test_ana3AIMEC.py
@@ -22,7 +22,7 @@ def test_analyzeArea(capfd):
     cfgPath = {}
     cfgPath['projectName'] = 'NameOfAvalanche'
     cfgPath['ppr'] = [dataRef, dataSim]
-    cfgPath['mb'] = [dataMass, dataMass1]
+    cfgPath['massBal'] = [dataMass, dataMass1]
     pathResult = os.path.join(dirname, 'data')
     cfgPath['pathResult'] = pathResult
     cfgPath['dirName'] = 'testAIMEC'
@@ -102,7 +102,7 @@ def test_makeDomainTransfo(capfd):
                       os.path.join(pathData, 'testAimec_2.asc'), os.path.join(pathData, 'testAimec_3.asc'),
                       os.path.join(pathData, 'testAimec_4.asc')]
 
-    cfgPath['mb'] = [os.path.join(dirname, '000001.txt')]*5
+    cfgPath['massBal'] = [os.path.join(dirname, '000001.txt')]*5
 
     cfgPath['contCmap'] = True
 

--- a/avaframe/tests/test_dfa2Aimec.py
+++ b/avaframe/tests/test_dfa2Aimec.py
@@ -31,14 +31,14 @@ def test_mainDfa2Aimec(tmp_path):
                         pathData / 'release2HS_entres_dfa_0.15500_pfd.asc']
     pathDTest['pfv'] = [pathData / 'release1HS_entres_dfa_0.15500_pfv.asc',
                         pathData / 'release2HS_entres_dfa_0.15500_pfv.asc']
-    pathDTest['mb'] = [os.path.join(testPath, 'Outputs', 'com1DFA', 'mass_release1HS_entres_dfa_0.15500.txt'),
+    pathDTest['massBal'] = [os.path.join(testPath, 'Outputs', 'com1DFA', 'mass_release1HS_entres_dfa_0.15500.txt'),
                        os.path.join(testPath, 'Outputs', 'com1DFA', 'mass_release2HS_entres_dfa_0.15500.txt')]
 
 
     assert pathDict['ppr'] == pathDTest['ppr']
     assert pathDict['pfd'] == pathDTest['pfd']
     assert pathDict['pfv'] == pathDTest['pfv']
-    assert pathDict['mb'] == pathDTest['mb']
+    assert pathDict['massBal'] == pathDTest['massBal']
 
 
 
@@ -60,10 +60,10 @@ def test_dfaComp2Aimec(tmp_path):
     pathDTest['ppr'] = [pathData / 'release1HS_entres_dfa_0.15500_ppr.asc', pathData2 / 'release1HS_entres_dfa_0.15500_ppr.asc']
     pathDTest['pfd'] = [pathData / 'release1HS_entres_dfa_0.15500_pfd.asc', pathData2 / 'release1HS_entres_dfa_0.15500_pfd.asc']
     pathDTest['pfv'] = [pathData / 'release1HS_entres_dfa_0.15500_pfv.asc', pathData2 / 'release1HS_entres_dfa_0.15500_pfv.asc']
-    pathDTest['mb'] = [os.path.join(testPath, 'Outputs', 'com1DFA', 'mass_release1HS_entres_dfa_0.15500.txt'), os.path.join(testPath, 'Outputs', 'com1DFAPy', 'mass_release1HS_entres_dfa_0.15500.txt')]
+    pathDTest['massBal'] = [os.path.join(testPath, 'Outputs', 'com1DFA', 'mass_release1HS_entres_dfa_0.15500.txt'), os.path.join(testPath, 'Outputs', 'com1DFAPy', 'mass_release1HS_entres_dfa_0.15500.txt')]
 
 
     assert pathDict['ppr'] == pathDTest['ppr']
     assert pathDict['pfd'] == pathDTest['pfd']
     assert pathDict['pfv'] == pathDTest['pfv']
-    assert pathDict['mb'] == pathDTest['mb']
+    assert pathDict['massBal'] == pathDTest['massBal']

--- a/benchmarks/avaAlrNullTest/avaAlr_com1DFACfgPy.ini
+++ b/benchmarks/avaAlrNullTest/avaAlr_com1DFACfgPy.ini
@@ -95,7 +95,7 @@ releaseScenario = relAlr
 
 [REPORT]
 # which result parameters shall be included as plots in report
-plotFields = ppr_pfd_pfv
+plotFields = ppr|pfd|pfv
 # units for output variables
 unitppr = kPa
 unitpfd = m

--- a/benchmarks/avaBowlNullTest/avaBowl_com1DFACfgPy.ini
+++ b/benchmarks/avaBowlNullTest/avaBowl_com1DFACfgPy.ini
@@ -95,7 +95,7 @@ releaseScenario = release1BL
 
 [REPORT]
 # which result parameters shall be included as plots in report
-plotFields = ppr_pfd_pfv
+plotFields = ppr|pfd|pfv
 # units for output variables
 unitppr = kPa
 unitpfd = m

--- a/benchmarks/avaFlatPlaneNullTest/avaFlatPlane_com1DFACfgPy.ini
+++ b/benchmarks/avaFlatPlaneNullTest/avaFlatPlane_com1DFACfgPy.ini
@@ -96,7 +96,7 @@ releaseScenario = release1FP
 
 [REPORT]
 # which result parameters shall be included as plots in report
-plotFields = ppr_pfd_pfv
+plotFields = ppr|pfd|pfv
 # units for output variables
 unitppr = kPa
 unitpfd = m

--- a/benchmarks/avaGarNullTest/avaGar_com1DFACfgPy.ini
+++ b/benchmarks/avaGarNullTest/avaGar_com1DFACfgPy.ini
@@ -96,7 +96,7 @@ releaseScenario = relGar|relGar6|relGar2
 
 [REPORT]
 # which result parameters shall be included as plots in report
-plotFields = ppr_pfd_pfv
+plotFields = ppr|pfd|pfv
 # units for output variables
 unitppr = kPa
 unitpfd = m

--- a/benchmarks/avaHelixChannelEnt1mTest/avaHelixChannel_com1DFACfgPy.ini
+++ b/benchmarks/avaHelixChannelEnt1mTest/avaHelixChannel_com1DFACfgPy.ini
@@ -96,7 +96,7 @@ releaseScenario = release1HX
 
 [REPORT]
 # which result parameters shall be included as plots in report
-plotFields = ppr_pfd_pfv
+plotFields = ppr|pfd|pfv
 # units for output variables
 unitppr = kPa
 unitpfd = m

--- a/benchmarks/avaHelixChannelEntTest/avaHelixChannel_com1DFACfgPy.ini
+++ b/benchmarks/avaHelixChannelEntTest/avaHelixChannel_com1DFACfgPy.ini
@@ -96,7 +96,7 @@ releaseScenario = release1HX
 
 [REPORT]
 # which result parameters shall be included as plots in report
-plotFields = ppr_pfd_pfv
+plotFields = ppr|pfd|pfv
 # units for output variables
 unitppr = kPa
 unitpfd = m

--- a/benchmarks/avaHelixNullTest/avaHelix_com1DFACfgPy.ini
+++ b/benchmarks/avaHelixNullTest/avaHelix_com1DFACfgPy.ini
@@ -95,7 +95,7 @@ releaseScenario = release1HX
 
 [REPORT]
 # which result parameters shall be included as plots in report
-plotFields = ppr_pfd_pfv
+plotFields = ppr|pfd|pfv
 # units for output variables
 unitppr = kPa
 unitpfd = m

--- a/benchmarks/avaHitNullTest/avaHit_com1DFACfgPy.ini
+++ b/benchmarks/avaHitNullTest/avaHit_com1DFACfgPy.ini
@@ -95,7 +95,7 @@ releaseScenario = relHit
 
 [REPORT]
 # which result parameters shall be included as plots in report
-plotFields = ppr_pfd_pfv
+plotFields = ppr|pfd|pfv
 # units for output variables
 unitppr = kPa
 unitpfd = m

--- a/benchmarks/avaHockeyChannelEntTest/avaHockeyChannel_com1DFACfgPy.ini
+++ b/benchmarks/avaHockeyChannelEntTest/avaHockeyChannel_com1DFACfgPy.ini
@@ -96,7 +96,7 @@ releaseScenario = release1HS|release2HS
 
 [REPORT]
 # which result parameters shall be included as plots in report
-plotFields = ppr_pfd_pfv
+plotFields = ppr|pfd|pfv
 # units for output variables
 unitppr = kPa
 unitpfd = m

--- a/benchmarks/avaHockeyChannelEntTestPy/avaHockeyChannel_com1DFACfgPy.ini
+++ b/benchmarks/avaHockeyChannelEntTestPy/avaHockeyChannel_com1DFACfgPy.ini
@@ -107,7 +107,7 @@ releaseScenario = release1HS|release2HS
 
 [REPORT]
 # which result parameters shall be included as plots in report
-plotFields = ppr_pfd_pfv
+plotFields = ppr|pfd|pfv
 # units for output variables
 unitppr = kPa
 unitpfd = m

--- a/benchmarks/avaHockeySmallNullTest/avaHockeySmall_com1DFACfgPy.ini
+++ b/benchmarks/avaHockeySmallNullTest/avaHockeySmall_com1DFACfgPy.ini
@@ -97,7 +97,7 @@ releaseScenario = release1HS
 
 [REPORT]
 # which result parameters shall be included as plots in report
-plotFields = ppr_pfd_pfv
+plotFields = ppr|pfd|pfv
 # units for output variables
 unitppr = kPa
 unitpfd = m

--- a/benchmarks/avaInclinedPlaneEntresTest/avaInclinedPlane_com1DFACfgPy.ini
+++ b/benchmarks/avaInclinedPlaneEntresTest/avaInclinedPlane_com1DFACfgPy.ini
@@ -96,7 +96,7 @@ releaseScenario = release1IP
 
 [REPORT]
 # which result parameters shall be included as plots in report
-plotFields = ppr_pfd_pfv
+plotFields = ppr|pfd|pfv
 # units for output variables
 unitppr = kPa
 unitpfd = m

--- a/benchmarks/avaKotNullTest/avaKot_com1DFACfgPy.ini
+++ b/benchmarks/avaKotNullTest/avaKot_com1DFACfgPy.ini
@@ -96,7 +96,7 @@ releaseScenario = relKot
 
 [REPORT]
 # which result parameters shall be included as plots in report
-plotFields = ppr_pfd_pfv
+plotFields = ppr|pfd|pfv
 # units for output variables
 unitppr = kPa
 unitpfd = m

--- a/benchmarks/avaMalNullTest/avaMal_com1DFACfgPy.ini
+++ b/benchmarks/avaMalNullTest/avaMal_com1DFACfgPy.ini
@@ -96,7 +96,7 @@ releaseScenario = relMal1to3
 
 [REPORT]
 # which result parameters shall be included as plots in report
-plotFields = ppr_pfd_pfv
+plotFields = ppr|pfd|pfv
 # units for output variables
 unitppr = kPa
 unitpfd = m

--- a/benchmarks/avaParabolaResTest/avaParabola_com1DFACfgPy.ini
+++ b/benchmarks/avaParabolaResTest/avaParabola_com1DFACfgPy.ini
@@ -96,7 +96,7 @@ releaseScenario = release1PF
 
 [REPORT]
 # which result parameters shall be included as plots in report
-plotFields = ppr_pfd_pfv
+plotFields = ppr|pfd|pfv
 # units for output variables
 unitppr = kPa
 unitpfd = m

--- a/benchmarks/avaPyramid45NullTest/avaPyramid45_com1DFACfgPy.ini
+++ b/benchmarks/avaPyramid45NullTest/avaPyramid45_com1DFACfgPy.ini
@@ -95,7 +95,7 @@ releaseScenario =
 
 [REPORT]
 # which result parameters shall be included as plots in report
-plotFields = ppr_pfd_pfv
+plotFields = ppr|pfd|pfv
 # units for output variables
 unitppr = kPa
 unitpfd = m

--- a/benchmarks/avaPyramidNullTest/avaPyramid_com1DFACfgPy.ini
+++ b/benchmarks/avaPyramidNullTest/avaPyramid_com1DFACfgPy.ini
@@ -96,7 +96,7 @@ releaseScenario =
 
 [REPORT]
 # which result parameters shall be included as plots in report
-plotFields = ppr_pfd_pfv
+plotFields = ppr|pfd|pfv
 # units for output variables
 unitppr = kPa
 unitpfd = m

--- a/benchmarks/avaWogNullTest/avaWog_com1DFACfgPy.ini
+++ b/benchmarks/avaWogNullTest/avaWog_com1DFACfgPy.ini
@@ -95,7 +95,7 @@ releaseScenario = relWog
 
 [REPORT]
 # which result parameters shall be included as plots in report
-plotFields = ppr_pfd_pfv
+plotFields = ppr|pfd|pfv
 # units for output variables
 unitppr = kPa
 unitpfd = m


### PR DESCRIPTION
* make groups more obvious
* ordering: parameters that are more likely to be changed to the top (for example what shall be saved in outputs,...)
* resType = now use | to separate more consistent 
* fix #444 
