### PR TITLE
fix bug in dfa2aime and update log info

### DIFF
--- a/avaframe/ana3AIMEC/dfa2Aimec.py
+++ b/avaframe/ana3AIMEC/dfa2Aimec.py
@@ -201,14 +201,16 @@ def getPathsFromSimName(pathDict, avaDir, cfg, inputDirRef, simNameRef, inputDir
         log.info('Added to pathDict[%s] %s ' % (suf, compFile))
 
     # if desired set path to mass log files
+    sims = {comModules[0]: simNameRef, comModules[1]: simNameComp}
     if cfg['FLAGS'].getboolean('flagMass'):
-        for comMod in comModules:
+        for comMod, sim in sims.items():
+            log.info('mass file for comMod: %s and sim: %s' % (comMod, sim))
             if comMod == 'benchmarkReference':
-                pathDict = getRefMB(cfg['AIMECSETUP']['testName'], pathDict, simNameRef)
+                pathDict = getRefMB(cfg['AIMECSETUP']['testName'], pathDict, sim)
             elif comMod == 'com1DFAOrig':
-                pathDict = extractCom1DFAMBInfo(avaDir, pathDict, simNameInput=simNameRef)
+                pathDict = extractCom1DFAMBInfo(avaDir, pathDict, simNameInput=sim)
             else:
-                pathDict = getMBInfo(avaDir, pathDict, comMod, simName=simNameComp)
+                pathDict = getMBInfo(avaDir, pathDict, comMod, simName=sim)
 
     return pathDict
 

--- a/avaframe/com1DFA/DFAfunctionsCython.pyx
+++ b/avaframe/com1DFA/DFAfunctionsCython.pyx
@@ -707,7 +707,7 @@ def updatePositionC(cfg, particles, dem, force, DT):
   # remove particles that are not located on the mesh any more
   if nRemove > 0:
       mask = np.array(np.asarray(keepParticle), dtype=bool)
-      particles = DFAtls.removePart(particles, mask, nRemove)
+      particles = DFAtls.removePart(particles, mask, nRemove, 'because they exited to domain')
 
   # split particles with too much mass
   particles = DFAtls.splitPart(particles)

--- a/avaframe/com1DFA/DFAfunctionsCython.pyx
+++ b/avaframe/com1DFA/DFAfunctionsCython.pyx
@@ -707,7 +707,7 @@ def updatePositionC(cfg, particles, dem, force, DT):
   # remove particles that are not located on the mesh any more
   if nRemove > 0:
       mask = np.array(np.asarray(keepParticle), dtype=bool)
-      particles = DFAtls.removePart(particles, mask, nRemove, 'because they exited to domain')
+      particles = DFAtls.removePart(particles, mask, nRemove, 'because they exited the domain')
 
   # split particles with too much mass
   particles = DFAtls.splitPart(particles)

--- a/avaframe/com1DFA/DFAtools.py
+++ b/avaframe/com1DFA/DFAtools.py
@@ -302,7 +302,7 @@ def getAreaMesh(Nx, Ny, Nz, csz, num):
     return A
 
 
-def removePart(particles, mask, nRemove):
+def removePart(particles, mask, nRemove, reasonString=''):
     """ remove given particles
 
     Parameters
@@ -313,6 +313,8 @@ def removePart(particles, mask, nRemove):
         particles to keep
     nRemove : int
         number of particles removed
+    reasonString: str
+        reason why removing particles - for log message
 
     Returns
     -------
@@ -320,7 +322,7 @@ def removePart(particles, mask, nRemove):
         particles dictionary
     """
 
-    log.info('removed %s particles because they exited the domain' % (nRemove))
+    log.info('removed %s particles %s' % (nRemove, reasonString))
     nPart = particles['Npart']
     for key in particles:
         if key == 'Npart':

--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -1548,7 +1548,7 @@ def checkParticlesInRelease(particles, line, radius):
 
     nRemove = len(Mask)-np.sum(Mask)
     if nRemove > 0:
-        particles = DFAtls.removePart(particles, Mask, nRemove)
+        particles = DFAtls.removePart(particles, Mask, nRemove, 'because they are not within the release polygon')
         log.debug('removed %s particles because they are not within the release polygon' % (nRemove))
 
     return particles


### PR DESCRIPTION
* when particles are removed in the initialisation step, when they are located outside of the release polygon - but within the cells that are crossed by the release line - the log was also because the extited the domain - now there is the option to pass a 'reasonString' to the removePart function so that the log message can be more descriptive of the actual situation (here changed to because the are not within the release polygon)
* when fetching the mass files for aimec, there was a bug that not the actual simName was passed but either the simNameRef or simNameComp already assuming the comModules instead of taking the respective simNames - fixed 