### PR TITLE
adjust color maps

### DIFF
--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -1656,8 +1656,7 @@ def plotPosition(fig, ax, particles, dem, data, Cmap, unit, plotPart=False, last
 
     ax.clear()
     ax.set_title('t=%.2f s' % particles['t'])
-    cmap, _, lev, norm, ticks = makePalette.makeColorMap(
-        Cmap, 0.0, np.nanmax(data), continuous=True)
+    cmap, _, lev, norm, ticks = makePalette.makeColorMap(Cmap, np.nanmax(data), continuous=True)
     cmap.set_under(color='w')
     ref0, im = pU.NonUnifIm(ax, xx, yy, data, 'x [m]', 'y [m]',
                          extent=[x.min(), x.max(), y.min(), y.max()],
@@ -1673,8 +1672,7 @@ def plotPosition(fig, ax, particles, dem, data, Cmap, unit, plotPart=False, last
         # ax.plot(x[NPPC == 16], y[NPPC == 16], '.m', linestyle='None', markersize=1)
         # load variation colormap
         variable = particles['h']
-        cmap, _, _, norm, ticks = makePalette.makeColorMap(
-            pU.cmapDepth, np.amin(variable), np.amax(variable), continuous=True)
+        cmap, _, _, norm, ticks = makePalette.makeColorMap(pU.cmapDepth, np.amax(variable), continuous=True)
         # set range and steps of colormap
         cc = variable
         sc = ax.scatter(x, y, c=cc, cmap=cmap, marker='.')
@@ -1709,8 +1707,7 @@ def plotContours(fig, ax, particles, dem, data, Cmap, unit, last=False):
 
     ax.clear()
     ax.set_title('t=%.2f s' % particles['t'])
-    cmap, _, lev, norm, ticks = makePalette.makeColorMap(
-        Cmap, 0.0, np.nanmax(data), continuous=True)
+    cmap, _, lev, norm, ticks = makePalette.makeColorMap(Cmap, np.nanmax(data), continuous=True)
     cmap.set_under(color='w')
 
     CS = ax.contour(X, Y, data, levels=8, origin='lower', cmap=cmap,

--- a/avaframe/out1Peak/outPlotAllPeak.py
+++ b/avaframe/out1Peak/outPlotAllPeak.py
@@ -95,8 +95,7 @@ def plotAllPeakFields(avaDir, cfg, cfgFLAGS, modName):
         fig = plt.figure(figsize=(pU.figW, pU.figH))
         fig, ax = plt.subplots()
         # choose colormap
-        cmap, _, _, norm, ticks = makePalette.makeColorMap(
-            pU.colorMaps[resType], np.amin(data), np.amax(data), continuous=pU.contCmap)
+        cmap, _, _, norm, ticks = makePalette.makeColorMap(pU.colorMaps[resType], np.amax(data), continuous=pU.contCmap)
         cmap.set_bad(alpha=0)
         rowsMinPlot = rowsMin*cellSize
         rowsMaxPlot = (rowsMax+1)*cellSize
@@ -170,8 +169,7 @@ def plotAllFields(avaDir, inputDir, outDir, unit=''):
         fig = plt.figure(figsize=(pU.figW, pU.figH))
         fig, ax = plt.subplots()
         # choose colormap
-        cmap, _, _, norm, ticks = makePalette.makeColorMap(
-            pU.cmapPres, np.amin(data), np.amax(data), continuous=pU.contCmap)
+        cmap, _, _, norm, ticks = makePalette.makeColorMap(pU.cmapPres, np.amax(data), continuous=pU.contCmap)
         cmap.set_bad('w')
         im1 = ax.imshow(data, cmap=cmap, norm=norm, extent=[0, Lx, 0, Ly], origin='lower', aspect=nx/ny)
         pU.addColorBar(im1, ax, ticks, unit)

--- a/avaframe/out3Plot/makePalette.py
+++ b/avaframe/out3Plot/makePalette.py
@@ -52,13 +52,12 @@ def get_continuous_cmap(hex_list, continuous=False, float_list=None):
     return cmp
 
 
-def makeColorMap(colormap, levMin, levMax, continuous=False):
+def makeColorMap(colormap, levMax, continuous=False):
     """
     Extract part of a listed colormap
     Inputs:
             -colors: list of hex colors
             -lev: levels associated to the colors
-            -levMin: min of the new levels
             -levMax: max of the new levels
     Outputs: Returns the new colormap
             -newCmap: new color map
@@ -66,37 +65,11 @@ def makeColorMap(colormap, levMin, levMax, continuous=False):
             -newLev: new levels list
             -newNorm: new norm for plotting
     """
-    N = 30
     colors = colormap['colors']
     cmap = colormap['cmap']
     lev = colormap['lev']
     ticks = colormap['ticks']
     if continuous:
-        ############# option one##############
-        # stick to the same colors for the same thresholds
-        # a bit more time consiuming to calculate and non linear scale
-        #############################################
-        # indStart = np.where(np.asarray(lev) <= levMin)[0][-1]
-        # indEnd = np.where(np.asarray(lev) > levMax)[0][0]
-        # lev = lev[indStart:indEnd+1]
-        # colors = colors[indStart:indEnd]
-        # newLev = []
-        # newColors =  np.empty((0, 4))
-        # for i in range(len(lev)-2):
-        #     interColors = [colors[i], colors[i+1]]
-        #     interCmap = get_continuous_cmap(interColors, continuous=True)
-        #     extractLev = list(np.linspace(lev[i],lev[i+1],N))
-        #     extractlevcol = np.linspace(0,1,N)
-        #     extractcol = interCmap(extractlevcol)
-        #     newColors = np.vstack((newColors, extractcol))
-        #     newLev = newLev+extractLev
-        # newCmap = mcolors.ListedColormap(newColors)
-        # newNorm = mcolors.BoundaryNorm(newLev, newCmap.N)
-
-        ########### option two #############
-        # use any colormap
-        # does not match the predefined thresholds / color pairs from the discrete map
-        #########################################
         newNorm = None
         newLev = None
         newColors = None
@@ -104,10 +77,10 @@ def makeColorMap(colormap, levMin, levMax, continuous=False):
         ticks = None
 
     else:
-        indStart = np.where(np.asarray(lev) <= levMin)[0][-1]
+        # indStart = np.where(np.asarray(lev) <= levMin)[0][-1]
         indEnd = np.where(np.asarray(lev) > levMax)[0][0]
-        newLev = lev[indStart:indEnd+1]
-        newColors = colors[indStart:indEnd]
+        newLev = lev[:indEnd+1]
+        newColors = colors[:indEnd]
         newCmap = get_continuous_cmap(newColors, continuous=False)
         newNorm = mcolors.BoundaryNorm(newLev, newCmap.N)
 

--- a/avaframe/out3Plot/outAIMEC.py
+++ b/avaframe/out3Plot/outAIMEC.py
@@ -64,8 +64,7 @@ def visuTransfo(rasterTransfo, inputData, cfgSetup, cfgPath, cfgFlags):
     maskedArray = np.ma.masked_where(xyRaster == 0, xyRaster)
     maskedArraySL = np.ma.masked_where(slRaster == 0, slRaster)
 
-    cmap, _, _, norm, ticks = makePalette.makeColorMap(
-        pU.colorMaps[resType], 0.0, np.nanmax(maskedArray), continuous=pU.contCmap)
+    cmap, _, _, norm, ticks = makePalette.makeColorMap(pU.colorMaps[resType], np.nanmax(maskedArray), continuous=pU.contCmap)
     cmap.set_under(color='w')
 
     ############################################
@@ -199,9 +198,7 @@ def visuRunoutStat(rasterTransfo, resAnalysis, newRasters, cfgSetup, cfgPath, cf
 
     maskedArray = np.ma.masked_where(rasterdataPres == 0, rasterdataPres)
 
-    cmap, _, _, norm, ticks = makePalette.makeColorMap(pU.colorMaps[resType], 0.0,
-                                                       np.nanmax(maskedArray),
-                                                       continuous=pU.contCmap)
+    cmap, _, _, norm, ticks = makePalette.makeColorMap(pU.colorMaps[resType], np.nanmax(maskedArray), continuous=pU.contCmap)
     cmap.set_bad('w', 1.)
 
     ############################################
@@ -347,8 +344,7 @@ def visuSimple(rasterTransfo, resAnalysis, newRasters, cfgPath, cfgFlags):
 
     for ax, cmap, data, title, unit in zip(axes.flatten(), Cmap, Data, Title, Unit):
         maskedArray = np.ma.masked_where(data == 0, data)
-        cmap, _, _, norm, ticks = makePalette.makeColorMap(
-            cmap, 0.0, np.nanmax(maskedArray), continuous=pU.contCmap)
+        cmap, _, _, norm, ticks = makePalette.makeColorMap(cmap, np.nanmax(maskedArray), continuous=pU.contCmap)
         cmap.set_bad('w', 1.)
         ax.axhline(y=runout[0], color='k', linestyle='-', label='runout')
 
@@ -400,9 +396,7 @@ def visuComparison(rasterTransfo, inputs, cfgPath, cfgFlags):
     ax1 = plt.subplot2grid((1,2), (0,0))
 
     # get color map
-    cmap, _, _, norm, ticks = makePalette.makeColorMap(pU.colorMaps[resType], thresholdValue,
-                                                       np.nanmax((refData)),
-                                                       continuous=contCmap)
+    cmap, _, _, norm, ticks = makePalette.makeColorMap(pU.colorMaps[resType], np.nanmax((refData)), continuous=contCmap)
     cmap.set_bad(color='w')
     refDataPlot = np.ma.masked_where(refData == 0.0, refData)
     ref0, im = pU.NonUnifIm(ax1, l, s, refDataPlot, 'l [m]', 's [m]',
@@ -449,9 +443,7 @@ def visuComparison(rasterTransfo, inputs, cfgPath, cfgFlags):
     fig = plt.figure(figsize=(pU.figW*3, pU.figH*2))#, constrained_layout=True)
     ax1 = plt.subplot2grid((3,3), (0,0), rowspan=3)
     # get color map
-    cmap, _, _, norm, ticks = makePalette.makeColorMap(pU.colorMaps[resType], thresholdValue,
-                                                       np.nanmax((refData)),
-                                                       continuous=pU.contCmap)
+    cmap, _, _, norm, ticks = makePalette.makeColorMap(pU.colorMaps[resType], np.nanmax((refData)), continuous=pU.contCmap)
     cmap.set_bad(color='w')
     refDataPlot = np.ma.masked_where(refData == 0.0, refData)
     ref0, im = pU.NonUnifIm(ax1, l, s, refDataPlot, 'l [m]', 's [m]',
@@ -492,7 +484,7 @@ def visuComparison(rasterTransfo, inputs, cfgPath, cfgFlags):
 
         # print contour lines only if the thre threshold is reached
         L, S = np.meshgrid(l, s[indStartOfRunout:])
-        colorsP = pU.colorMaps[resType]['colors'][1:]
+        colorsP = pU.colorMaps['pfd']['colors'][1:]
         if (np.where(refData > thresholdArray[-1], True, False)).any():
             contourRef = ax2.contour(L, S, refData, levels=thresholdArray[:-1], linewidths=2, colors=colorsP)
             labels = [str(level) + unit for level in thresholdArray[:-1]]
@@ -726,8 +718,7 @@ def resultVisu(cfgSetup, cfgPath, cfgFlags, rasterTransfo, resAnalysis):
         if cfgPath['colorParameter'] == []:
             nSamples = np.size(runout)
             colors = np.zeros(nSamples)
-            cmap, _, _, norm, ticks = makePalette.makeColorMap(
-                pU.cmapVar, 0, 0, continuous=True)
+            cmap, _, _, norm, ticks = makePalette.makeColorMap(pU.cmapVar, None, continuous=True)
             displayColorBar = False
             dataFrame = False
         else:
@@ -741,8 +732,7 @@ def resultVisu(cfgSetup, cfgPath, cfgFlags, rasterTransfo, resAnalysis):
                 displayColorBar = False
             else:
                 colors = cfgPath['colorParameter']
-                cmap, _, _, norm, ticks = makePalette.makeColorMap(
-                    pU.cmapVar, np.nanmin(cfgPath['colorParameter']), np.nanmax(cfgPath['colorParameter']), continuous=True)
+                cmap, _, _, norm, ticks = makePalette.makeColorMap(pU.cmapVar, np.nanmax(cfgPath['colorParameter']), continuous=True)
                 displayColorBar = True
                 dataFrame = False
     else:
@@ -750,8 +740,7 @@ def resultVisu(cfgSetup, cfgPath, cfgFlags, rasterTransfo, resAnalysis):
         dataFrame = False
         nSamples = np.size(runout)
         colors = np.zeros(nSamples)
-        cmap, _, _, norm, ticks = makePalette.makeColorMap(
-            pU.cmapVar, 0, 0, continuous=True)
+        cmap, _, _, norm, ticks = makePalette.makeColorMap(pU.cmapVar, None, continuous=True)
     #######################################
     # Final result diagram - z_profile+data
 

--- a/avaframe/out3Plot/outQuickPlot.py
+++ b/avaframe/out3Plot/outQuickPlot.py
@@ -91,8 +91,7 @@ def generatePlot(dataDict, avaName, outDir, cfg, plotDict):
     fig = plt.figure(figsize=(pU.figW*3, pU.figH*2))
     suptitle = fig.suptitle(avaName, fontsize=14, color='0.5')
     ax1 = fig.add_subplot(221)
-    cmap, _, _, norm, ticks = makePalette.makeColorMap(
-        pU.cmapPres, np.nanmin(data1), np.nanmax(data1), continuous=pU.contCmap)
+    cmap, _, _, norm, ticks = makePalette.makeColorMap(pU.cmapPres, np.nanmax(data1), continuous=pU.contCmap)
 
     cmap.set_bad('w')
     data1P = ma.masked_where(data1 == 0.0, data1)
@@ -107,8 +106,7 @@ def generatePlot(dataDict, avaName, outDir, cfg, plotDict):
     ax1.set_ylabel('y [m]')
 
     ax2 = fig.add_subplot(222)
-    cmap, _, _, norm, ticks = makePalette.makeColorMap(
-        pU.cmapPres, np.nanmin(data2), np.nanmax(data2), continuous=pU.contCmap)
+    cmap, _, _, norm, ticks = makePalette.makeColorMap(pU.cmapPres, np.nanmax(data2), continuous=pU.contCmap)
 
     cmap.set_bad('w')
     data2P = ma.masked_where(data2 == 0.0, data2)
@@ -436,8 +434,7 @@ def generateOnePlot(dataDict, outDir, cfg, plotDict):
     fig = plt.figure(figsize=(pU.figW*2, pU.figH))
     suptitle = fig.suptitle(name1, fontsize=14, color='0.5')
     ax1 = fig.add_subplot(121)
-    cmap, _, _, norm, ticks = makePalette.makeColorMap(
-        pU.cmapPres, np.nanmin(data1), np.nanmax(data1), continuous=pU.contCmap)
+    cmap, _, _, norm, ticks = makePalette.makeColorMap(pU.cmapPres, np.nanmax(data1), continuous=pU.contCmap)
 
     im1 = plt.imshow(data1, cmap=cmap, extent=[0, Lx, 0, Ly], origin='lower', aspect=nx/ny, norm=norm)
     pU.addColorBar(im1, ax1, ticks, unit)

--- a/avaframe/out3Plot/plotUtils.py
+++ b/avaframe/out3Plot/plotUtils.py
@@ -14,7 +14,6 @@ import datetime
 import pathlib
 from matplotlib.image import NonUniformImage
 from matplotlib import pyplot as plt
-import cmocean
 import logging
 from cmcrameri import cm as cmapCameri
 
@@ -98,12 +97,6 @@ cmapPlasma.set_bad(color='k')
 
 cmapViridis = copy.copy(matplotlib.cm.viridis)
 cmapViridis.set_bad(color='k')
-
-cmapIce = copy.copy(cmocean.cm.ice)
-cmapIce.set_bad(color='k')
-
-cmapDense = copy.copy(cmocean.cm.dense)
-cmapDense.set_bad(color='k')
 
 # divergent color map
 cmapdiv = copy.copy(matplotlib.cm.RdBu_r)  # sns.color_palette("RdBu_r")

--- a/avaframe/out3Plot/plotUtils.py
+++ b/avaframe/out3Plot/plotUtils.py
@@ -16,6 +16,7 @@ from matplotlib.image import NonUniformImage
 from matplotlib import pyplot as plt
 import cmocean
 import logging
+from cmcrameri import cm as cmapCameri
 
 from avaframe.in3Utils import cfgUtils
 from avaframe.out3Plot import makePalette
@@ -121,25 +122,25 @@ cmapAvaframeCont = makePalette.get_continuous_cmap(colorAvaframe, continuous=Tru
 # for the choice of the colormaps, check https://www.fabiocrameri.ch/colourmaps/
 # and http://hclwizard.org:3000/hclwizard/
 # multi sequential colormap for pressure
-levP = [0., 1.0, 10.0, 25.0, 50.0, 1000.0]
+levP = [1.0, 10.0, 25.0, 50.0, 1000.0]
 ticksP = [0., 1.0, 10.0, 25.0, 50.0]
 # Hawaii color map
-colorsP = ['#FFFAFA', "#B0F4FA", "#75C165", "#A96C00", "#8B0069"]
-cmapP = makePalette.get_continuous_cmap(colorsP, continuous=True)
+colorsP = ["#B0F4FA", "#75C165", "#A96C00", "#8B0069"]
+cmapP = cmapCameri.hawaii.reversed()
 
 # multi sequential colormap for flow depth
-levD = [0., 0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 50.0]
-ticksD = [0., 0.5, 1.0, 2.0, 3.0, 4.0, 5.0]
+levD = [0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 50.0]
+ticksD = [0.5, 1.0, 2.0, 3.0, 4.0, 5.0]
 # Lajolla color map
-colorsD = ['#FFFAFA', "#FCFFC9", "#EBCE7B", "#DE9529", "#BE5A32", "#7F2B3F", "#1D0B14"]
-cmapD = makePalette.get_continuous_cmap(colorsD, continuous=True)
+colorsD = ["#FCFFC9", "#EBCE7B", "#DE9529", "#BE5A32", "#7F2B3F", "#1D0B14"]
+cmapD = cmapCameri.lajolla
 
 # multi sequential colormap for speed
-levS = [0., 1, 5, 10, 15, 20, 25, 30, 100]
-ticksS = [0., 1, 5, 10, 15, 20, 25, 30]
+levS = [1, 5, 10, 15, 20, 25, 30, 100]
+ticksS = [1, 5, 10, 15, 20, 25, 30]
 # Batflow color map
-colorsS = ['#FFFAFA', '#FFCEF4', '#FFA7A8', '#C19A1B', '#578B21', '#007054', '#004960', '#201158']
-cmapS = makePalette.get_continuous_cmap(colorsS, continuous=True)
+colorsS = ['#FFCEF4', '#FFA7A8', '#C19A1B', '#578B21', '#007054', '#004960', '#201158']
+cmapS = cmapCameri.batlow.reversed()
 
 ###############################################
 # Set colormaps to use

--- a/avaframe/out3Plot/statsPlots.py
+++ b/avaframe/out3Plot/statsPlots.py
@@ -56,8 +56,7 @@ def plotValuesScatter(peakValues, resType1, resType2, cfg, avalancheDir, flagSho
     varValV = np.array(varVal)
 
     # load variation colormap
-    cmap, _, _, norm, ticks = makePalette.makeColorMap(
-        pU.cmapVar, np.amin(varValV), np.amax(varValV), continuous=True)
+    cmap, _, _, norm, ticks = makePalette.makeColorMap(pU.cmapVar, np.amax(varValV), continuous=True)
 
     fig, ax = plt.subplots()
     plt.title('%s vs. %s' % (name1, name2))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy
 matplotlib
 pyshp
 scipy
-cmocean
+cmcrameri
 seaborn
 cython
 pandas


### PR DESCRIPTION
Read continuous colormaps directly from cameri python module
For discrete color maps, use the lower level as limit (everything below appears transparent)