### PR TITLE
solve bug for entrainment thickness

### DIFF
--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -671,10 +671,8 @@ def initializeSimulation(cfg, demOri, inputSimLines, logName, relThField):
     # initialize entrainment and resistance
     # get info of simType and whether or not to initialize resistance and entrainment
     simTypeActual = cfgGen['simTypeActual']
-    rhoEnt = cfgGen.getfloat('rhoEnt')
-    entTh = cfgGen.getfloat('entTh')
     entrMassRaster, reportAreaInfo = initializeMassEnt(demOri, simTypeActual, inputSimLines['entLine'], reportAreaInfo,
-                                                       thresholdPointInPoly)
+                                                       thresholdPointInPoly, cfgGen.getfloat('rhoEnt'))
 
     # check if entrainment and release overlap
     entrMassRaster = geoTrans.checkOverlap(entrMassRaster, relRaster, 'Entrainment', 'Release', crop=True)
@@ -684,7 +682,7 @@ def initializeSimulation(cfg, demOri, inputSimLines, logName, relThField):
             entrMassRaster = geoTrans.checkOverlap(entrMassRaster, secRelRaster, 'Entrainment', 'Secondary release ',
                 crop=True)
     # surfacic entrainment mass available (unit kg/m²)
-    fields['entrMassRaster'] = entrMassRaster*rhoEnt
+    fields['entrMassRaster'] = entrMassRaster#*rhoEnt
     entreainableMass = np.nansum(fields['entrMassRaster']*dem['areaRaster'])
     log.info('Mass available for entrainment: %.2f kg' % (entreainableMass))
 
@@ -993,7 +991,7 @@ def placeParticles(massCell, indx, indy, csz, massPerPart, rng, initPartDistType
     return xpart, ypart, mPart, nPart
 
 
-def initializeMassEnt(dem, simTypeActual, entLine, reportAreaInfo, thresholdPointInPoly):
+def initializeMassEnt(dem, simTypeActual, entLine, reportAreaInfo, thresholdPointInPoly, rhoEnt):
     """ Initialize mass for entrainment
 
     Parameters
@@ -1009,6 +1007,8 @@ def initializeMassEnt(dem, simTypeActual, entLine, reportAreaInfo, thresholdPoin
     thresholdPointInPoly: float
         threshold val that decides if a point is in the polygon, on the line or
         very close but outside
+    rhoEnt: float
+        density of entrainment snow
 
     Returns
     -------
@@ -1031,6 +1031,8 @@ def initializeMassEnt(dem, simTypeActual, entLine, reportAreaInfo, thresholdPoin
     else:
         entrMassRaster = np.zeros((nrows, ncols))
         reportAreaInfo['entrainment'] = 'No'
+
+    entrMassRaster = entrMassRaster * rhoEnt
 
     return entrMassRaster, reportAreaInfo
 

--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -675,6 +675,7 @@ def initializeSimulation(cfg, demOri, inputSimLines, logName, relThField):
     entTh = cfgGen.getfloat('entTh')
     entrMassRaster, reportAreaInfo = initializeMassEnt(demOri, simTypeActual, inputSimLines['entLine'], reportAreaInfo,
                                                        thresholdPointInPoly)
+
     # check if entrainment and release overlap
     entrMassRaster = geoTrans.checkOverlap(entrMassRaster, relRaster, 'Entrainment', 'Release', crop=True)
     # check for overlap with the secondary release area
@@ -683,7 +684,7 @@ def initializeSimulation(cfg, demOri, inputSimLines, logName, relThField):
             entrMassRaster = geoTrans.checkOverlap(entrMassRaster, secRelRaster, 'Entrainment', 'Secondary release ',
                 crop=True)
     # surfacic entrainment mass available (unit kg/m²)
-    fields['entrMassRaster'] = entrMassRaster*rhoEnt*entTh
+    fields['entrMassRaster'] = entrMassRaster*rhoEnt
     entreainableMass = np.nansum(fields['entrMassRaster']*dem['areaRaster'])
     log.info('Mass available for entrainment: %.2f kg' % (entreainableMass))
 

--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -682,7 +682,7 @@ def initializeSimulation(cfg, demOri, inputSimLines, logName, relThField):
             entrMassRaster = geoTrans.checkOverlap(entrMassRaster, secRelRaster, 'Entrainment', 'Secondary release ',
                 crop=True)
     # surfacic entrainment mass available (unit kg/m²)
-    fields['entrMassRaster'] = entrMassRaster#*rhoEnt
+    fields['entrMassRaster'] = entrMassRaster
     entreainableMass = np.nansum(fields['entrMassRaster']*dem['areaRaster'])
     log.info('Mass available for entrainment: %.2f kg' % (entreainableMass))
 

--- a/avaframe/com1DFAOrig/com1DFAOrig.py
+++ b/avaframe/com1DFAOrig/com1DFAOrig.py
@@ -121,11 +121,11 @@ def getSimulation(cfg, rel, entResInfo):
         the suffix _AF will be added')
         simName = relName + '_AF'
     relDict = sP.SHP2Array(rel)
-    for k in range(len(relDict['d0'])):
-        if relDict['d0'][k] == 'None':
-            relDict['d0'][k] = cfg['DEFVALUES'].getfloat('RelTh')
+    for k in range(len(relDict['thickness'])):
+        if relDict['thickness'][k] == 'None':
+            relDict['thickness'][k] = cfg['DEFVALUES'].getfloat('RelTh')
         else:
-            relDict['d0'][k] = float(relDict['d0'][k])
+            relDict['thickness'][k] = float(relDict['thickness'][k])
 
     log.info('Release area scenario: %s - perform simulations' % (relName))
 
@@ -318,10 +318,10 @@ def com1DFAOrigMain(cfg, avaDir):
                         reportVar['Simulation Parameters'].update({'Entrainment thickness [m]': float(entrainmentTH)})
                         reportVar['Release area'].update({'Release thickness [m]': item})
                     elif cfgPar['varPar'] == 'Mu':
-                        reportVar['Simulation Parameters'].update({'Release thickness [m]': relDict['d0']})
+                        reportVar['Simulation Parameters'].update({'Release thickness [m]': relDict['thickness']})
                         reportVar['Simulation Parameters'].update({'Mu': item})
                         reportVar['Simulation Parameters'].update({'Entrainment thickness [m]': float(entrainmentTH)})
-                        reportVar['Release area'].update({'Release thickness [m]': relDict['d0']})
+                        reportVar['Release area'].update({'Release thickness [m]': relDict['thickness']})
 
                     if entInfo == 'Yes':
                         reportVar['Entrainment area'] = {'type': 'columns', 'Entrainment area scenario': entrainmentArea, 'Entrainment thickness [m]': float(entrainmentTH)}
@@ -375,9 +375,9 @@ def com1DFAOrigMain(cfg, avaDir):
                         'Parameter variation on': '',
                         'Parameter value': '',
                         'Mu': defValues['Mu'],
-                        'Release thickness [m]': relDict['d0'],
+                        'Release thickness [m]': relDict['thickness'],
                         'Entrainment thickness [m]': float(entrainmentTH)},
-                    'Release Area': {'type': 'columns', 'Release area scenario': relName, 'Release features': relDict['Name'], 'Release thickness [m]': relDict['d0']}}
+                    'Release Area': {'type': 'columns', 'Release area scenario': relName, 'Release features': relDict['Name'], 'Release thickness [m]': relDict['thickness']}}
 
                 if entInfo == 'Yes':
                     reportST.update({'Entrainment area': {'type': 'columns', 'Entrainment area scenario': entrainmentArea, 'Entrainment thickness [m]': float(entrainmentTH)}})
@@ -438,9 +438,9 @@ def com1DFAOrigMain(cfg, avaDir):
                 'Parameter variation on': '',
                 'Parameter value': '',
                 'Mu': defValues['Mu'],
-                'Release thickness [m]': relDict['d0'],
+                'Release thickness [m]': relDict['thickness'],
                 'Entrainment thickness [m]': float(entrainmentTH)},
-            'Release area': {'type': 'columns', 'Release area scenario': relName, 'Release features': relDict['Name'], 'Release thickness [m]': relDict['d0']}}
+            'Release area': {'type': 'columns', 'Release area scenario': relName, 'Release features': relDict['Name'], 'Release thickness [m]': relDict['thickness']}}
 
         endTime = time.time()
         timeNeeded = '%.2f' % (endTime - startTime)

--- a/avaframe/runScripts/runCompareCom1DFAvsCom1DFAOrig.py
+++ b/avaframe/runScripts/runCompareCom1DFAvsCom1DFAOrig.py
@@ -34,6 +34,7 @@ simType = 'null'
 cfgAimec = cfgUtils.getDefaultModuleConfig(ana3AIMEC)
 cfgAimec['AIMECSETUP']['comModules'] = 'com1DFAOrig|com1DFA'
 cfgAimec['AIMECSETUP']['resType'] = 'ppr'
+cfgAimec['AIMECSETUP']['startOfRunoutAreaAngle'] = '10'
 cfgAimec['FLAGS']['flagMass'] = 'True'
 # Which parameter to filter data for creating comparison plots, e.g. varPar = 'simType', values = ['null'] or
 # varPar = 'Mu', values = ['0.055', '0.155']; values need to be given as list, also if only one value

--- a/avaframe/tests/test_com1DFA.py
+++ b/avaframe/tests/test_com1DFA.py
@@ -72,7 +72,7 @@ def test_prepareReleaseEntrainment(tmp_path):
     cfg['GENERAL'] = {'secRelArea': 'True', 'useRelThFromIni': 'False', 'useEntThFromIni': 'False',
                       'relTh': '1.32', 'secondaryRelTh': '2.5'}
     inputSimLines = {}
-    inputSimLines['entResInfo'] = {'flagSecondaryRelease': 'Yes', 'flagEnt': 'False'}
+    inputSimLines['entResInfo'] = {'flagSecondaryRelease': 'Yes', 'flagEnt': 'No'}
     inputSimLines['releaseLine'] = {'thickness': ['None', 'None'], 'type': 'Release'}
     inputSimLines['secondaryReleaseLine'] = {'thickness': ['1.789'], 'type': 'Secondary release'}
     rel = pathlib.Path(tmp_path, 'release1PF_test.shp')
@@ -85,11 +85,13 @@ def test_prepareReleaseEntrainment(tmp_path):
     assert inputSimLines['entResInfo']['flagSecondaryRelease'] == 'Yes'
     assert inputSimLines['releaseLine']['thickness'] == [1.32, 1.32]
     assert inputSimLines['secondaryReleaseLine']['thickness'] == [1.789]
+    assert inputSimLines['releaseLine']['thicknessSource'] == ['ini file', 'ini file']
+    assert inputSimLines['secondaryReleaseLine']['thicknessSource'] == ['shp file']
     assert badName is True
 
     # setup required inputs
     inputSimLines = {}
-    inputSimLines['entResInfo'] = {'flagSecondaryRelease': 'Yes', 'flagEnt': 'False'}
+    inputSimLines['entResInfo'] = {'flagSecondaryRelease': 'Yes', 'flagEnt': 'No'}
     inputSimLines['releaseLine'] = {'thickness': ['1.78', '4.328'], 'type': 'release'}
     inputSimLines['secondaryReleaseLine'] = {'thickness': ['None'], 'type': 'Secondary release'}
     rel = pathlib.Path(tmp_path, 'release1PF_test.shp')
@@ -102,11 +104,13 @@ def test_prepareReleaseEntrainment(tmp_path):
     assert inputSimLines2['entResInfo']['flagSecondaryRelease'] == 'Yes'
     assert inputSimLines2['releaseLine']['thickness'] == [1.78, 4.328]
     assert inputSimLines2['secondaryReleaseLine']['thickness'] == [2.5]
+    assert inputSimLines2['secondaryReleaseLine']['thicknessSource'] == ['ini file']
+    assert inputSimLines2['releaseLine']['thicknessSource'] == ['shp file', 'shp file']
     assert badName2 is True
 
     # setup required inputs
     inputSimLines = {}
-    inputSimLines['entResInfo'] = {'flagSecondaryRelease': 'No', 'flagEnt': 'False'}
+    inputSimLines['entResInfo'] = {'flagSecondaryRelease': 'No', 'flagEnt': 'No'}
     inputSimLines['releaseLine'] = {'thickness': ['1.78', '4.328'], 'type': 'release'}
     rel = pathlib.Path(tmp_path, 'release1PF_test.shp')
 
@@ -123,12 +127,13 @@ def test_prepareReleaseEntrainment(tmp_path):
     assert relName3 == 'release1PF_test'
     assert inputSimLines3['entResInfo']['flagSecondaryRelease'] == 'No'
     assert inputSimLines3['releaseLine']['thickness'] == [1.78, 4.328]
+    assert inputSimLines3['releaseLine']['thicknessSource'] == ['shp file', 'shp file']
     assert inputSimLines3['secondaryReleaseLine'] is None
     assert badName3 is True
 
     # setup required inputs
     inputSimLines = {}
-    inputSimLines['entResInfo'] = {'flagSecondaryRelease': 'No', 'flagEnt': 'False'}
+    inputSimLines['entResInfo'] = {'flagSecondaryRelease': 'No', 'flagEnt': 'No'}
     inputSimLines['releaseLine'] = {'thickness': ['1.78', '4.328'], 'type': 'release'}
     rel = pathlib.Path(tmp_path, 'release1PF_test.shp')
     cfg['GENERAL']['useRelThFromIni'] = 'True'
@@ -141,6 +146,25 @@ def test_prepareReleaseEntrainment(tmp_path):
     assert inputSimLines4['entResInfo']['flagSecondaryRelease'] == 'No'
     assert inputSimLines4['releaseLine']['thickness'] == [1.32, 1.32]
     assert inputSimLines4['secondaryReleaseLine'] is None
+    assert inputSimLines4['releaseLine']['thicknessSource'] == ['ini file', 'ini file']
+
+    # call function to test
+    cfg['GENERAL'] = {'secRelArea': 'False', 'useRelThFromIni': 'False', 'useEntThFromIni': 'False',
+                      'relTh': '1.32', 'secondaryRelTh': '2.5', 'entTh': '0.3'}
+    inputSimLines = {}
+    inputSimLines['entResInfo'] = {'flagSecondaryRelease': 'No', 'flagEnt': 'Yes'}
+    inputSimLines['releaseLine'] = {'thickness': ['None', 'None'], 'type': 'Release'}
+    inputSimLines['entLine'] = {'thickness': ['0.4', 'None'], 'type': 'Entrainment'}
+    relName5, inputSimLines5, badName5 = com1DFA.prepareReleaseEntrainment(
+        cfg, rel, inputSimLines)
+
+    assert relName5 == 'release1PF_test'
+    assert inputSimLines5['entResInfo']['flagSecondaryRelease'] == 'No'
+    assert inputSimLines5['releaseLine']['thickness'] == [1.32, 1.32]
+    assert inputSimLines5['entLine']['thickness'] == [0.4, 0.3]
+    assert inputSimLines5['secondaryReleaseLine'] is None
+    assert inputSimLines5['entLine']['thicknessSource'] == ['shp file', 'ini file']
+    assert inputSimLines5['releaseLine']['thicknessSource'] == ['ini file', 'ini file']
 
 
 def test_setThickness():

--- a/avaframe/tests/test_com1DFA.py
+++ b/avaframe/tests/test_com1DFA.py
@@ -1361,7 +1361,8 @@ def test_initializeSimulation():
 
     # setup required input
     cfg = configparser.ConfigParser()
-    cfg['GENERAL'] = {'methodMeshNormal': '1', 'thresholdPointInPoly': '0.001',
+    cfg['GENERAL'] = {'methodMeshNormal': '1', 'thresholdPointInPoly': '0.001', 'useRelThFromIni': 'False',
+                      'relTh': '1.0', 'useEntThFromIni': 'False',
                       'sphKernelRadius': '1.', 'meshCellSizeThreshold': '0.0001',
                       'meshCellSize': '1.', 'simTypeActual': 'ent', 'rhoEnt': '100.', 'entTh': '0.3',
                       'rho': '200.', 'gravAcc': '9.81', 'massPerParticleDeterminationMethod': 'MPPDH',
@@ -1383,7 +1384,8 @@ def test_initializeSimulation():
     releaseLine = {'x': np.asarray([6.9, 8.5, 8.5, 6.9, 6.9]), 'y': np.asarray([7.9, 7.9, 9.5, 9.5, 7.9]),
                    'Start': np.asarray([0]), 'Length': np.asarray([5]), 'Name': [''], 'thickness': [1.0],
                    'thicknessSource': ['ini File'], 'type': 'release'}
-    entLine = {'fileName': 'test/entTest.shp', 'Name': ['testEnt'], 'Start': np.asarray([0.]),
+    entLine = {'fileName': 'test/entTest.shp', 'Name': ['testEnt'], 'Start': np.asarray([0.]), 'thickness': [0.3, 0.3],
+               'thicknessSource': ['shp file', 'shp file'],
                'Length': np.asarray([5]), 'x': np.asarray([4, 5., 5.0, 4., 4.]), 'type': 'entrainment',
                'y': np.asarray([4., 4., 5.0, 5., 4.0]), 'thickness': [0.3], 'thicknessSource': ['ini File']}
     inputSimLines = {'releaseLine': releaseLine, 'entResInfo': {'flagSecondaryRelease': 'No'}, 'entLine': entLine,

--- a/avaframe/tests/test_com1DFA.py
+++ b/avaframe/tests/test_com1DFA.py
@@ -471,22 +471,22 @@ def test_initializeMassEnt():
 
     # call function to be tested
     entrMassRaster, reportAreaInfo = com1DFA.initializeMassEnt(
-        dem, simTypeActual, entLine, reportAreaInfo, thresholdPointInPoly)
+        dem, simTypeActual, entLine, reportAreaInfo, thresholdPointInPoly, 200.)
     testData = np.zeros((nrows, ncols))
-    testData[0:11, 0:11] = 1.0
+    testData[0:11, 0:11] = 1.0 * 200.
 
     print('data', testData)
     print('ent', entrMassRaster, entLine)
 
     assert np.array_equal(entrMassRaster, testData)
-    assert np.sum(entrMassRaster) == 121
+    assert np.sum(entrMassRaster) == 24200.
     assert entrMassRaster.shape[0] == nrows
     assert reportAreaInfo['entrainment'] == 'Yes'
 
     # call function to be tested
     simTypeActual = 'res'
     entrMassRaster, reportAreaInfo = com1DFA.initializeMassEnt(
-        dem, simTypeActual, entLine, reportAreaInfo, thresholdPointInPoly)
+        dem, simTypeActual, entLine, reportAreaInfo, thresholdPointInPoly, 200.)
 
     assert np.array_equal(entrMassRaster, np.zeros((nrows, ncols)))
     assert reportAreaInfo['entrainment'] == 'No'


### PR DESCRIPTION
as entrainment thickness is now an attribute to the entLine dict - also set from there to the raster already so no need for multiplication afterwards anymore - needs a test 
* also switch in com1DFAorig from d0 to thickness in line dicts