### PR TITLE
Ata viscosity

### DIFF
--- a/avaframe/com1DFA/DFAfunctionsCython.pyx
+++ b/avaframe/com1DFA/DFAfunctionsCython.pyx
@@ -1,6 +1,5 @@
 """
     function related to SPH calculations in com1DFA
-
     to build: go to repository containing this file and run:
     python setup.py build_ext --inplace
 """
@@ -29,10 +28,8 @@ log = logging.getLogger(__name__)
 @cython.cdivision(True)
 def pointsToRasterC(double[:] xArray, double[:] yArray, double[:] zArray, Z0, double csz=1, double xllc=0, double yllc=0):
     """ Interpolate from unstructured points to grid
-
     Interpolate unstructured points on a structured grid using bilinear interpolation
     The (x, y) points have to be on the extend of the DEM!!
-
     Parameters
       ----------
       x: 1D numpy array
@@ -49,10 +46,8 @@ def pointsToRasterC(double[:] xArray, double[:] yArray, double[:] zArray, Z0, do
           x coord of the lower left center
       yllc : float
           y coord of the lower left center
-
       Returns
       -------
-
       Z1: 2D numpy array
           interpolated results
     """
@@ -109,9 +104,7 @@ def pointsToRasterC(double[:] xArray, double[:] yArray, double[:] zArray, Z0, do
 @cython.cdivision(True)
 def computeForceC(cfg, particles, fields, dem, dT, int frictType):
   """ compute forces acting on the particles (without the SPH component)
-
   Cython implementation implementation
-
   Parameters
   ----------
   cfg: configparser
@@ -122,7 +115,6 @@ def computeForceC(cfg, particles, fields, dem, dT, int frictType):
       dictionary with dem information
   dT : float
       time step
-
   Returns
   -------
   force : dict
@@ -149,6 +141,7 @@ def computeForceC(cfg, particles, fields, dem, dT, int frictType):
   cdef int reprojectionIterations = cfg.getint('reprojectionIterations')
   cdef double thresholdProjection = cfg.getfloat('thresholdProjection')
   cdef double subgridMixingFactor = cfg.getfloat('subgridMixingFactor')
+  cdef int viscOption = cfg.getint('viscOption')
   cdef double dt = dT
   cdef double mu = cfg.getfloat('mu')
   cdef int nPart = particles['nPart']
@@ -218,29 +211,30 @@ def computeForceC(cfg, particles, fields, dem, dT, int frictType):
       nx, ny, nz = getVector(Lx0, Ly0, w[0], w[1], w[2], w[3], nxArray, nyArray, nzArray)
       nx, ny, nz = normalize(nx, ny, nz)
 
-      # add artificial viscosity
-      vMeanx, vMeany, vMeanz = getVector(Lx0, Ly0, w[0], w[1], w[2], w[3], VX, VY, VZ)
-      # compute normal component of the velocity
-      vMeanNorm = scalProd(vMeanx, vMeany, vMeanz, nx, ny, nz)
-      # remove normal component (make sure vMean is in the tangent plane)
-      vMeanx = vMeanx - vMeanNorm * nx
-      vMeany = vMeany - vMeanNorm * ny
-      vMeanz = vMeanz - vMeanNorm * nz
-      # compute particle to field velocity difference
-      dvX = vMeanx - ux
-      dvY = vMeany - uy
-      dvZ = vMeanz - uz
-      dvMag = norm(dvX, dvY, dvZ)
-      Alat = 2.0 * math.sqrt((m * h) / rho)
-      fDrag = (subgridMixingFactor * 0.5 * rho * dvMag * Alat * dt) / m
+      if viscOption == 1:
+        # add artificial viscosity
+        vMeanx, vMeany, vMeanz = getVector(Lx0, Ly0, w[0], w[1], w[2], w[3], VX, VY, VZ)
+        # compute normal component of the velocity
+        vMeanNorm = scalProd(vMeanx, vMeany, vMeanz, nx, ny, nz)
+        # remove normal component (make sure vMean is in the tangent plane)
+        vMeanx = vMeanx - vMeanNorm * nx
+        vMeany = vMeany - vMeanNorm * ny
+        vMeanz = vMeanz - vMeanNorm * nz
+        # compute particle to field velocity difference
+        dvX = vMeanx - ux
+        dvY = vMeany - uy
+        dvZ = vMeanz - uz
+        dvMag = norm(dvX, dvY, dvZ)
+        Alat = 2.0 * math.sqrt((m * h) / rho)
+        fDrag = (subgridMixingFactor * 0.5 * rho * dvMag * Alat * dt) / m
 
-      # update velocity with artificial viscosity - implicit method
-      ux = ux + fDrag * vMeanx
-      uy = uy + fDrag * vMeany
-      uz = uz + fDrag * vMeanz
-      ux = ux / (1.0 + fDrag)
-      uy = uy / (1.0 + fDrag)
-      uz = uz / (1.0 + fDrag)
+        # update velocity with artificial viscosity - implicit method
+        ux = ux + fDrag * vMeanx
+        uy = uy + fDrag * vMeany
+        uz = uz + fDrag * vMeanz
+        ux = ux / (1.0 + fDrag)
+        uy = uy / (1.0 + fDrag)
+        uz = uz / (1.0 + fDrag)
 
       # get normal at the particle estimated end location
       xEnd = x + dt * ux
@@ -391,7 +385,6 @@ cpdef (double, double) computeEntMassAndForce(double dt, double entrMassCell,
                                               double tau, double entEroEnergy,
                                               double rhoEnt):
   """ compute force component due to entrained mass
-
   Parameters
   ----------
   entrMassCell : float
@@ -402,7 +395,6 @@ cpdef (double, double) computeEntMassAndForce(double dt, double entrMassCell,
       particle speed (velocity magnitude)
   tau : float
       bottom shear stress
-
   Returns
   -------
   dm : float
@@ -439,7 +431,6 @@ cpdef (double, double) computeEntMassAndForce(double dt, double entrMassCell,
 cpdef double computeResForce(double hRes, double h, double areaPart, double rho,
                              double cResCell, double uMag, int explicitFriction):
   """ compute force component due to resistance
-
   Parameters
   ----------
   hRes: float
@@ -456,7 +447,6 @@ cpdef double computeResForce(double hRes, double h, double areaPart, double rho,
       particle speed (velocity magnitude)
   explicitFriction: int
     if 1 add resistance with an explicit method. Implicit otherwise
-
   Returns
   -------
   cResPart : float
@@ -479,9 +469,7 @@ cpdef double computeResForce(double hRes, double h, double areaPart, double rho,
 @cython.cdivision(True)
 def updatePositionC(cfg, particles, dem, force, DT):
   """ update particle position using euler forward scheme
-
   Cython implementation
-
   Parameters
   ----------
   cfg: configparser
@@ -720,7 +708,6 @@ cpdef (double, double, double, double) account4FrictionForce(double ux, double u
                                                             double dt, double forceFrict,
                                                             double uMag, int explicitFriction):
   """ update velocity with friction force
-
   Parameters
   ----------
   ux: float
@@ -739,7 +726,6 @@ cpdef (double, double, double, double) account4FrictionForce(double ux, double u
       particle speed (velocity magnitude)
   explicitFriction: int
     if 1 add resistance with an explicit method. Implicit otherwise
-
   Returns
   -------
   uxNew: float
@@ -789,9 +775,7 @@ cpdef (double, double, double, double) account4FrictionForce(double ux, double u
 @cython.cdivision(True)
 def updateFieldsC(cfg, particles, dem, fields):
   """ update fields and particles fow depth
-
   Cython implementation
-
  Parameters
  ----------
  cfg: configparser
@@ -804,7 +788,6 @@ def updateFieldsC(cfg, particles, dem, fields):
      fields dictionary
  Returns
  -------
-
  particles : dict
      particles dictionary
  fields : dict
@@ -919,18 +902,15 @@ def updateFieldsC(cfg, particles, dem, fields):
 @cython.cdivision(True)
 def getNeighborsC(particles, dem):
     """ Locate particles on DEM and neighbour search grid
-
     Ĺocate each particle in a grid cell (both DEM and neighbour search grid) and build the
     indPartInCell and partInCell arrays for SPH neighbourSearch and
     InCell, IndX and IndY arrays location on the DEM grid.
     See issue #200 and documentation for details
-
     Parameters
     ----------
     particles : dict
     dem : dict
       dem dict with neighbour search grid header (information about neighbour search grid)
-
     Returns
     -------
     particles : dict
@@ -998,7 +978,6 @@ def getNeighborsC(particles, dem):
 def computeForceSPHC(cfg, particles, force, dem, gradient=0):
   """ Prepare data for C computation of lateral forces (SPH component)
   acting on the particles (SPH component)
-
   Parameters
   ----------
   cfg: configparser
@@ -1041,9 +1020,7 @@ def computeForceSPHC(cfg, particles, force, dem, gradient=0):
 def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid, double[:, :] nxArray, double[:, :] nyArray,
                  double[:, :] nzArray, gradient):
   """ compute lateral forces acting on the particles (SPH component)
-
   Cython implementation
-
   Parameters
   ----------
   cfg: configparser
@@ -1080,6 +1057,10 @@ def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid, double[:
   cdef double gravAcc = cfg.getfloat('gravAcc')
   cdef int interpOption = cfg.getint('interpOption')
   cdef int SPHoption = cfg.getint('sphOption')
+  cdef int viscOption = cfg.getint('viscOption')
+  cdef int flowDepthOption = cfg.getint('flowDepthOption')
+  cdef int symetryOption = cfg.getint('symetryOption')
+
   # grid normal raster information
   cdef double cszNormal = headerNormalGrid['cellsize']
   cdef int nRowsNormal = headerNormalGrid['nrows']
@@ -1097,7 +1078,6 @@ def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid, double[:
   cdef double dfacKernel = - 3.0 * facKernel
   # particle information
   cdef double[:] mass = particles['m']
-  cdef double[:] h = particles['h']
   cdef double[:] xArray = particles['x']
   cdef double[:] yArray = particles['y']
   cdef double[:] zArray = particles['z']
@@ -1105,6 +1085,12 @@ def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid, double[:
   cdef double[:] uyArray = particles['uy']
   cdef double[:] uzArray = particles['uz']
   cdef int N = xArray.shape[0]
+
+  cdef double[:] hArray = np.zeros(N, dtype=np.float64)
+  if flowDepthOption==0:
+    hArray = particles['h']
+  elif flowDepthOption==1:
+    hArray = particles['hSPH']
 
   # initialize variables and outputs
   cdef double[:] GHX = np.zeros(N, dtype=np.float64)
@@ -1115,59 +1101,73 @@ def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid, double[:
   cdef double gravAcc3
   cdef double gradhX, gradhY, gradhZ, uMag, nx, ny, nz, G1, G2, mdwdrr
   cdef double g1, g2, g11, g12, g22, g33
-  cdef double m11, m12, m22, GG1, GG2
+  cdef double m11, m12, m22, GG1, GG2, mk, ml
   cdef double x, y, z, ux, uy, uz, vx, vy, wx, wy, uxOrtho, uyOrtho, uzOrtho
-  cdef double dx, dy, dz, dn, r, hr, dwdr, wKernel
+  cdef double dx, dy, dz, dux, duy, duz, dn, r, hr, dwdr, wKernel
   cdef int Lx0, Ly0, iCell
   cdef double w[4]
   cdef int lInd, rInd
   cdef int indx, indy
-  cdef int j, ic, n, p, l, imax, imin, iPstart, iPend
+  cdef int k, ic, n, p, l, imax, imin, iPstart, iPend
   cdef int grad = gradient
+  # artificial viscosity parameters
+  cdef double dwdrr, vol, volr
+  cdef double viscX, viscY, viscZ, pikl
+  cdef double epsilon = 100
+  cdef double hk, hl, ck, cl, lambdakl
+
 
   # loop on particles
-  for j in range(N):
+  for k in range(N):
     gradhX = 0
     gradhY = 0
     gradhZ = 0
+    # adding Atartificial viscosity
+    if viscOption==2:
+      viscX = 0
+      viscY = 0
+      viscZ = 0
     G1 = 0
     G2 = 0
     m11 = 0
     m12 = 0
     m22 = 0
-    x = xArray[j]
-    y = yArray[j]
-    z = zArray[j]
-    ux = uxArray[j]
-    uy = uyArray[j]
-    uz = uzArray[j]
+    x = xArray[k]
+    y = yArray[k]
+    z = zArray[k]
+    ux = uxArray[k]
+    uy = uyArray[k]
+    uz = uzArray[k]
+    hk = hArray[k]
+
     # locate particle in SPH grid
     indx = <int>math.round(x / cszNeighbourGrid)
     indy = <int>math.round(y / cszNeighbourGrid)
 
+
+    # get normal vector
+    Lx0, Ly0, iCell, w[0], w[1], w[2], w[3] = getCellAndWeights(x, y, nColsNormal, nRowsNormal, cszNormal, interpOption)
+    nx, ny, nz = getVector(Lx0, Ly0, w[0], w[1], w[2], w[3], nxArray, nyArray, nzArray)
+    nx, ny, nz = normalize(nx, ny, nz)
+    # projection of gravity on normal vector
+    gravAcc3 = scalProd(nx, ny, nz, 0, 0, gravAcc)
     if SPHoption > 1:
-      # get normal vector
-      Lx0, Ly0, iCell, w[0], w[1], w[2], w[3] = getCellAndWeights(x, y, nColsNormal, nRowsNormal, cszNormal, interpOption)
-      nx, ny, nz = getVector(Lx0, Ly0, w[0], w[1], w[2], w[3], nxArray, nyArray, nzArray)
-      nx, ny, nz = normalize(nx, ny, nz)
-      # projection of gravity on normal vector
-      gravAcc3 = scalProd(nx, ny, nz, 0, 0, gravAcc)
-      uMag = norm(ux, uy, uz)
-      if uMag < velMagMin:
+        uMag = norm(ux, uy, uz)
+        if uMag < velMagMin:
           ux = 1
           uy = 0
           uz = -(1*nx + 0*ny) / nz
           ux, uy, uz = normalize(ux, uy, uz)
           K1 = 1
           K2 = 1
-      else:
+        else:
           ux, uy, uz = normalize(ux, uy, uz)
 
-      uxOrtho, uyOrtho, uzOrtho = crossProd(nx, ny, nz, ux, uy, uz)
-      uxOrtho, uyOrtho, uzOrtho = normalize(uxOrtho, uyOrtho, uzOrtho)
+        uxOrtho, uyOrtho, uzOrtho = crossProd(nx, ny, nz, ux, uy, uz)
+        uxOrtho, uyOrtho, uzOrtho = normalize(uxOrtho, uyOrtho, uzOrtho)
 
-      g1 = nx/(nz)
-      g2 = ny/(nz)
+        g1 = nx/(nz)
+        g2 = ny/(nz)
 
     # check if we are on the bottom ot top row!!!
     lInd = -1
@@ -1187,34 +1187,65 @@ def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid, double[:
         for p in range(iPstart, iPend):
             # index of particle in neighbour box
             l = partInCell[p]
-            if j != l:
+            if k != l:
                 dx = xArray[l] - x
                 dy = yArray[l] - y
                 dz = zArray[l] - z
                 if SPHoption == 1:
-                  dz = 0
-                  # get norm of r = xj - xl
+                  # like option 2 with dz!=0
+                  #dz = 0
+                  # get norm of r = xk - xl
                   r = norm(dx, dy, dz)
                   if r < minRKern * rKernel:
                       # impose a minimum distance between particles
-                      # dx = minRKern * rKernel * dx
-                      # dy = minRKern * rKernel * dy
+                      dx = minRKern * rKernel * dx
+                      dy = minRKern * rKernel * dy
+                      dz = minRKern * rKernel * dz
                       r = minRKern * rKernel
                   if r < rKernel:
                       hr = rKernel - r
                       dwdr = dfacKernel * hr * hr
-                      mdwdrr = mass[l] * dwdr / r
+                      ml = mass[l]
+                      hl = hArray[l]
+
+#-----------------------SPH gradient computation--------------------------------
+
+                      if symetryOption==0:
+                        # standard SPH formulation
+                        mdwdrr = ml * dwdr / r
+                      elif symetryOption==1:
+                        # symetric SPH formulation
+                        mdwdrr = ml*(1 + hk/hl) * dwdr / r
+
                       gradhX = gradhX + mdwdrr*dx
                       gradhY = gradhY + mdwdrr*dy
                       gradhZ = gradhZ + mdwdrr*dz
-                      gravAcc3 = gravAcc
+
+#-----------------------artificial viscosity computation------------------------
+
+                      dux = uxArray[l] - ux
+                      duy = uyArray[l] - uy
+                      duz = uzArray[l] - uz
+
+                      # ATA artificial viscosity
+                      if viscOption == 2:
+                        ck = math.sqrt(gravAcc3*hk)
+                        cl = math.sqrt(gravAcc3*hl)
+                        lamdbakl = (ck+cl)/2
+                        pikl = - lamdbakl * scalProd(dux, duy, duz, dx, dy, dz) / r
+                        # standard SPH formulation
+                        viscX = viscX + pikl * mdwdrr/hl * dx
+                        viscY = viscY + pikl * mdwdrr/hl * dy
+                        viscZ = viscZ + pikl * mdwdrr/hl * dz
+
+#=End of ABF modifications======================================================
 
                 if SPHoption == 2:
                   # get coordinates in local coord system
                   r1 = scalProd(dx, dy, dz, ux, uy, uz)
                   r2 = scalProd(dx, dy, dz, uxOrtho, uyOrtho, uzOrtho)
                   # impse r3=0 even if the particle is not exactly on the tengent plane
-                  # get norm of r = xj - xl
+                  # get norm of r = xk - xl
                   r = norm(r1, r2, 0)
                   if r < minRKern * rKernel:
                       # impose a minimum distance between particles
@@ -1238,7 +1269,7 @@ def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid, double[:
                   r1 = scalProd(dx, dy, dz, ux, uy, uz)
                   r2 = scalProd(dx, dy, dz, uxOrtho, uyOrtho, uzOrtho)
                   # impse r3=0 even if the particle is not exactly on the tengent plane
-                  # get norm of r = xj - xl
+                  # get norm of r = xk - xl
                   r = norm(r1, r2, 0)
                   if r < minRKern * rKernel:
                       # impose a minimum distance between particles
@@ -1248,7 +1279,7 @@ def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid, double[:
                   if r < rKernel:
                       hr = rKernel - r
                       dwdr = dfacKernel * hr * hr
-                      mdwdrr = mass[l] * (1 - h[j]/h[l]) * dwdr / r
+                      mdwdrr = mass[l] * (1 - hArray[k]/hArray[l]) * dwdr / r
                       G1 = mdwdrr * K1*r1
                       G2 = mdwdrr * K2*r2
 
@@ -1262,7 +1293,7 @@ def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid, double[:
                   r1 = scalProd(dx, dy, dz, ux, uy, uz)
                   r2 = scalProd(dx, dy, dz, uxOrtho, uyOrtho, uzOrtho)
                   # impse r3=0 even if the particle is not exactly on the tengent plane
-                  # get norm of r = xj - xl
+                  # get norm of r = xk - xl
                   r = norm(r1, r2, 0)
                   if r < minRKern * rKernel:
                       # impose a minimum distance between particles
@@ -1272,10 +1303,10 @@ def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid, double[:
                   if r < rKernel:
                       hr = rKernel - r
                       dwdr = dfacKernel * hr * hr
-                      mdwdrr = mass[l] * (1 - h[j]/h[l]) * dwdr / r
-                      m11 = m11 + mass[l] / h[l] * dwdr / r * r1 * r1 / rho
-                      m12 = m12 + mass[l] / h[l] * dwdr / r * r1 * r2 / rho
-                      m22 = m22 + mass[l] / h[l] * dwdr / r * r2 * r2 / rho
+                      mdwdrr = mass[l] * (1 - hArray[k]/hArray[l]) * dwdr / r
+                      m11 = m11 + mass[l] / hArray[l] * dwdr / r * r1 * r1 / rho
+                      m12 = m12 + mass[l] / hArray[l] * dwdr / r * r1 * r2 / rho
+                      m22 = m22 + mass[l] / hArray[l] * dwdr / r * r2 * r2 / rho
                       G1 = G1 + mdwdrr * K1*r1
                       G2 = G2 + mdwdrr * K2*r2
 
@@ -1285,7 +1316,7 @@ def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid, double[:
                   r1 = scalProd(dx, dy, dz, ux, uy, uz)
                   r2 = scalProd(dx, dy, dz, uxOrtho, uyOrtho, uzOrtho)
                   # impse r3=0 even if the particle is not exactly on the tengent plane
-                  # get norm of r = xj - xl
+                  # get norm of r = xk - xl
                   r = norm(r1, r2, 0)
                   if r < minRKern * rKernel:
                       # impose a minimum distance between particles
@@ -1295,11 +1326,11 @@ def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid, double[:
                   if r < rKernel:
                       hr = rKernel - r
                       wKernel = facKernel * hr * hr * hr
-                      m11 = m11 + mass[l] / h[l] * wKernel * r1 * r1 / rho
-                      m12 = m12 + mass[l] / h[l] * wKernel * r1 * r2 / rho
-                      m22 = m22 + mass[l] / h[l] * wKernel * r2 * r2 / rho
-                      G1 = G1 + mass[l] * (1 - h[j]/h[l]) * wKernel * K1*r1
-                      G2 = G2 + mass[l] * (1 - h[j]/h[l]) * wKernel * K2*r2
+                      m11 = m11 + mass[l] / hArray[l] * wKernel * r1 * r1 / rho
+                      m12 = m12 + mass[l] / hArray[l] * wKernel * r1 * r2 / rho
+                      m22 = m22 + mass[l] / hArray[l] * wKernel * r2 * r2 / rho
+                      G1 = G1 + mass[l] * (1 - hArray[k]/hArray[l]) * wKernel * K1*r1
+                      G2 = G2 + mass[l] * (1 - hArray[k]/hArray[l]) * wKernel * K2*r2
 
     if grad == 1:
       if SPHoption >= 4:
@@ -1313,13 +1344,13 @@ def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid, double[:
         gradhX = ux*GG1 + uxOrtho*GG2
         gradhY = uy*GG1 + uyOrtho*GG2
         gradhZ = (- g1*(ux*GG1 + uxOrtho*GG2) - g2*(uy*GG1 + uyOrtho*GG2))
-        GHX[j] = GHX[j] + gradhX / rho
-        GHY[j] = GHY[j] + gradhY / rho
-        GHZ[j] = GHZ[j] + gradhZ / rho
+        GHX[k] = GHX[k] + gradhX / rho
+        GHY[k] = GHY[k] + gradhY / rho
+        GHZ[k] = GHZ[k] + gradhZ / rho
       else:
-        GHX[j] = GHX[j] - gradhX / rho
-        GHY[j] = GHY[j] - gradhY / rho
-        GHZ[j] = GHZ[j] - gradhZ / rho
+        GHX[k] = GHX[k] - gradhX / rho
+        GHY[k] = GHY[k] - gradhY / rho
+        GHZ[k] = GHZ[k] - gradhZ / rho
     else:
       if SPHoption >= 4:
           # check that M is invertible
@@ -1332,22 +1363,157 @@ def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid, double[:
         gradhX = ux*GG1 + uxOrtho*GG2
         gradhY = uy*GG1 + uyOrtho*GG2
         gradhZ = (- g1*(ux*GG1 + uxOrtho*GG2) - g2*(uy*GG1 + uyOrtho*GG2))
-        GHX[j] = GHX[j] - gradhX / rho * mass[j] * gravAcc3
-        GHY[j] = GHY[j] - gradhY / rho * mass[j] * gravAcc3
-        GHZ[j] = GHZ[j] - gradhZ / rho * mass[j] * gravAcc3
+        GHX[k] = GHX[k] - gradhX / rho * mass[k] * gravAcc3
+        GHY[k] = GHY[k] - gradhY / rho * mass[k] * gravAcc3
+        GHZ[k] = GHZ[k] - gradhZ / rho * mass[k] * gravAcc3
       else:
-        GHX[j] = GHX[j] + gradhX / rho* mass[j] * gravAcc3
-        GHY[j] = GHY[j] + gradhY / rho* mass[j] * gravAcc3
-        GHZ[j] = GHZ[j] + gradhZ / rho* mass[j] * gravAcc3
+
+        mk = mass[k]
+
+        if viscOption==0 or viscOption==1:
+          # without artificial viscosity or with SAMOS artificial viscosity
+          GHX[k] = GHX[k] + gradhX*gravAcc3 / rho* mk
+          GHY[k] = GHY[k] + gradhY*gravAcc3 / rho* mk
+          GHZ[k] = GHZ[k] + gradhZ*gravAcc3 / rho* mk
+
+        elif viscOption==2:
+          # with Ata artificial viscosity
+          GHX[k] = GHX[k] + (gradhX*gravAcc3  + viscX) / rho * mk
+          GHY[k] = GHY[k] + (gradhY*gravAcc3  + viscY) / rho * mk
+          GHZ[k] = GHZ[k] + (gradhZ*gravAcc3  + viscZ) / rho * mk
 
   return GHX, GHY, GHZ
 
 
+@cython.boundscheck(False)  # Deactivate bounds checking
+@cython.wraparound(False)   # Deactivate negative indexing.
+@cython.cdivision(True)
+def computeFlowDepthSPH(cfg, particles, headerNeighbourGrid, headerNormalGrid):
+  """ compute lateral forces acting on the particles (SPH component)
+  Cython implementation
+  Parameters
+  ----------
+  cfg: configparser
+      configuration for DFA simulation
+  particles : dict
+      particles dictionary at t
+  headerNeighbourGrid : dict
+      neighbour search header dictionary (information about SPH grid)
+  headerNormalGrid : double
+      normal grid header dictionary (information about the DEM grid)
+  Returns
+  -------
+  hArray : 1D numpy array
+      SPH computed flow depth
+  """
+  # get all inputs
+  cdef double rho = cfg.getfloat('rho')
+  # configuration parameters
+  cdef double minRKern = cfg.getfloat('minRKern')
+  cdef int interpOption = cfg.getint('interpOption')
+  cdef int SPHoption = cfg.getint('sphOption')
+  cdef int symetryOption = cfg.getint('symetryOption')
+  cdef double hmin = cfg.getfloat('hmin')
+
+  # grid normal raster information
+  cdef double cszNormal = headerNormalGrid['cellsize']
+  cdef int nRowsNormal = headerNormalGrid['nrows']
+  cdef int nColsNormal = headerNormalGrid['ncols']
+  # neighbour search grid information and neighbour information
+  cdef double cszNeighbourGrid = headerNeighbourGrid['cellsize']
+  cdef int nRowsNeighbourGrid = headerNeighbourGrid['nrows']
+  cdef int nColsNeighbourGrid = headerNeighbourGrid['ncols']
+  cdef int[:] indPartInCell = particles['indPartInCell']
+  cdef int[:] partInCell = particles['partInCell']
+  # SPH kernel
+  # use "spiky" kernel: w = (rKernel - r)**3 * 10/(pi*rKernel**5)
+  cdef double rKernel = cszNeighbourGrid
+  cdef double facKernel = 10.0 / (math.pi * rKernel * rKernel * rKernel * rKernel * rKernel)
+  cdef double dfacKernel = - 3.0 * facKernel
+  # particle information
+  cdef double[:] mass = particles['m']
+  #cdef double[:] hSPHArrayOld = particles['hSPH']
+  cdef double[:] xArray = particles['x']
+  cdef double[:] yArray = particles['y']
+  cdef double[:] zArray = particles['z']
+  cdef int N = xArray.shape[0]
+
+  # initialize variables and outputs
+  cdef double[:] hSPHArray = np.zeros(N, dtype=np.float64)
+
+  cdef double mrhowkl, ml, al
+  cdef double x, y, z
+  cdef double dx, dy, dz, r, hr, wkl
+  cdef int lInd, rInd
+  cdef int indx, indy
+  cdef int k, ic, n, p, l, imax, imin, iPstart, iPend
+  cdef double hSPHk
+
+  # loop on particles
+  for k in range(N):
+    # hSPHk: SPH computed flow depth
+    hSPHk = 0
+    x = xArray[k]
+    y = yArray[k]
+    z = zArray[k]
+    # locate particle in SPH grid
+    indx = <int>math.round(x / cszNeighbourGrid)
+    indy = <int>math.round(y / cszNeighbourGrid)
+
+    # check if we are on the bottom ot top row!!!
+    lInd = -1
+    rInd = 2
+    if indy == 0:
+        lInd = 0
+    if indy == nRowsNeighbourGrid - 1:
+        rInd = 1
+    for n in range(lInd, rInd):
+        ic = (indx - 1) + nColsNeighbourGrid * (indy + n)
+        # make sure not to take particles from the other edge
+        imax = max(ic, nColsNeighbourGrid * (indy + n))
+        imin = min(ic+3, nColsNeighbourGrid * (indy + n + 1))
+        iPstart = indPartInCell[imax]
+        iPend = indPartInCell[imin]
+        # loop on all particles in neighbour boxes
+        for p in range(iPstart, iPend):
+            # index of particle in neighbour box
+            l = partInCell[p]
+            if k != l:
+                dx = xArray[l] - x
+                dy = yArray[l] - y
+                dz = zArray[l] - z
+                if SPHoption == 1:
+                  # like option 2 with dz!=0
+                  #dz = 0
+                  # get norm of r = xk - xl
+                  r = norm(dx, dy, dz)
+                  if r < minRKern * rKernel:
+                      # impose a minimum distance between particles
+                      dx = minRKern * rKernel * dx
+                      dy = minRKern * rKernel * dy
+                      dz = minRKern * rKernel * dz
+                      r = minRKern * rKernel
+                  if r < rKernel:
+                      hr = rKernel - r
+                      wkl = facKernel * hr * hr * hr
+                      ml = mass[l]
+                      mrhowkl = ml/rho * wkl
+                      # standard SPH formulation
+                      hSPHk = hSPHk + mrhowkl
+
+    if hSPHk>hmin:
+      hSPHArray[k] = hSPHk
+    else:
+      hSPHArray[k] = hmin
+
+  particles['hSPH']=np.asarray(hSPHArray)
+
+  return particles
+
+
 cpdef double norm(double x, double y, double z):
   """ Compute the Euclidean norm of the vector (x, y, z).
-
   (x, y, z) can be numpy arrays.
-
   Parameters
   ----------
       x: numpy array
@@ -1356,7 +1522,6 @@ cpdef double norm(double x, double y, double z):
           y component of the vector
       z: numpy array
           z component of the vector
-
   Returns
   -------
       norme: numpy array
@@ -1366,9 +1531,7 @@ cpdef double norm(double x, double y, double z):
 
 cpdef double norm2(double x, double y, double z):
   """ Compute the Euclidean norm of the vector (x, y, z).
-
   (x, y, z) can be numpy arrays.
-
   Parameters
   ----------
       x: numpy array
@@ -1377,7 +1540,6 @@ cpdef double norm2(double x, double y, double z):
           y component of the vector
       z: numpy array
           z component of the vector
-
   Returns
   -------
       norme: numpy array
@@ -1389,9 +1551,7 @@ cpdef double norm2(double x, double y, double z):
 @cython.cdivision(True)
 cpdef (double, double, double) normalize(double x, double y, double z):
   """ Normalize vector (x, y, z) for the Euclidean norm.
-
   (x, y, z) can be np arrays.
-
   Parameters
   ----------
       x: numpy array
@@ -1400,7 +1560,6 @@ cpdef (double, double, double) normalize(double x, double y, double z):
           y component of the vector
       z: numpy array
           z component of the vector
-
   Returns
   -------
       xn: numpy array
@@ -1442,7 +1601,6 @@ cpdef double scalProd(double ux, double uy, double uz, double vx, double vy, dou
 @cython.cdivision(True)
 cpdef (int) getCells(double x, double y, int ncols, int nrows, double csz):
   """ Locate point on grid.
-
   Parameters
   ----------
       x: float
@@ -1455,7 +1613,6 @@ cpdef (int) getCells(double x, double y, int ncols, int nrows, double csz):
           number of rows
       csz: float
           cellsize of the grid
-
   Returns
   -------
       iCell: int
@@ -1484,11 +1641,9 @@ cpdef (int) getCells(double x, double y, int ncols, int nrows, double csz):
 @cython.cdivision(True)
 cpdef (double, double, double, double) getWeights(double x, double y, int iCell, double csz, int ncols, int interpOption):
   """ Get weight for interpolation from grid to single point location
-
   3 Options available : -0: nearest neighbour interpolation
                         -1: equal weights interpolation
                         -2: bilinear interpolation
-
   Parameters
   ----------
     x: float
@@ -1505,7 +1660,6 @@ cpdef (double, double, double, double) getWeights(double x, double y, int iCell,
         -0: nearest neighbour interpolation
         -1: equal weights interpolation
         -2: bilinear interpolation
-
   Returns
   -------
       w00, w10, w01, w11: floats
@@ -1564,7 +1718,6 @@ cpdef (double, double, int, int, int, double, double, double, double) normalProj
   double[:,:] nzArray, double csz, int ncols, int nrows, int interpOption,
   int reprojectionIterations, double threshold):
   """ Find the orthogonal projection of a point on a mesh
-
   Iterative method to find the projection of a point on a surface defined by its mesh
   Parameters
   ----------
@@ -1663,7 +1816,6 @@ cpdef (double, double, int, int, int, double, double, double, double) samosProje
   double xOld, double yOld, double zOld, double[:,:] ZDEM, double[:,:] nxArray, double[:,:] nyArray,
   double[:,:] nzArray, double csz, int ncols, int nrows, int interpOption, int reprojectionIterations):
   """ Find the projection of a point on a mesh (comes from samos)
-
   Iterative method to find the projection of a point on a surface defined by its mesh
   Parameters
   ----------
@@ -1765,7 +1917,6 @@ cpdef (double, double, double, int, int, int, double, double, double, double) di
   int reprojectionIterations, double threshold):
   """ Find the projection of a point on a mesh conserving the distance
   with the previous time step position
-
   Iterative method to find the projection of a point on a surface defined by its mesh
   Parameters
   ----------
@@ -1902,12 +2053,10 @@ cpdef double[:] projOnRaster(double[:] xArray, double[:] yArray, double[:, :] vA
 @cython.boundscheck(False)
 cpdef double getScalar(int Lx0, int Ly0, double w0, double w1, double w2, double w3, double[:, :] V):
   """ Interpolate vector field from grid to single point location
-
   Originaly created to get the normal vector at location (x,y) given the
   normal vector field on the grid. Grid has its origin in (0,0).
   Can be used to interpolate any vector field.
   Interpolation using a bilinear interpolation
-
   Parameters
   ----------
     Lx0: int
@@ -1918,7 +2067,6 @@ cpdef double getScalar(int Lx0, int Ly0, double w0, double w1, double w2, double
         corresponding weights
     V: 2D numpy array
         scalar field at the grid nodes
-
   Returns
   -------
       v: float
@@ -1938,11 +2086,9 @@ cpdef (double, double, double) getVector(
   int Lx0, int Ly0, double w0, double w1, double w2, double w3,
   double[:, :] Nx, double[:, :] Ny, double[:, :] Nz):
   """ Interpolate vector field from grid to single point location
-
   Originaly created to get the normal vector at location (x,y) given the
   normal vector field on the grid. Grid has its origin in (0,0).
   Can be used to interpolate any vector field.
-
   Parameters
   ----------
       Lx0: int
@@ -1958,7 +2104,6 @@ cpdef (double, double, double) getVector(
           y component of the vector field at the grid nodes
       Nz: 2D numpy array
           z component of the vector field at the grid nodes
-
   Returns
   -------
       nx: float

--- a/avaframe/com1DFA/DFAfunctionsCython.pyx
+++ b/avaframe/com1DFA/DFAfunctionsCython.pyx
@@ -31,7 +31,7 @@ def pointsToRasterC(double[:] xArray, double[:] yArray, double[:] zArray, Z0, do
 
     Interpolate unstructured points on a structured grid using bilinear interpolation
     The (x, y) points have to be on the extend of the DEM!!
-    
+
     Parameters
       ----------
       x: 1D numpy array
@@ -1142,7 +1142,6 @@ def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid,
   cdef int interpOption = cfg.getint('interpOption')
   cdef int SPHoption = cfg.getint('sphOption')
   cdef int viscOption = cfg.getint('viscOption')
-  cdef int symmetryOption = cfg.getint('symmetryOption')
 
   # grid normal raster information
   cdef double cszNormal = headerNormalGrid['cellsize']
@@ -1198,7 +1197,7 @@ def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid,
     gradhX = 0
     gradhY = 0
     gradhZ = 0
-    pikl
+    pikl = 0
     G1 = 0
     G2 = 0
     m11 = 0

--- a/avaframe/com1DFA/DFAfunctionsCython.pyx
+++ b/avaframe/com1DFA/DFAfunctionsCython.pyx
@@ -1148,12 +1148,6 @@ def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid,
   cdef double[:] uzArray = particles['uz']
   cdef int N = xArray.shape[0]
 
-  cdef double[:] hArray = np.zeros(N, dtype=np.float64)
-  if flowDepthOption==0:
-    hArray = particles['h']
-  elif flowDepthOption==1:
-    hArray = particles['hSPH']
-
   # initialize variables and outputs
   cdef double[:] GHX = np.zeros(N, dtype=np.float64)
   cdef double[:] GHY = np.zeros(N, dtype=np.float64)
@@ -1245,8 +1239,6 @@ def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid,
             # index of particle in neighbour box
             l = partInCell[p]
             if k != l:
-                hl = hArray[l]
-                ml = mass[l]
                 dx = xArray[l] - x
                 dy = yArray[l] - y
                 dz = zArray[l] - z
@@ -1409,7 +1401,7 @@ def computeFlowDepthSPH(cfg, particles, headerNeighbourGrid, headerNormalGrid):
   # initialize variables and outputs
   cdef double[:] hSPHArray = np.zeros(N, dtype=np.float64)
 
-  cdef double mrhowkl, ml, al
+  cdef double mrhowkl
   cdef double x, y, z
   cdef double dx, dy, dz, r, hr, wkl
   cdef int lInd, rInd
@@ -1463,8 +1455,7 @@ def computeFlowDepthSPH(cfg, particles, headerNeighbourGrid, headerNormalGrid):
                   if r < rKernel:
                       hr = rKernel - r
                       wkl = facKernel * hr * hr * hr
-                      ml = mass[l]
-                      mrhowkl = ml/rho * wkl
+                      mrhowkl = mass[l]/rho * wkl
                       # standard SPH formulation
                       hSPHk = hSPHk + mrhowkl
 
@@ -1480,8 +1471,7 @@ def computeFlowDepthSPH(cfg, particles, headerNeighbourGrid, headerNormalGrid):
                   if r < rKernel:
                       hr = rKernel - r
                       wkl = facKernel * hr * hr * hr
-                      ml = mass[l]
-                      mrhowkl = ml/rho * wkl
+                      mrhowkl = mass[l]/rho * wkl
                       # standard SPH formulation
                       hSPHk = hSPHk + mrhowkl
 

--- a/avaframe/com1DFA/DFAfunctionsCython.pyx
+++ b/avaframe/com1DFA/DFAfunctionsCython.pyx
@@ -463,6 +463,8 @@ cdef (double, double, double) addArtificialViscosity(double m, double h, double 
                                                      double nx, double ny, double nz):
   """ add artificial viscosity
 
+  Add the artificial viscosity in an implicit way and this before adding the other forces.
+
   Parameters
   ----------
   m : float
@@ -1189,7 +1191,6 @@ def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid,
   # artificial viscosity parameters
   cdef double dwdrr, area
   cdef double pikl, flux
-  cdef double epsilon = 100
   cdef double hk, hl, ck, cl, lambdakl
 
   # loop on particles
@@ -1265,7 +1266,7 @@ def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid,
                 dz = zArray[l] - z
 
 #----------------------------SPHOPTION = 1--------------------------------------
-
+                # SamosAT style (no reprojecion on the surface, dz = 0 and gz is used)
                 if SPHoption == 1:
                     dz = 0
                     # get norm of r = xj - xl
@@ -1283,7 +1284,9 @@ def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid,
                         gravAcc3 = gravAcc
 
 #----------------------------SPHOPTION = 2--------------------------------------
-
+                # Compute the gradient in the cartesian coord system with reprojecion on the surface
+                # and dz != 0 and g3 are used
+                # It is here also possible to add the artificial viscosity comming from the Ata theory
                 elif SPHoption == 2:
                     # like option 1 but with dz!=0
                     # get norm of r = xk - xl
@@ -1317,7 +1320,8 @@ def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid,
 
 
 #----------------------------SPHOPTION = 3--------------------------------------
-
+                # Compute the gradient in the local coord system (will allow us to add the earth pressure coef)
+                # and this time reprojecion on the surface, dz != 0 and g3 are used
                 if SPHoption == 3:
                   # get coordinates in local coord system
                   r1 = scalProd(dx, dy, dz, ux, uy, uz)

--- a/avaframe/com1DFA/DFAfunctionsCython.pyx
+++ b/avaframe/com1DFA/DFAfunctionsCython.pyx
@@ -1344,25 +1344,17 @@ def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid,
 
 
     if grad == 1:
-      GHX[k] = GHX[k] - gradhX / rho
-      GHY[k] = GHY[k] - gradhY / rho
-      GHZ[k] = GHZ[k] - gradhZ / rho
-    else:
-      if SPHoption >= 4:
-          # check that M is invertible
-        if (m11*m22-m12*m12)>0:
-          GG1 = 1/(m11*m22-m12*m12)*(m22*G1-m12*G2)
-          GG2 = 1/(m11*m22-m12*m12)*(m11*G2-m12*G1)
-        else:
-          GG1 = G1
-          GG2 = G2
-        gradhX = ux*GG1 + uxOrtho*GG2
-        gradhY = uy*GG1 + uyOrtho*GG2
-        gradhZ = (- g1*(ux*GG1 + uxOrtho*GG2) - g2*(uy*GG1 + uyOrtho*GG2))
-        GHX[k] = GHX[k] - gradhX / rho * mk * gravAcc3
-        GHY[k] = GHY[k] - gradhY / rho * mk * gravAcc3
-        GHZ[k] = GHZ[k] - gradhZ / rho * mk * gravAcc3
-      elif SPHoption == 2:
+      if SPHoption == 2:
+        GHX[k] = GHX[k] + gradhX / gravAcc3
+        GHY[k] = GHY[k] + gradhY / gravAcc3
+        GHZ[k] = GHZ[k] + gradhZ / gravAcc3
+      else:
+        GHX[k] = GHX[k] - gradhX / rho
+        GHY[k] = GHY[k] - gradhY / rho
+        GHZ[k] = GHZ[k] - gradhZ / rho
+    elif grad == 0:
+      if SPHoption == 2:
+        # grad here is g*grad(h)
         GHX[k] = GHX[k] + gradhX * mk
         GHY[k] = GHY[k] + gradhY * mk
         GHZ[k] = GHZ[k] + gradhZ * mk

--- a/avaframe/com1DFA/DFAfunctionsCython.pyx
+++ b/avaframe/com1DFA/DFAfunctionsCython.pyx
@@ -28,8 +28,10 @@ log = logging.getLogger(__name__)
 @cython.cdivision(True)
 def pointsToRasterC(double[:] xArray, double[:] yArray, double[:] zArray, Z0, double csz=1, double xllc=0, double yllc=0):
     """ Interpolate from unstructured points to grid
+
     Interpolate unstructured points on a structured grid using bilinear interpolation
     The (x, y) points have to be on the extend of the DEM!!
+    
     Parameters
       ----------
       x: 1D numpy array
@@ -46,6 +48,7 @@ def pointsToRasterC(double[:] xArray, double[:] yArray, double[:] zArray, Z0, do
           x coord of the lower left center
       yllc : float
           y coord of the lower left center
+
       Returns
       -------
       Z1: 2D numpy array
@@ -104,7 +107,9 @@ def pointsToRasterC(double[:] xArray, double[:] yArray, double[:] zArray, Z0, do
 @cython.cdivision(True)
 def computeForceC(cfg, particles, fields, dem, dT, int frictType):
   """ compute forces acting on the particles (without the SPH component)
+
   Cython implementation implementation
+
   Parameters
   ----------
   cfg: configparser
@@ -115,6 +120,7 @@ def computeForceC(cfg, particles, fields, dem, dT, int frictType):
       dictionary with dem information
   dT : float
       time step
+
   Returns
   -------
   force : dict
@@ -364,6 +370,7 @@ cpdef (double, double) computeEntMassAndForce(double dt, double entrMassCell,
                                               double tau, double entEroEnergy,
                                               double rhoEnt):
   """ compute force component due to entrained mass
+
   Parameters
   ----------
   entrMassCell : float
@@ -374,6 +381,7 @@ cpdef (double, double) computeEntMassAndForce(double dt, double entrMassCell,
       particle speed (velocity magnitude)
   tau : float
       bottom shear stress
+
   Returns
   -------
   dm : float
@@ -410,6 +418,7 @@ cpdef (double, double) computeEntMassAndForce(double dt, double entrMassCell,
 cpdef double computeResForce(double hRes, double h, double areaPart, double rho,
                              double cResCell, double uMag, int explicitFriction):
   """ compute force component due to resistance
+
   Parameters
   ----------
   hRes: float
@@ -426,6 +435,7 @@ cpdef double computeResForce(double hRes, double h, double areaPart, double rho,
       particle speed (velocity magnitude)
   explicitFriction: int
     if 1 add resistance with an explicit method. Implicit otherwise
+
   Returns
   -------
   cResPart : float
@@ -525,7 +535,9 @@ cdef (double, double, double) addArtificialViscosity(double m, double h, double 
 @cython.cdivision(True)
 def updatePositionC(cfg, particles, dem, force, DT):
   """ update particle position using euler forward scheme
+
   Cython implementation
+
   Parameters
   ----------
   cfg: configparser
@@ -765,6 +777,7 @@ cpdef (double, double, double, double) account4FrictionForce(double ux, double u
                                                             double dt, double forceFrict,
                                                             double uMag, int explicitFriction):
   """ update velocity with friction force
+
   Parameters
   ----------
   ux: float
@@ -783,6 +796,7 @@ cpdef (double, double, double, double) account4FrictionForce(double ux, double u
       particle speed (velocity magnitude)
   explicitFriction: int
     if 1 add resistance with an explicit method. Implicit otherwise
+
   Returns
   -------
   uxNew: float
@@ -832,7 +846,9 @@ cpdef (double, double, double, double) account4FrictionForce(double ux, double u
 @cython.cdivision(True)
 def updateFieldsC(cfg, particles, dem, fields):
   """ update fields and particles fow depth
+
   Cython implementation
+
  Parameters
  ----------
  cfg: configparser
@@ -960,15 +976,18 @@ def updateFieldsC(cfg, particles, dem, fields):
 @cython.cdivision(True)
 def getNeighborsC(particles, dem):
     """ Locate particles on DEM and neighbour search grid
+
     Ĺocate each particle in a grid cell (both DEM and neighbour search grid) and build the
     indPartInCell and partInCell arrays for SPH neighbourSearch and
     InCell, IndX and IndY arrays location on the DEM grid.
     See issue #200 and documentation for details
+
     Parameters
     ----------
     particles : dict
     dem : dict
       dem dict with neighbour search grid header (information about neighbour search grid)
+
     Returns
     -------
     particles : dict
@@ -1037,6 +1056,7 @@ def computeForceSPHC(cfg, particles, force, dem, gradient=0):
   """ Prepare data for C computation of lateral forces (SPH component)
 
   acting on the particles (SPH component)
+
   Parameters
   ----------
   cfg: configparser
@@ -1081,7 +1101,9 @@ def computeForceSPHC(cfg, particles, force, dem, gradient=0):
 def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid,
                  double[:, :] nxArray, double[:, :] nyArray, double[:, :] nzArray, gradient):
   """ compute lateral forces acting on the particles (SPH component)
+
   Cython implementation
+
   Parameters
   ----------
   cfg: configparser
@@ -1345,149 +1367,11 @@ def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid,
   return GHX, GHY, GHZ
 
 
-@cython.boundscheck(False)  # Deactivate bounds checking
-@cython.wraparound(False)   # Deactivate negative indexing.
-@cython.cdivision(True)
-def computeFlowDepthSPH(cfg, particles, headerNeighbourGrid, headerNormalGrid):
-  """ compute SPH flow depth
-  Cython implementation
-  Parameters
-  ----------
-  cfg: configparser
-      configuration for DFA simulation
-  particles : dict
-      particles dictionary at t
-  headerNeighbourGrid : dict
-      neighbour search header dictionary (information about SPH grid)
-  headerNormalGrid : double
-      normal grid header dictionary (information about the DEM grid)
-  Returns
-  -------
-  hArray : 1D numpy array
-      SPH computed flow depth
-  """
-  # get all inputs
-  cdef double rho = cfg.getfloat('rho')
-  # configuration parameters
-  cdef double minRKern = cfg.getfloat('minRKern')
-  cdef int interpOption = cfg.getint('interpOption')
-  cdef int SPHoption = cfg.getint('sphOption')
-  cdef int symmetryOption = cfg.getint('symmetryOption')
-  cdef double hmin = cfg.getfloat('hmin')
-
-  # grid normal raster information
-  cdef double cszNormal = headerNormalGrid['cellsize']
-  cdef int nRowsNormal = headerNormalGrid['nrows']
-  cdef int nColsNormal = headerNormalGrid['ncols']
-  # neighbour search grid information and neighbour information
-  cdef double cszNeighbourGrid = headerNeighbourGrid['cellsize']
-  cdef int nRowsNeighbourGrid = headerNeighbourGrid['nrows']
-  cdef int nColsNeighbourGrid = headerNeighbourGrid['ncols']
-  cdef int[:] indPartInCell = particles['indPartInCell']
-  cdef int[:] partInCell = particles['partInCell']
-  # SPH kernel
-  # use "spiky" kernel: w = (rKernel - r)**3 * 10/(pi*rKernel**5)
-  cdef double rKernel = cszNeighbourGrid
-  cdef double facKernel = 10.0 / (math.pi * rKernel * rKernel * rKernel * rKernel * rKernel)
-  cdef double dfacKernel = - 3.0 * facKernel
-  # particle information
-  cdef double[:] mass = particles['m']
-  #cdef double[:] hSPHArrayOld = particles['hSPH']
-  cdef double[:] xArray = particles['x']
-  cdef double[:] yArray = particles['y']
-  cdef double[:] zArray = particles['z']
-  cdef int N = xArray.shape[0]
-
-  # initialize variables and outputs
-  cdef double[:] hSPHArray = np.zeros(N, dtype=np.float64)
-
-  cdef double mrhowkl
-  cdef double x, y, z
-  cdef double dx, dy, dz, r, hr, wkl
-  cdef int lInd, rInd
-  cdef int indx, indy
-  cdef int k, ic, n, p, l, imax, imin, iPstart, iPend
-  cdef double hSPHk
-
-  # loop on particles
-  for k in range(N):
-    # hSPHk: SPH computed flow depth
-    hSPHk = 0
-    x = xArray[k]
-    y = yArray[k]
-    z = zArray[k]
-    # locate particle in SPH grid
-    indx = <int>math.round(x / cszNeighbourGrid)
-    indy = <int>math.round(y / cszNeighbourGrid)
-
-    # check if we are on the bottom ot top row!!!
-    lInd = -1
-    rInd = 2
-    if indy == 0:
-        lInd = 0
-    if indy == nRowsNeighbourGrid - 1:
-        rInd = 1
-    for n in range(lInd, rInd):
-        ic = (indx - 1) + nColsNeighbourGrid * (indy + n)
-        # make sure not to take particles from the other edge
-        imax = max(ic, nColsNeighbourGrid * (indy + n))
-        imin = min(ic+3, nColsNeighbourGrid * (indy + n + 1))
-        iPstart = indPartInCell[imax]
-        iPend = indPartInCell[imin]
-        # loop on all particles in neighbour boxes
-        for p in range(iPstart, iPend):
-            # index of particle in neighbour box
-            l = partInCell[p]
-            if k != l:
-                dx = xArray[l] - x
-                dy = yArray[l] - y
-                dz = zArray[l] - z
-
-                if SPHoption == 1:
-                  dz = 0
-                  # get norm of r = xj - xl
-                  if r < minRKern * rKernel:
-                      # impose a minimum distance between particles
-                      dx = minRKern * rKernel * dx
-                      dy = minRKern * rKernel * dy
-                      dz = minRKern * rKernel * dz
-                      r = minRKern * rKernel
-                  if r < rKernel:
-                      hr = rKernel - r
-                      wkl = facKernel * hr * hr * hr
-                      mrhowkl = mass[l]/rho * wkl
-                      # standard SPH formulation
-                      hSPHk = hSPHk + mrhowkl
-
-                if SPHoption == 2:
-                  # get norm of r = xj - xl
-                  r = norm(dx, dy, dz)
-                  if r < minRKern * rKernel:
-                      # impose a minimum distance between particles
-                      dx = minRKern * rKernel * dx
-                      dy = minRKern * rKernel * dy
-                      dz = minRKern * rKernel * dz
-                      r = minRKern * rKernel
-                  if r < rKernel:
-                      hr = rKernel - r
-                      wkl = facKernel * hr * hr * hr
-                      mrhowkl = mass[l]/rho * wkl
-                      # standard SPH formulation
-                      hSPHk = hSPHk + mrhowkl
-
-    if hSPHk>hmin:
-      hSPHArray[k] = hSPHk
-    else:
-      hSPHArray[k] = hmin
-
-  particles['hSPH']=np.asarray(hSPHArray)
-
-  return particles
-
-
 cpdef double norm(double x, double y, double z):
   """ Compute the Euclidean norm of the vector (x, y, z).
+
   (x, y, z) can be numpy arrays.
+
   Parameters
   ----------
       x: numpy array
@@ -1496,6 +1380,7 @@ cpdef double norm(double x, double y, double z):
           y component of the vector
       z: numpy array
           z component of the vector
+
   Returns
   -------
       norme: numpy array
@@ -1505,7 +1390,9 @@ cpdef double norm(double x, double y, double z):
 
 cpdef double norm2(double x, double y, double z):
   """ Compute the Euclidean norm of the vector (x, y, z).
+
   (x, y, z) can be numpy arrays.
+
   Parameters
   ----------
       x: numpy array
@@ -1514,6 +1401,7 @@ cpdef double norm2(double x, double y, double z):
           y component of the vector
       z: numpy array
           z component of the vector
+
   Returns
   -------
       norme: numpy array
@@ -1525,7 +1413,9 @@ cpdef double norm2(double x, double y, double z):
 @cython.cdivision(True)
 cpdef (double, double, double) normalize(double x, double y, double z):
   """ Normalize vector (x, y, z) for the Euclidean norm.
+
   (x, y, z) can be np arrays.
+
   Parameters
   ----------
       x: numpy array
@@ -1534,6 +1424,7 @@ cpdef (double, double, double) normalize(double x, double y, double z):
           y component of the vector
       z: numpy array
           z component of the vector
+
   Returns
   -------
       xn: numpy array
@@ -1575,6 +1466,7 @@ cpdef double scalProd(double ux, double uy, double uz, double vx, double vy, dou
 @cython.cdivision(True)
 cpdef (int) getCells(double x, double y, int ncols, int nrows, double csz):
   """ Locate point on grid.
+
   Parameters
   ----------
       x: float
@@ -1587,6 +1479,7 @@ cpdef (int) getCells(double x, double y, int ncols, int nrows, double csz):
           number of rows
       csz: float
           cellsize of the grid
+
   Returns
   -------
       iCell: int
@@ -1615,9 +1508,11 @@ cpdef (int) getCells(double x, double y, int ncols, int nrows, double csz):
 @cython.cdivision(True)
 cpdef (double, double, double, double) getWeights(double x, double y, int iCell, double csz, int ncols, int interpOption):
   """ Get weight for interpolation from grid to single point location
+
   3 Options available : -0: nearest neighbour interpolation
                         -1: equal weights interpolation
                         -2: bilinear interpolation
+
   Parameters
   ----------
     x: float
@@ -1634,6 +1529,7 @@ cpdef (double, double, double, double) getWeights(double x, double y, int iCell,
         -0: nearest neighbour interpolation
         -1: equal weights interpolation
         -2: bilinear interpolation
+
   Returns
   -------
       w00, w10, w01, w11: floats
@@ -1692,6 +1588,7 @@ cpdef (double, double, int, int, int, double, double, double, double) normalProj
   double[:,:] nzArray, double csz, int ncols, int nrows, int interpOption,
   int reprojectionIterations, double threshold):
   """ Find the orthogonal projection of a point on a mesh
+
   Iterative method to find the projection of a point on a surface defined by its mesh
 
   Parameters
@@ -1792,6 +1689,7 @@ cpdef (double, double, int, int, int, double, double, double, double) samosProje
   double xOld, double yOld, double zOld, double[:,:] ZDEM, double[:,:] nxArray, double[:,:] nyArray,
   double[:,:] nzArray, double csz, int ncols, int nrows, int interpOption, int reprojectionIterations):
   """ Find the projection of a point on a mesh (comes from samos)
+
   Iterative method to find the projection of a point on a surface defined by its mesh
 
   Parameters
@@ -1895,6 +1793,7 @@ cpdef (double, double, double, int, int, int, double, double, double, double) di
   int reprojectionIterations, double threshold):
   """ Find the projection of a point on a mesh conserving the distance
   with the previous time step position
+
   Iterative method to find the projection of a point on a surface defined by its mesh
 
   Parameters
@@ -2033,10 +1932,12 @@ cpdef double[:] projOnRaster(double[:] xArray, double[:] yArray, double[:, :] vA
 @cython.boundscheck(False)
 cpdef double getScalar(int Lx0, int Ly0, double w0, double w1, double w2, double w3, double[:, :] V):
   """ Interpolate vector field from grid to single point location
+
   Originaly created to get the normal vector at location (x,y) given the
   normal vector field on the grid. Grid has its origin in (0,0).
   Can be used to interpolate any vector field.
   Interpolation using a bilinear interpolation
+
   Parameters
   ----------
     Lx0: int
@@ -2047,6 +1948,7 @@ cpdef double getScalar(int Lx0, int Ly0, double w0, double w1, double w2, double
         corresponding weights
     V: 2D numpy array
         scalar field at the grid nodes
+
   Returns
   -------
       v: float
@@ -2066,9 +1968,11 @@ cpdef (double, double, double) getVector(
   int Lx0, int Ly0, double w0, double w1, double w2, double w3,
   double[:, :] Nx, double[:, :] Ny, double[:, :] Nz):
   """ Interpolate vector field from grid to single point location
+
   Originaly created to get the normal vector at location (x,y) given the
   normal vector field on the grid. Grid has its origin in (0,0).
   Can be used to interpolate any vector field.
+
   Parameters
   ----------
       Lx0: int
@@ -2084,6 +1988,7 @@ cpdef (double, double, double) getVector(
           y component of the vector field at the grid nodes
       Nz: 2D numpy array
           z component of the vector field at the grid nodes
+
   Returns
   -------
       nx: float

--- a/avaframe/com1DFA/DFAfunctionsCython.pyx
+++ b/avaframe/com1DFA/DFAfunctionsCython.pyx
@@ -28,8 +28,10 @@ log = logging.getLogger(__name__)
 @cython.cdivision(True)
 def pointsToRasterC(double[:] xArray, double[:] yArray, double[:] zArray, Z0, double csz=1, double xllc=0, double yllc=0):
     """ Interpolate from unstructured points to grid
+
     Interpolate unstructured points on a structured grid using bilinear interpolation
     The (x, y) points have to be on the extend of the DEM!!
+    
     Parameters
       ----------
       x: 1D numpy array
@@ -46,6 +48,7 @@ def pointsToRasterC(double[:] xArray, double[:] yArray, double[:] zArray, Z0, do
           x coord of the lower left center
       yllc : float
           y coord of the lower left center
+
       Returns
       -------
       Z1: 2D numpy array
@@ -104,7 +107,9 @@ def pointsToRasterC(double[:] xArray, double[:] yArray, double[:] zArray, Z0, do
 @cython.cdivision(True)
 def computeForceC(cfg, particles, fields, dem, dT, int frictType):
   """ compute forces acting on the particles (without the SPH component)
+
   Cython implementation implementation
+
   Parameters
   ----------
   cfg: configparser
@@ -115,6 +120,7 @@ def computeForceC(cfg, particles, fields, dem, dT, int frictType):
       dictionary with dem information
   dT : float
       time step
+
   Returns
   -------
   force : dict
@@ -364,6 +370,7 @@ cpdef (double, double) computeEntMassAndForce(double dt, double entrMassCell,
                                               double tau, double entEroEnergy,
                                               double rhoEnt):
   """ compute force component due to entrained mass
+
   Parameters
   ----------
   entrMassCell : float
@@ -374,6 +381,7 @@ cpdef (double, double) computeEntMassAndForce(double dt, double entrMassCell,
       particle speed (velocity magnitude)
   tau : float
       bottom shear stress
+
   Returns
   -------
   dm : float
@@ -410,6 +418,7 @@ cpdef (double, double) computeEntMassAndForce(double dt, double entrMassCell,
 cpdef double computeResForce(double hRes, double h, double areaPart, double rho,
                              double cResCell, double uMag, int explicitFriction):
   """ compute force component due to resistance
+
   Parameters
   ----------
   hRes: float
@@ -426,6 +435,7 @@ cpdef double computeResForce(double hRes, double h, double areaPart, double rho,
       particle speed (velocity magnitude)
   explicitFriction: int
     if 1 add resistance with an explicit method. Implicit otherwise
+
   Returns
   -------
   cResPart : float
@@ -452,6 +462,7 @@ cdef (double, double, double) addArtificialViscosity(double m, double h, double 
                                                      double[:, :] VX, double[:, :] VY, double[:, :] VZ,
                                                      double nx, double ny, double nz):
   """ add artificial viscosity
+
   Parameters
   ----------
   m : float
@@ -483,6 +494,7 @@ cdef (double, double, double) addArtificialViscosity(double m, double h, double 
       y component of the interpolated vector field at particle position
   nz: float
       z component of the interpolated vector field at particle position
+
   Returns
   -------
   ux: float
@@ -523,7 +535,9 @@ cdef (double, double, double) addArtificialViscosity(double m, double h, double 
 @cython.cdivision(True)
 def updatePositionC(cfg, particles, dem, force, DT):
   """ update particle position using euler forward scheme
+
   Cython implementation
+
   Parameters
   ----------
   cfg: configparser
@@ -534,6 +548,7 @@ def updatePositionC(cfg, particles, dem, force, DT):
       dictionary with dem information
   force : dict
       force dictionary
+
   Returns
   -------
   particles : dict
@@ -762,6 +777,7 @@ cpdef (double, double, double, double) account4FrictionForce(double ux, double u
                                                             double dt, double forceFrict,
                                                             double uMag, int explicitFriction):
   """ update velocity with friction force
+
   Parameters
   ----------
   ux: float
@@ -780,6 +796,7 @@ cpdef (double, double, double, double) account4FrictionForce(double ux, double u
       particle speed (velocity magnitude)
   explicitFriction: int
     if 1 add resistance with an explicit method. Implicit otherwise
+
   Returns
   -------
   uxNew: float
@@ -829,7 +846,9 @@ cpdef (double, double, double, double) account4FrictionForce(double ux, double u
 @cython.cdivision(True)
 def updateFieldsC(cfg, particles, dem, fields):
   """ update fields and particles fow depth
+
   Cython implementation
+
  Parameters
  ----------
  cfg: configparser
@@ -840,6 +859,7 @@ def updateFieldsC(cfg, particles, dem, fields):
      dictionary with dem information
  fields : dict
      fields dictionary
+
  Returns
  -------
  particles : dict
@@ -956,15 +976,18 @@ def updateFieldsC(cfg, particles, dem, fields):
 @cython.cdivision(True)
 def getNeighborsC(particles, dem):
     """ Locate particles on DEM and neighbour search grid
+
     Ĺocate each particle in a grid cell (both DEM and neighbour search grid) and build the
     indPartInCell and partInCell arrays for SPH neighbourSearch and
     InCell, IndX and IndY arrays location on the DEM grid.
     See issue #200 and documentation for details
+
     Parameters
     ----------
     particles : dict
     dem : dict
       dem dict with neighbour search grid header (information about neighbour search grid)
+
     Returns
     -------
     particles : dict
@@ -1031,7 +1054,9 @@ def getNeighborsC(particles, dem):
 
 def computeForceSPHC(cfg, particles, force, dem, gradient=0):
   """ Prepare data for C computation of lateral forces (SPH component)
+
   acting on the particles (SPH component)
+
   Parameters
   ----------
   cfg: configparser
@@ -1042,6 +1067,7 @@ def computeForceSPHC(cfg, particles, force, dem, gradient=0):
       force dictionary
   dem : dict
       dictionary with dem information
+
   Returns
   -------
   particles : dict
@@ -1075,7 +1101,9 @@ def computeForceSPHC(cfg, particles, force, dem, gradient=0):
 def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid,
                  double[:, :] nxArray, double[:, :] nyArray, double[:, :] nzArray, gradient):
   """ compute lateral forces acting on the particles (SPH component)
+
   Cython implementation
+
   Parameters
   ----------
   cfg: configparser
@@ -1095,6 +1123,7 @@ def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid,
       row index of the location of the particles
   gradient : int
     Return the gradient (if 1) or the force associated (if 0, default)
+
   Returns
   -------
   GHX : 1D numpy array
@@ -1344,149 +1373,11 @@ def computeGradC(cfg, particles, headerNeighbourGrid, headerNormalGrid,
   return GHX, GHY, GHZ
 
 
-@cython.boundscheck(False)  # Deactivate bounds checking
-@cython.wraparound(False)   # Deactivate negative indexing.
-@cython.cdivision(True)
-def computeFlowDepthSPH(cfg, particles, headerNeighbourGrid, headerNormalGrid):
-  """ compute SPH flow depth
-  Cython implementation
-  Parameters
-  ----------
-  cfg: configparser
-      configuration for DFA simulation
-  particles : dict
-      particles dictionary at t
-  headerNeighbourGrid : dict
-      neighbour search header dictionary (information about SPH grid)
-  headerNormalGrid : double
-      normal grid header dictionary (information about the DEM grid)
-  Returns
-  -------
-  hArray : 1D numpy array
-      SPH computed flow depth
-  """
-  # get all inputs
-  cdef double rho = cfg.getfloat('rho')
-  # configuration parameters
-  cdef double minRKern = cfg.getfloat('minRKern')
-  cdef int interpOption = cfg.getint('interpOption')
-  cdef int SPHoption = cfg.getint('sphOption')
-  cdef int symmetryOption = cfg.getint('symmetryOption')
-  cdef double hmin = cfg.getfloat('hmin')
-
-  # grid normal raster information
-  cdef double cszNormal = headerNormalGrid['cellsize']
-  cdef int nRowsNormal = headerNormalGrid['nrows']
-  cdef int nColsNormal = headerNormalGrid['ncols']
-  # neighbour search grid information and neighbour information
-  cdef double cszNeighbourGrid = headerNeighbourGrid['cellsize']
-  cdef int nRowsNeighbourGrid = headerNeighbourGrid['nrows']
-  cdef int nColsNeighbourGrid = headerNeighbourGrid['ncols']
-  cdef int[:] indPartInCell = particles['indPartInCell']
-  cdef int[:] partInCell = particles['partInCell']
-  # SPH kernel
-  # use "spiky" kernel: w = (rKernel - r)**3 * 10/(pi*rKernel**5)
-  cdef double rKernel = cszNeighbourGrid
-  cdef double facKernel = 10.0 / (math.pi * rKernel * rKernel * rKernel * rKernel * rKernel)
-  cdef double dfacKernel = - 3.0 * facKernel
-  # particle information
-  cdef double[:] mass = particles['m']
-  #cdef double[:] hSPHArrayOld = particles['hSPH']
-  cdef double[:] xArray = particles['x']
-  cdef double[:] yArray = particles['y']
-  cdef double[:] zArray = particles['z']
-  cdef int N = xArray.shape[0]
-
-  # initialize variables and outputs
-  cdef double[:] hSPHArray = np.zeros(N, dtype=np.float64)
-
-  cdef double mrhowkl
-  cdef double x, y, z
-  cdef double dx, dy, dz, r, hr, wkl
-  cdef int lInd, rInd
-  cdef int indx, indy
-  cdef int k, ic, n, p, l, imax, imin, iPstart, iPend
-  cdef double hSPHk
-
-  # loop on particles
-  for k in range(N):
-    # hSPHk: SPH computed flow depth
-    hSPHk = 0
-    x = xArray[k]
-    y = yArray[k]
-    z = zArray[k]
-    # locate particle in SPH grid
-    indx = <int>math.round(x / cszNeighbourGrid)
-    indy = <int>math.round(y / cszNeighbourGrid)
-
-    # check if we are on the bottom ot top row!!!
-    lInd = -1
-    rInd = 2
-    if indy == 0:
-        lInd = 0
-    if indy == nRowsNeighbourGrid - 1:
-        rInd = 1
-    for n in range(lInd, rInd):
-        ic = (indx - 1) + nColsNeighbourGrid * (indy + n)
-        # make sure not to take particles from the other edge
-        imax = max(ic, nColsNeighbourGrid * (indy + n))
-        imin = min(ic+3, nColsNeighbourGrid * (indy + n + 1))
-        iPstart = indPartInCell[imax]
-        iPend = indPartInCell[imin]
-        # loop on all particles in neighbour boxes
-        for p in range(iPstart, iPend):
-            # index of particle in neighbour box
-            l = partInCell[p]
-            if k != l:
-                dx = xArray[l] - x
-                dy = yArray[l] - y
-                dz = zArray[l] - z
-
-                if SPHoption == 1:
-                  dz = 0
-                  # get norm of r = xj - xl
-                  if r < minRKern * rKernel:
-                      # impose a minimum distance between particles
-                      dx = minRKern * rKernel * dx
-                      dy = minRKern * rKernel * dy
-                      dz = minRKern * rKernel * dz
-                      r = minRKern * rKernel
-                  if r < rKernel:
-                      hr = rKernel - r
-                      wkl = facKernel * hr * hr * hr
-                      mrhowkl = mass[l]/rho * wkl
-                      # standard SPH formulation
-                      hSPHk = hSPHk + mrhowkl
-
-                if SPHoption == 2:
-                  # get norm of r = xj - xl
-                  r = norm(dx, dy, dz)
-                  if r < minRKern * rKernel:
-                      # impose a minimum distance between particles
-                      dx = minRKern * rKernel * dx
-                      dy = minRKern * rKernel * dy
-                      dz = minRKern * rKernel * dz
-                      r = minRKern * rKernel
-                  if r < rKernel:
-                      hr = rKernel - r
-                      wkl = facKernel * hr * hr * hr
-                      mrhowkl = mass[l]/rho * wkl
-                      # standard SPH formulation
-                      hSPHk = hSPHk + mrhowkl
-
-    if hSPHk>hmin:
-      hSPHArray[k] = hSPHk
-    else:
-      hSPHArray[k] = hmin
-
-  particles['hSPH']=np.asarray(hSPHArray)
-
-  return particles
-
-
 cpdef double norm(double x, double y, double z):
   """ Compute the Euclidean norm of the vector (x, y, z).
+
   (x, y, z) can be numpy arrays.
+
   Parameters
   ----------
       x: numpy array
@@ -1495,6 +1386,7 @@ cpdef double norm(double x, double y, double z):
           y component of the vector
       z: numpy array
           z component of the vector
+
   Returns
   -------
       norme: numpy array
@@ -1504,7 +1396,9 @@ cpdef double norm(double x, double y, double z):
 
 cpdef double norm2(double x, double y, double z):
   """ Compute the Euclidean norm of the vector (x, y, z).
+
   (x, y, z) can be numpy arrays.
+
   Parameters
   ----------
       x: numpy array
@@ -1513,6 +1407,7 @@ cpdef double norm2(double x, double y, double z):
           y component of the vector
       z: numpy array
           z component of the vector
+
   Returns
   -------
       norme: numpy array
@@ -1524,7 +1419,9 @@ cpdef double norm2(double x, double y, double z):
 @cython.cdivision(True)
 cpdef (double, double, double) normalize(double x, double y, double z):
   """ Normalize vector (x, y, z) for the Euclidean norm.
+
   (x, y, z) can be np arrays.
+
   Parameters
   ----------
       x: numpy array
@@ -1533,6 +1430,7 @@ cpdef (double, double, double) normalize(double x, double y, double z):
           y component of the vector
       z: numpy array
           z component of the vector
+
   Returns
   -------
       xn: numpy array
@@ -1574,6 +1472,7 @@ cpdef double scalProd(double ux, double uy, double uz, double vx, double vy, dou
 @cython.cdivision(True)
 cpdef (int) getCells(double x, double y, int ncols, int nrows, double csz):
   """ Locate point on grid.
+
   Parameters
   ----------
       x: float
@@ -1586,6 +1485,7 @@ cpdef (int) getCells(double x, double y, int ncols, int nrows, double csz):
           number of rows
       csz: float
           cellsize of the grid
+
   Returns
   -------
       iCell: int
@@ -1614,9 +1514,11 @@ cpdef (int) getCells(double x, double y, int ncols, int nrows, double csz):
 @cython.cdivision(True)
 cpdef (double, double, double, double) getWeights(double x, double y, int iCell, double csz, int ncols, int interpOption):
   """ Get weight for interpolation from grid to single point location
+
   3 Options available : -0: nearest neighbour interpolation
                         -1: equal weights interpolation
                         -2: bilinear interpolation
+
   Parameters
   ----------
     x: float
@@ -1633,6 +1535,7 @@ cpdef (double, double, double, double) getWeights(double x, double y, int iCell,
         -0: nearest neighbour interpolation
         -1: equal weights interpolation
         -2: bilinear interpolation
+
   Returns
   -------
       w00, w10, w01, w11: floats
@@ -1691,7 +1594,9 @@ cpdef (double, double, int, int, int, double, double, double, double) normalProj
   double[:,:] nzArray, double csz, int ncols, int nrows, int interpOption,
   int reprojectionIterations, double threshold):
   """ Find the orthogonal projection of a point on a mesh
+
   Iterative method to find the projection of a point on a surface defined by its mesh
+
   Parameters
   ----------
       xOld: float
@@ -1719,6 +1624,7 @@ cpdef (double, double, int, int, int, double, double, double, double) normalProj
       threshold: double
           stop criterion for reprojection, stops when the distance between two iterations
           is smaller than threshold * csz
+
     Returns
     -------
     xNew: float
@@ -1789,7 +1695,9 @@ cpdef (double, double, int, int, int, double, double, double, double) samosProje
   double xOld, double yOld, double zOld, double[:,:] ZDEM, double[:,:] nxArray, double[:,:] nyArray,
   double[:,:] nzArray, double csz, int ncols, int nrows, int interpOption, int reprojectionIterations):
   """ Find the projection of a point on a mesh (comes from samos)
+
   Iterative method to find the projection of a point on a surface defined by its mesh
+
   Parameters
   ----------
       xOld: float
@@ -1814,6 +1722,7 @@ cpdef (double, double, int, int, int, double, double, double, double) samosProje
           -2: bilinear interpolation
       reprojectionIterations: int
           maximum number or iterations
+
     Returns
     -------
     xNew: float
@@ -1890,7 +1799,9 @@ cpdef (double, double, double, int, int, int, double, double, double, double) di
   int reprojectionIterations, double threshold):
   """ Find the projection of a point on a mesh conserving the distance
   with the previous time step position
+
   Iterative method to find the projection of a point on a surface defined by its mesh
+
   Parameters
   ----------
       xPrev: float
@@ -1924,6 +1835,7 @@ cpdef (double, double, double, int, int, int, double, double, double, double) di
       threshold: double
           stop criterion for reprojection, stops when the error on the distance after projection
           is smaller than threshold * (dist + csz)
+
     Returns
     -------
     xNew: float
@@ -2026,10 +1938,12 @@ cpdef double[:] projOnRaster(double[:] xArray, double[:] yArray, double[:, :] vA
 @cython.boundscheck(False)
 cpdef double getScalar(int Lx0, int Ly0, double w0, double w1, double w2, double w3, double[:, :] V):
   """ Interpolate vector field from grid to single point location
+
   Originaly created to get the normal vector at location (x,y) given the
   normal vector field on the grid. Grid has its origin in (0,0).
   Can be used to interpolate any vector field.
   Interpolation using a bilinear interpolation
+
   Parameters
   ----------
     Lx0: int
@@ -2040,6 +1954,7 @@ cpdef double getScalar(int Lx0, int Ly0, double w0, double w1, double w2, double
         corresponding weights
     V: 2D numpy array
         scalar field at the grid nodes
+
   Returns
   -------
       v: float
@@ -2059,9 +1974,11 @@ cpdef (double, double, double) getVector(
   int Lx0, int Ly0, double w0, double w1, double w2, double w3,
   double[:, :] Nx, double[:, :] Ny, double[:, :] Nz):
   """ Interpolate vector field from grid to single point location
+
   Originaly created to get the normal vector at location (x,y) given the
   normal vector field on the grid. Grid has its origin in (0,0).
   Can be used to interpolate any vector field.
+
   Parameters
   ----------
       Lx0: int
@@ -2077,6 +1994,7 @@ cpdef (double, double, double) getVector(
           y component of the vector field at the grid nodes
       Nz: 2D numpy array
           z component of the vector field at the grid nodes
+
   Returns
   -------
       nx: float

--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -1269,7 +1269,6 @@ def computeEulerTimeStep(cfg, particles, fields, dt, dem, Tcpu, frictType):
 
     # get forces
     startTime = time.time()
-
     # loop version of the compute force
     log.debug('Compute Force C')
     particles, force, fields = DFAfunC.computeForceC(cfg, particles, fields, dem, dt, frictType)
@@ -1329,6 +1328,8 @@ def computeEulerTimeStep(cfg, particles, fields, dt, dem, Tcpu, frictType):
     startTime = time.time()
     log.debug('update Fields C')
     # particles, fields = updateFields(cfg, particles, force, dem, fields)
+
+    #if flowDepthOption!=1 or viscOption !=2 :
     particles, fields = DFAfunC.updateFieldsC(cfg, particles, dem, fields)
     tcpuField = time.time() - startTime
     Tcpu['Field'] = Tcpu['Field'] + tcpuField

--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -48,6 +48,7 @@ featLF = False
 
 def com1DFAMain(avalancheDir, cfgMain, cfgFile='', relThField='', variationDict=''):
     """ preprocess information from ini and run all desired simulations, create outputs and reports
+
         Parameters
         ------------
         avalancheDir: str or pathlib Path
@@ -56,6 +57,7 @@ def com1DFAMain(avalancheDir, cfgMain, cfgFile='', relThField='', variationDict=
             path to configuration file if overwrite is desired
         variationDict: dict
             dictionary with parameter variation info if not provided via ini file
+
         Returns
         --------
         particlesList: list
@@ -161,7 +163,9 @@ def com1DFAMain(avalancheDir, cfgMain, cfgFile='', relThField='', variationDict=
 
 def com1DFACore(cfg, avaDir, cuSimName, inputSimFiles, outDir, relThField=''):
     """ Run main com1DFA model
+
     This will compute a dense flow avalanche
+
     Parameters
     ----------
     cfg : dict
@@ -177,6 +181,7 @@ def com1DFACore(cfg, avaDir, cuSimName, inputSimFiles, outDir, relThField=''):
     relThField: 2D array
         release thickness field with varying release thickness if '', release thickness is taken from
         (a) shapefile or (b) configuration file
+
     Returns
     -------
     reportDictList : list
@@ -246,6 +251,7 @@ def prepareReleaseEntrainment(cfg, rel, inputSimLines):
         path to release file
     inputSimLines: dict
         dictionary with dictionaries with input data infos (releaseLine, entLine, ...)
+
     Returns
     -------
     relName : str
@@ -294,6 +300,7 @@ def prepareReleaseEntrainment(cfg, rel, inputSimLines):
 
 def setThickness(cfg, lineTh, useThFromIni, typeTh):
     """ set thickness in line dictionary for release area, entrainment area
+
     Parameters
     -----------
     lineTh: dict
@@ -302,6 +309,7 @@ def setThickness(cfg, lineTh, useThFromIni, typeTh):
         True if thickness shall be set from ini file
     typeTh: str
         type of thickness to be set (e.g. relTh for release thickness -from ini)
+
     Returns
     --------
     lineTh: dict
@@ -324,6 +332,7 @@ def setThickness(cfg, lineTh, useThFromIni, typeTh):
 
 def prepareInputData(inputSimFiles):
     """ Fetch input data
+
     Parameters
     ----------
     relFiles : str
@@ -340,6 +349,7 @@ def prepareInputData(inputSimFiles):
         entResInfo : flag dict
             flag if Yes entrainment and/or resistance areas found and used for simulation
             flag True if a Secondary Release file found and activated
+
     Returns
     -------
     demOri : dict
@@ -414,6 +424,7 @@ def prepareInputData(inputSimFiles):
 
 def createReportDict(avaDir, logName, relName, inputSimLines, cfgGen, reportAreaInfo):
     """ create simulaton report dictionary
+
     Parameters
     ----------
     logName : str
@@ -428,6 +439,7 @@ def createReportDict(avaDir, logName, relName, inputSimLines, cfgGen, reportArea
         entrainment file name
     resistanceArea : str
         resistance file name
+
     Returns
     -------
     reportST : dict
@@ -498,8 +510,10 @@ def reportAddTimeMassInfo(reportDict, tcpuDFA, infoDict):
 
 def initializeMesh(cfg, demOri, num):
     """ Create rectangular mesh
+
     Reads the DEM information, computes the normal vector field and
     boundries to the DEM. Also generates the grid for the neighbour search
+
     Parameters
     ----------
     demOri : dict
@@ -507,6 +521,7 @@ def initializeMesh(cfg, demOri, num):
     num : int
         chose between 4, 6 or 8 (using then 4, 6 or 8 triangles) or
         1 to use the simple cross product method
+
     Returns
     -------
     dem : dict
@@ -568,6 +583,7 @@ def setDEMoriginToZero(demOri):
 
 def initializeSimulation(cfg, demOri, inputSimLines, logName, relThField=''):
     """ create simulaton report dictionary
+
     Parameters
     ----------
     cfg : str
@@ -588,6 +604,7 @@ def initializeSimulation(cfg, demOri, inputSimLines, logName, relThField=''):
     relThField : 2D numpy array
         inhomogeneous release thickness if wanted (relThField='' by default  - in this case
         release thickness from (a) shapefile or if not provided (b) configuration file is used)
+
     Returns
     -------
     particles : dict
@@ -691,8 +708,10 @@ def initializeSimulation(cfg, demOri, inputSimLines, logName, relThField=''):
 
 def initializeParticles(cfg, releaseLine, dem, logName='', relThField=''):
     """ Initialize DFA simulation
+
     Create particles and fields dictionary according to config parameters
     release raster and dem
+
     Parameters
     ----------
     cfg: configparser
@@ -844,6 +863,7 @@ def initializeParticles(cfg, releaseLine, dem, logName='', relThField=''):
 
 def initializeFields(cfg, dem, particles):
     """Initialize fields and update particles flow depth
+
     Parameters
     ----------
     cfg: configparser
@@ -852,6 +872,7 @@ def initializeFields(cfg, dem, particles):
         dictionary with dem information
     particles : dict
         particles dictionary at initial time step
+
     Returns
     -------
     particles : dict
@@ -885,6 +906,7 @@ def initializeFields(cfg, dem, particles):
 
 def initializeMassEnt(dem, simTypeActual, entLine, reportAreaInfo, thresholdPointInPoly, rhoEnt):
     """ Initialize mass for entrainment
+
     Parameters
     ----------
     dem: dict
@@ -900,6 +922,7 @@ def initializeMassEnt(dem, simTypeActual, entLine, reportAreaInfo, thresholdPoin
         very close but outside
     rhoEnt: float
         density of entrainment snow
+
     Returns
     -------
     entrMassRaster : 2D numpy array
@@ -929,6 +952,7 @@ def initializeMassEnt(dem, simTypeActual, entLine, reportAreaInfo, thresholdPoin
 
 def initializeResistance(cfg, dem, simTypeActual, resLine, reportAreaInfo, thresholdPointInPoly):
     """ Initialize resistance matrix
+
     Parameters
     ----------
     dem: dict
@@ -942,6 +966,7 @@ def initializeResistance(cfg, dem, simTypeActual, resLine, reportAreaInfo, thres
     thresholdPointInPoly: float
         threshold val that decides if a point is in the polygon, on the line or
         very close but outside
+
     Returns
     -------
     cResRaster : 2D numpy array
@@ -974,6 +999,7 @@ def initializeResistance(cfg, dem, simTypeActual, resLine, reportAreaInfo, thres
 def DFAIterate(cfg, particles, fields, dem):
     """ Perform time loop for DFA simulation
      Save results at desired intervals
+
     Parameters
     ----------
     cfg: configparser
@@ -986,6 +1012,7 @@ def DFAIterate(cfg, particles, fields, dem):
         fields dictionary at initial time step
     dem : dict
         dictionary with dem information
+
     Returns
     -------
     particlesList : list
@@ -1152,6 +1179,7 @@ def DFAIterate(cfg, particles, fields, dem):
 
 def appendFieldsParticles(fieldsList, particlesList, particles, fields, resTypes):
     """ append fields and optionally particle dictionaries to list for export
+
         Parameters
         ------------
         particles: dict
@@ -1160,6 +1188,7 @@ def appendFieldsParticles(fieldsList, particlesList, particles, fields, resTypes
             dictionary with all result type fields
         resTypes: list
             list with all result types that shall be exported
+
         Returns
         -------
         Fields: list
@@ -1181,6 +1210,7 @@ def appendFieldsParticles(fieldsList, particlesList, particles, fields, resTypes
 
 def writeMBFile(infoDict, avaDir, logName):
     """ write mass balance info to file
+
         Parameters
         -----------
         infoDict: dict
@@ -1206,6 +1236,7 @@ def writeMBFile(infoDict, avaDir, logName):
 
 def computeEulerTimeStep(cfg, particles, fields, dt, dem, Tcpu, frictType):
     """ compute next time step using an euler forward scheme
+
     Parameters
     ----------
     cfg: configparser
@@ -1222,6 +1253,7 @@ def computeEulerTimeStep(cfg, particles, fields, dt, dem, Tcpu, frictType):
         computation time dictionary
     frictType: int
         indicator for chosen type of friction model
+
     Returns
     -------
     particles : dict
@@ -1325,6 +1357,7 @@ def computeLeapFrogTimeStep(cfg, particles, fields, dt, dem, Tcpu):
         resistance raster
     Tcpu : dict
         computation time dictionary
+
     Returns
     -------
     particles : dict
@@ -1445,6 +1478,7 @@ def computeLeapFrogTimeStep(cfg, particles, fields, dt, dem, Tcpu):
 
 def prepareArea(line, dem, radius, thList='', combine=True, checkOverlap=True):
     """ convert shape file polygon to raster
+
     Parameters
     ----------
     line: dict
@@ -1462,6 +1496,7 @@ def prepareArea(line, dem, radius, thList='', combine=True, checkOverlap=True):
     checkOverlap : Boolean
         if True check if features are overlaping and return an error if it is the case
         if False check if features are overlaping and average the value for overlaping areas
+
     Returns
     -------
     updates the line dictionary with the rasterData: Either
@@ -1524,6 +1559,7 @@ def prepareArea(line, dem, radius, thList='', combine=True, checkOverlap=True):
 
 def polygon2Raster(demHeader, Line, radius, th=''):
     """ convert line to raster
+
     Parameters
     ----------
     demHeader: dict
@@ -1588,6 +1624,7 @@ def polygon2Raster(demHeader, Line, radius, th=''):
 
 def checkParticlesInRelease(particles, line, radius):
     """ remove particles laying outside the polygon
+
     Parameters
     ----------
     particles : dict
@@ -1597,6 +1634,7 @@ def checkParticlesInRelease(particles, line, radius):
     radius: float
         threshold val that decides if a point is in the polygon, on the line or
         very close but outside
+
     Returns
     -------
     particles : dict
@@ -1630,6 +1668,7 @@ def checkParticlesInRelease(particles, line, radius):
 
 def pointInPolygon(demHeader, points, Line, radius):
     """ find particles within a polygon
+
     Parameters
     ----------
     demHeader: dict
@@ -1725,6 +1764,7 @@ def releaseSecRelArea(cfg, particles, fields, dem):
 
 def savePartToPickle(dictList, outDir, logName):
     """ Save each dictionary from a list to a pickle in outDir; works also for one dictionary instead of list
+
         Parameters
         ---------
         dictList: list or dict
@@ -1744,9 +1784,11 @@ def savePartToPickle(dictList, outDir, logName):
 
 def trackParticles(cfgTrackPart, dem, particlesList):
     """ track particles from initial area
+
         Find all particles in an initial area. Find the same particles in
         the other time steps (+ the children if they were splitted).
         Extract time series of given properties of the tracked particles
+
         Parameters
         -----------
         cfgTrackPart: configParser
@@ -1761,6 +1803,7 @@ def trackParticles(cfgTrackPart, dem, particlesList):
             dem dictionary
         particlesList: list
             list of particles dictionary
+
         Returns
         -------
         particlesList : list
@@ -1808,6 +1851,7 @@ def trackParticles(cfgTrackPart, dem, particlesList):
 
 def readFields(inDir, resType, simName='', flagAvaDir=True, comModule='com1DFA'):
     """ Read ascii files within a directory and return List of dicionaries
+
         Parameters
         -----------
         inDir: str
@@ -1853,6 +1897,7 @@ def readFields(inDir, resType, simName='', flagAvaDir=True, comModule='com1DFA')
 def exportFields(cfg, Tsave, fieldsList, demOri, outDir, logName):
     """ export result fields to Outputs directory according to result parameters and time step
         that can be specified in the configuration file
+
         Parameters
         -----------
         cfg: dict
@@ -1912,6 +1957,7 @@ def exportFields(cfg, Tsave, fieldsList, demOri, outDir, logName):
 
 def prepareVarSimDict(standardCfg, inputSimFiles, variationDict, simNameOld=''):
     """ Prepare a dictionary with simulations that shall be run with varying parameters following the variation dict
+
         Parameters
         -----------
         standardCfg : configParser object
@@ -1982,12 +2028,14 @@ def prepareVarSimDict(standardCfg, inputSimFiles, variationDict, simNameOld=''):
 
 def getSimTypeList(simTypeList, inputSimFiles):
     """ Define available simulation types of requested types
+
         Parameters
         -----------
         standardCfg : configParser object
             default configuration or local configuration
         inputSimFiles: dict
             info dict on available input data
+
         Returns
         --------
         simTypeList: list

--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -48,6 +48,7 @@ featLF = False
 
 def com1DFAMain(avalancheDir, cfgMain, cfgFile='', relThField='', variationDict=''):
     """ preprocess information from ini and run all desired simulations, create outputs and reports
+
         Parameters
         ------------
         avalancheDir: str or pathlib Path
@@ -56,6 +57,7 @@ def com1DFAMain(avalancheDir, cfgMain, cfgFile='', relThField='', variationDict=
             path to configuration file if overwrite is desired
         variationDict: dict
             dictionary with parameter variation info if not provided via ini file
+
         Returns
         --------
         particlesList: list
@@ -161,7 +163,9 @@ def com1DFAMain(avalancheDir, cfgMain, cfgFile='', relThField='', variationDict=
 
 def com1DFACore(cfg, avaDir, cuSimName, inputSimFiles, outDir, relThField=''):
     """ Run main com1DFA model
+
     This will compute a dense flow avalanche
+
     Parameters
     ----------
     cfg : dict
@@ -177,6 +181,7 @@ def com1DFACore(cfg, avaDir, cuSimName, inputSimFiles, outDir, relThField=''):
     relThField: 2D array
         release thickness field with varying release thickness if '', release thickness is taken from
         (a) shapefile or (b) configuration file
+
     Returns
     -------
     reportDictList : list
@@ -237,6 +242,7 @@ def com1DFACore(cfg, avaDir, cuSimName, inputSimFiles, outDir, relThField=''):
 
 def prepareReleaseEntrainment(cfg, rel, inputSimLines):
     """ get Simulation to run for a given release
+
     Parameters
     ----------
     cfg : dict
@@ -245,6 +251,7 @@ def prepareReleaseEntrainment(cfg, rel, inputSimLines):
         path to release file
     inputSimLines: dict
         dictionary with dictionaries with input data infos (releaseLine, entLine, ...)
+
     Returns
     -------
     relName : str
@@ -293,6 +300,7 @@ def prepareReleaseEntrainment(cfg, rel, inputSimLines):
 
 def setThickness(cfg, lineTh, useThFromIni, typeTh):
     """ set thickness in line dictionary for release area, entrainment area
+
     Parameters
     -----------
     lineTh: dict
@@ -301,6 +309,7 @@ def setThickness(cfg, lineTh, useThFromIni, typeTh):
         True if thickness shall be set from ini file
     typeTh: str
         type of thickness to be set (e.g. relTh for release thickness -from ini)
+
     Returns
     --------
     lineTh: dict
@@ -323,6 +332,7 @@ def setThickness(cfg, lineTh, useThFromIni, typeTh):
 
 def prepareInputData(inputSimFiles):
     """ Fetch input data
+
     Parameters
     ----------
     relFiles : str
@@ -339,6 +349,7 @@ def prepareInputData(inputSimFiles):
         entResInfo : flag dict
             flag if Yes entrainment and/or resistance areas found and used for simulation
             flag True if a Secondary Release file found and activated
+
     Returns
     -------
     demOri : dict
@@ -413,6 +424,7 @@ def prepareInputData(inputSimFiles):
 
 def createReportDict(avaDir, logName, relName, inputSimLines, cfgGen, reportAreaInfo):
     """ create simulaton report dictionary
+
     Parameters
     ----------
     logName : str
@@ -427,6 +439,7 @@ def createReportDict(avaDir, logName, relName, inputSimLines, cfgGen, reportArea
         entrainment file name
     resistanceArea : str
         resistance file name
+
     Returns
     -------
     reportST : dict
@@ -497,8 +510,10 @@ def reportAddTimeMassInfo(reportDict, tcpuDFA, infoDict):
 
 def initializeMesh(cfg, demOri, num):
     """ Create rectangular mesh
+
     Reads the DEM information, computes the normal vector field and
     boundries to the DEM. Also generates the grid for the neighbour search
+
     Parameters
     ----------
     demOri : dict
@@ -506,6 +521,7 @@ def initializeMesh(cfg, demOri, num):
     num : int
         chose between 4, 6 or 8 (using then 4, 6 or 8 triangles) or
         1 to use the simple cross product method
+
     Returns
     -------
     dem : dict
@@ -567,6 +583,7 @@ def setDEMoriginToZero(demOri):
 
 def initializeSimulation(cfg, demOri, inputSimLines, logName, relThField=''):
     """ create simulaton report dictionary
+
     Parameters
     ----------
     cfg : str
@@ -587,6 +604,7 @@ def initializeSimulation(cfg, demOri, inputSimLines, logName, relThField=''):
     relThField : 2D numpy array
         inhomogeneous release thickness if wanted (relThField='' by default  - in this case
         release thickness from (a) shapefile or if not provided (b) configuration file is used)
+
     Returns
     -------
     particles : dict
@@ -690,8 +708,10 @@ def initializeSimulation(cfg, demOri, inputSimLines, logName, relThField=''):
 
 def initializeParticles(cfg, releaseLine, dem, logName='', relThField=''):
     """ Initialize DFA simulation
+
     Create particles and fields dictionary according to config parameters
     release raster and dem
+
     Parameters
     ----------
     cfg: configparser
@@ -843,6 +863,7 @@ def initializeParticles(cfg, releaseLine, dem, logName='', relThField=''):
 
 def initializeFields(cfg, dem, particles):
     """Initialize fields and update particles flow depth
+
     Parameters
     ----------
     cfg: configparser
@@ -851,6 +872,7 @@ def initializeFields(cfg, dem, particles):
         dictionary with dem information
     particles : dict
         particles dictionary at initial time step
+
     Returns
     -------
     particles : dict
@@ -884,6 +906,7 @@ def initializeFields(cfg, dem, particles):
 
 def initializeMassEnt(dem, simTypeActual, entLine, reportAreaInfo, thresholdPointInPoly, rhoEnt):
     """ Initialize mass for entrainment
+
     Parameters
     ----------
     dem: dict
@@ -899,6 +922,7 @@ def initializeMassEnt(dem, simTypeActual, entLine, reportAreaInfo, thresholdPoin
         very close but outside
     rhoEnt: float
         density of entrainment snow
+
     Returns
     -------
     entrMassRaster : 2D numpy array
@@ -928,6 +952,7 @@ def initializeMassEnt(dem, simTypeActual, entLine, reportAreaInfo, thresholdPoin
 
 def initializeResistance(cfg, dem, simTypeActual, resLine, reportAreaInfo, thresholdPointInPoly):
     """ Initialize resistance matrix
+
     Parameters
     ----------
     dem: dict
@@ -941,6 +966,7 @@ def initializeResistance(cfg, dem, simTypeActual, resLine, reportAreaInfo, thres
     thresholdPointInPoly: float
         threshold val that decides if a point is in the polygon, on the line or
         very close but outside
+
     Returns
     -------
     cResRaster : 2D numpy array
@@ -973,6 +999,7 @@ def initializeResistance(cfg, dem, simTypeActual, resLine, reportAreaInfo, thres
 def DFAIterate(cfg, particles, fields, dem):
     """ Perform time loop for DFA simulation
      Save results at desired intervals
+
     Parameters
     ----------
     cfg: configparser
@@ -985,6 +1012,7 @@ def DFAIterate(cfg, particles, fields, dem):
         fields dictionary at initial time step
     dem : dict
         dictionary with dem information
+
     Returns
     -------
     particlesList : list
@@ -1151,6 +1179,7 @@ def DFAIterate(cfg, particles, fields, dem):
 
 def appendFieldsParticles(fieldsList, particlesList, particles, fields, resTypes):
     """ append fields and optionally particle dictionaries to list for export
+
         Parameters
         ------------
         particles: dict
@@ -1159,6 +1188,7 @@ def appendFieldsParticles(fieldsList, particlesList, particles, fields, resTypes
             dictionary with all result type fields
         resTypes: list
             list with all result types that shall be exported
+
         Returns
         -------
         Fields: list
@@ -1180,6 +1210,7 @@ def appendFieldsParticles(fieldsList, particlesList, particles, fields, resTypes
 
 def writeMBFile(infoDict, avaDir, logName):
     """ write mass balance info to file
+
         Parameters
         -----------
         infoDict: dict
@@ -1205,6 +1236,7 @@ def writeMBFile(infoDict, avaDir, logName):
 
 def computeEulerTimeStep(cfg, particles, fields, dt, dem, Tcpu, frictType):
     """ compute next time step using an euler forward scheme
+
     Parameters
     ----------
     cfg: configparser
@@ -1221,6 +1253,7 @@ def computeEulerTimeStep(cfg, particles, fields, dt, dem, Tcpu, frictType):
         computation time dictionary
     frictType: int
         indicator for chosen type of friction model
+
     Returns
     -------
     particles : dict
@@ -1231,12 +1264,8 @@ def computeEulerTimeStep(cfg, particles, fields, dt, dem, Tcpu, frictType):
         computation time dictionary
     """
 
-    flowDepthOption = cfg.getint('flowDepthOption')
     headerNeighbourGrid = dem['headerNeighbourGrid']
     headerNormalGrid = dem['header']
-
-    if flowDepthOption==1:
-        particles = DFAfunC.computeFlowDepthSPH(cfg, particles, headerNeighbourGrid, headerNormalGrid)
 
     # get forces
     startTime = time.time()
@@ -1309,6 +1338,7 @@ def computeEulerTimeStep(cfg, particles, fields, dt, dem, Tcpu, frictType):
 
 def computeLeapFrogTimeStep(cfg, particles, fields, dt, dem, Tcpu):
     """ compute next time step using a Leap Frog scheme
+
     Parameters
     ----------
     cfg: configparser
@@ -1327,6 +1357,7 @@ def computeLeapFrogTimeStep(cfg, particles, fields, dt, dem, Tcpu):
         resistance raster
     Tcpu : dict
         computation time dictionary
+
     Returns
     -------
     particles : dict
@@ -1447,6 +1478,7 @@ def computeLeapFrogTimeStep(cfg, particles, fields, dt, dem, Tcpu):
 
 def prepareArea(line, dem, radius, thList='', combine=True, checkOverlap=True):
     """ convert shape file polygon to raster
+
     Parameters
     ----------
     line: dict
@@ -1464,6 +1496,7 @@ def prepareArea(line, dem, radius, thList='', combine=True, checkOverlap=True):
     checkOverlap : Boolean
         if True check if features are overlaping and return an error if it is the case
         if False check if features are overlaping and average the value for overlaping areas
+
     Returns
     -------
     updates the line dictionary with the rasterData: Either
@@ -1526,6 +1559,7 @@ def prepareArea(line, dem, radius, thList='', combine=True, checkOverlap=True):
 
 def polygon2Raster(demHeader, Line, radius, th=''):
     """ convert line to raster
+
     Parameters
     ----------
     demHeader: dict
@@ -1536,6 +1570,7 @@ def polygon2Raster(demHeader, Line, radius, th=''):
         include all cells which center is in the polygon or close enough
     th: float
         thickness value ot the line feature
+
     Returns
     -------
     Mask : 2D numpy array
@@ -1589,6 +1624,7 @@ def polygon2Raster(demHeader, Line, radius, th=''):
 
 def checkParticlesInRelease(particles, line, radius):
     """ remove particles laying outside the polygon
+
     Parameters
     ----------
     particles : dict
@@ -1598,6 +1634,7 @@ def checkParticlesInRelease(particles, line, radius):
     radius: float
         threshold val that decides if a point is in the polygon, on the line or
         very close but outside
+
     Returns
     -------
     particles : dict
@@ -1631,6 +1668,7 @@ def checkParticlesInRelease(particles, line, radius):
 
 def pointInPolygon(demHeader, points, Line, radius):
     """ find particles within a polygon
+
     Parameters
     ----------
     demHeader: dict
@@ -1642,6 +1680,7 @@ def pointInPolygon(demHeader, points, Line, radius):
     radius: float
         threshold val that decides if a point is in the polygon, on the line or
         very close but outside
+
     Returns
     -------
     Mask : 1D numpy array
@@ -1725,6 +1764,7 @@ def releaseSecRelArea(cfg, particles, fields, dem):
 
 def savePartToPickle(dictList, outDir, logName):
     """ Save each dictionary from a list to a pickle in outDir; works also for one dictionary instead of list
+
         Parameters
         ---------
         dictList: list or dict
@@ -1744,9 +1784,11 @@ def savePartToPickle(dictList, outDir, logName):
 
 def trackParticles(cfgTrackPart, dem, particlesList):
     """ track particles from initial area
+
         Find all particles in an initial area. Find the same particles in
         the other time steps (+ the children if they were splitted).
         Extract time series of given properties of the tracked particles
+
         Parameters
         -----------
         cfgTrackPart: configParser
@@ -1761,6 +1803,7 @@ def trackParticles(cfgTrackPart, dem, particlesList):
             dem dictionary
         particlesList: list
             list of particles dictionary
+
         Returns
         -------
         particlesList : list
@@ -1808,6 +1851,7 @@ def trackParticles(cfgTrackPart, dem, particlesList):
 
 def readFields(inDir, resType, simName='', flagAvaDir=True, comModule='com1DFA'):
     """ Read ascii files within a directory and return List of dicionaries
+
         Parameters
         -----------
         inDir: str
@@ -1853,6 +1897,7 @@ def readFields(inDir, resType, simName='', flagAvaDir=True, comModule='com1DFA')
 def exportFields(cfg, Tsave, fieldsList, demOri, outDir, logName):
     """ export result fields to Outputs directory according to result parameters and time step
         that can be specified in the configuration file
+
         Parameters
         -----------
         cfg: dict
@@ -1863,6 +1908,7 @@ def exportFields(cfg, Tsave, fieldsList, demOri, outDir, logName):
             list of Fields for each dtSave
         outDir: str
             outputs Directory
+
         Returns
         --------
         exported peak fields are saved in Outputs/com1DFA/peakFiles
@@ -1911,6 +1957,7 @@ def exportFields(cfg, Tsave, fieldsList, demOri, outDir, logName):
 
 def prepareVarSimDict(standardCfg, inputSimFiles, variationDict, simNameOld=''):
     """ Prepare a dictionary with simulations that shall be run with varying parameters following the variation dict
+
         Parameters
         -----------
         standardCfg : configParser object
@@ -1922,6 +1969,7 @@ def prepareVarSimDict(standardCfg, inputSimFiles, variationDict, simNameOld=''):
         simNameOld: list
             list of simulation names that already exist (optional). If provided,
             only carry on simulation that do not exist
+
         Returns
         -------
         simDict: dict
@@ -1980,12 +2028,14 @@ def prepareVarSimDict(standardCfg, inputSimFiles, variationDict, simNameOld=''):
 
 def getSimTypeList(simTypeList, inputSimFiles):
     """ Define available simulation types of requested types
+
         Parameters
         -----------
         standardCfg : configParser object
             default configuration or local configuration
         inputSimFiles: dict
             info dict on available input data
+
         Returns
         --------
         simTypeList: list

--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -48,7 +48,6 @@ featLF = False
 
 def com1DFAMain(avalancheDir, cfgMain, cfgFile='', relThField='', variationDict=''):
     """ preprocess information from ini and run all desired simulations, create outputs and reports
-
         Parameters
         ------------
         avalancheDir: str or pathlib Path
@@ -57,7 +56,6 @@ def com1DFAMain(avalancheDir, cfgMain, cfgFile='', relThField='', variationDict=
             path to configuration file if overwrite is desired
         variationDict: dict
             dictionary with parameter variation info if not provided via ini file
-
         Returns
         --------
         particlesList: list
@@ -163,9 +161,7 @@ def com1DFAMain(avalancheDir, cfgMain, cfgFile='', relThField='', variationDict=
 
 def com1DFACore(cfg, avaDir, cuSimName, inputSimFiles, outDir, relThField=''):
     """ Run main com1DFA model
-
     This will compute a dense flow avalanche
-
     Parameters
     ----------
     cfg : dict
@@ -181,7 +177,6 @@ def com1DFACore(cfg, avaDir, cuSimName, inputSimFiles, outDir, relThField=''):
     relThField: 2D array
         release thickness field with varying release thickness if '', release thickness is taken from
         (a) shapefile or (b) configuration file
-
     Returns
     -------
     reportDictList : list
@@ -242,8 +237,6 @@ def com1DFACore(cfg, avaDir, cuSimName, inputSimFiles, outDir, relThField=''):
 
 def prepareReleaseEntrainment(cfg, rel, inputSimLines):
     """ get Simulation to run for a given release
-
-
     Parameters
     ----------
     cfg : dict
@@ -252,7 +245,6 @@ def prepareReleaseEntrainment(cfg, rel, inputSimLines):
         path to release file
     inputSimLines: dict
         dictionary with dictionaries with input data infos (releaseLine, entLine, ...)
-
     Returns
     -------
     relName : str
@@ -301,7 +293,6 @@ def prepareReleaseEntrainment(cfg, rel, inputSimLines):
 
 def setThickness(cfg, lineTh, useThFromIni, typeTh):
     """ set thickness in line dictionary for release area, entrainment area
-
     Parameters
     -----------
     lineTh: dict
@@ -310,12 +301,10 @@ def setThickness(cfg, lineTh, useThFromIni, typeTh):
         True if thickness shall be set from ini file
     typeTh: str
         type of thickness to be set (e.g. relTh for release thickness -from ini)
-
     Returns
     --------
     lineTh: dict
         updated dictionary with new key: thickness and thicknessSource
-
     """
 
     lineTh['thicknessSource'] = [''] * len(lineTh['thickness'])
@@ -334,7 +323,6 @@ def setThickness(cfg, lineTh, useThFromIni, typeTh):
 
 def prepareInputData(inputSimFiles):
     """ Fetch input data
-
     Parameters
     ----------
     relFiles : str
@@ -351,7 +339,6 @@ def prepareInputData(inputSimFiles):
         entResInfo : flag dict
             flag if Yes entrainment and/or resistance areas found and used for simulation
             flag True if a Secondary Release file found and activated
-
     Returns
     -------
     demOri : dict
@@ -372,7 +359,6 @@ def prepareInputData(inputSimFiles):
         entResInfo : flag dict
             flag if Yes entrainment and/or resistance areas found and used for simulation
             flag True if a Secondary Release file found and activated
-
     """
 
     # load data
@@ -427,7 +413,6 @@ def prepareInputData(inputSimFiles):
 
 def createReportDict(avaDir, logName, relName, inputSimLines, cfgGen, reportAreaInfo):
     """ create simulaton report dictionary
-
     Parameters
     ----------
     logName : str
@@ -442,7 +427,6 @@ def createReportDict(avaDir, logName, relName, inputSimLines, cfgGen, reportArea
         entrainment file name
     resistanceArea : str
         resistance file name
-
     Returns
     -------
     reportST : dict
@@ -513,10 +497,8 @@ def reportAddTimeMassInfo(reportDict, tcpuDFA, infoDict):
 
 def initializeMesh(cfg, demOri, num):
     """ Create rectangular mesh
-
     Reads the DEM information, computes the normal vector field and
     boundries to the DEM. Also generates the grid for the neighbour search
-
     Parameters
     ----------
     demOri : dict
@@ -524,7 +506,6 @@ def initializeMesh(cfg, demOri, num):
     num : int
         chose between 4, 6 or 8 (using then 4, 6 or 8 triangles) or
         1 to use the simple cross product method
-
     Returns
     -------
     dem : dict
@@ -586,7 +567,6 @@ def setDEMoriginToZero(demOri):
 
 def initializeSimulation(cfg, demOri, inputSimLines, logName, relThField=''):
     """ create simulaton report dictionary
-
     Parameters
     ----------
     cfg : str
@@ -607,7 +587,6 @@ def initializeSimulation(cfg, demOri, inputSimLines, logName, relThField=''):
     relThField : 2D numpy array
         inhomogeneous release thickness if wanted (relThField='' by default  - in this case
         release thickness from (a) shapefile or if not provided (b) configuration file is used)
-
     Returns
     -------
     particles : dict
@@ -711,10 +690,8 @@ def initializeSimulation(cfg, demOri, inputSimLines, logName, relThField=''):
 
 def initializeParticles(cfg, releaseLine, dem, logName='', relThField=''):
     """ Initialize DFA simulation
-
     Create particles and fields dictionary according to config parameters
     release raster and dem
-
     Parameters
     ----------
     cfg: configparser
@@ -866,7 +843,6 @@ def initializeParticles(cfg, releaseLine, dem, logName='', relThField=''):
 
 def initializeFields(cfg, dem, particles):
     """Initialize fields and update particles flow depth
-
     Parameters
     ----------
     cfg: configparser
@@ -875,7 +851,6 @@ def initializeFields(cfg, dem, particles):
         dictionary with dem information
     particles : dict
         particles dictionary at initial time step
-
     Returns
     -------
     particles : dict
@@ -909,7 +884,6 @@ def initializeFields(cfg, dem, particles):
 
 def initializeMassEnt(dem, simTypeActual, entLine, reportAreaInfo, thresholdPointInPoly, rhoEnt):
     """ Initialize mass for entrainment
-
     Parameters
     ----------
     dem: dict
@@ -925,7 +899,6 @@ def initializeMassEnt(dem, simTypeActual, entLine, reportAreaInfo, thresholdPoin
         very close but outside
     rhoEnt: float
         density of entrainment snow
-
     Returns
     -------
     entrMassRaster : 2D numpy array
@@ -955,7 +928,6 @@ def initializeMassEnt(dem, simTypeActual, entLine, reportAreaInfo, thresholdPoin
 
 def initializeResistance(cfg, dem, simTypeActual, resLine, reportAreaInfo, thresholdPointInPoly):
     """ Initialize resistance matrix
-
     Parameters
     ----------
     dem: dict
@@ -969,7 +941,6 @@ def initializeResistance(cfg, dem, simTypeActual, resLine, reportAreaInfo, thres
     thresholdPointInPoly: float
         threshold val that decides if a point is in the polygon, on the line or
         very close but outside
-
     Returns
     -------
     cResRaster : 2D numpy array
@@ -1001,9 +972,7 @@ def initializeResistance(cfg, dem, simTypeActual, resLine, reportAreaInfo, thres
 
 def DFAIterate(cfg, particles, fields, dem):
     """ Perform time loop for DFA simulation
-
      Save results at desired intervals
-
     Parameters
     ----------
     cfg: configparser
@@ -1016,7 +985,6 @@ def DFAIterate(cfg, particles, fields, dem):
         fields dictionary at initial time step
     dem : dict
         dictionary with dem information
-
     Returns
     -------
     particlesList : list
@@ -1183,7 +1151,6 @@ def DFAIterate(cfg, particles, fields, dem):
 
 def appendFieldsParticles(fieldsList, particlesList, particles, fields, resTypes):
     """ append fields and optionally particle dictionaries to list for export
-
         Parameters
         ------------
         particles: dict
@@ -1192,14 +1159,12 @@ def appendFieldsParticles(fieldsList, particlesList, particles, fields, resTypes
             dictionary with all result type fields
         resTypes: list
             list with all result types that shall be exported
-
         Returns
         -------
         Fields: list
             updated list with desired result type fields dictionary
         Particles: list
             updated list with particles dicionaries
-
     """
 
     fieldAppend = {}
@@ -1215,7 +1180,6 @@ def appendFieldsParticles(fieldsList, particlesList, particles, fields, resTypes
 
 def writeMBFile(infoDict, avaDir, logName):
     """ write mass balance info to file
-
         Parameters
         -----------
         infoDict: dict
@@ -1241,7 +1205,6 @@ def writeMBFile(infoDict, avaDir, logName):
 
 def computeEulerTimeStep(cfg, particles, fields, dt, dem, Tcpu, frictType):
     """ compute next time step using an euler forward scheme
-
     Parameters
     ----------
     cfg: configparser
@@ -1258,7 +1221,6 @@ def computeEulerTimeStep(cfg, particles, fields, dt, dem, Tcpu, frictType):
         computation time dictionary
     frictType: int
         indicator for chosen type of friction model
-
     Returns
     -------
     particles : dict
@@ -1278,6 +1240,7 @@ def computeEulerTimeStep(cfg, particles, fields, dt, dem, Tcpu, frictType):
 
     # get forces
     startTime = time.time()
+
     # loop version of the compute force
     log.debug('Compute Force C')
     particles, force, fields = DFAfunC.computeForceC(cfg, particles, fields, dem, dt, frictType)
@@ -1337,8 +1300,6 @@ def computeEulerTimeStep(cfg, particles, fields, dt, dem, Tcpu, frictType):
     startTime = time.time()
     log.debug('update Fields C')
     # particles, fields = updateFields(cfg, particles, force, dem, fields)
-
-    #if flowDepthOption!=1 or viscOption !=2 :
     particles, fields = DFAfunC.updateFieldsC(cfg, particles, dem, fields)
     tcpuField = time.time() - startTime
     Tcpu['Field'] = Tcpu['Field'] + tcpuField
@@ -1348,8 +1309,6 @@ def computeEulerTimeStep(cfg, particles, fields, dt, dem, Tcpu, frictType):
 
 def computeLeapFrogTimeStep(cfg, particles, fields, dt, dem, Tcpu):
     """ compute next time step using a Leap Frog scheme
-
-
     Parameters
     ----------
     cfg: configparser
@@ -1368,7 +1327,6 @@ def computeLeapFrogTimeStep(cfg, particles, fields, dt, dem, Tcpu):
         resistance raster
     Tcpu : dict
         computation time dictionary
-
     Returns
     -------
     particles : dict
@@ -1489,7 +1447,6 @@ def computeLeapFrogTimeStep(cfg, particles, fields, dt, dem, Tcpu):
 
 def prepareArea(line, dem, radius, thList='', combine=True, checkOverlap=True):
     """ convert shape file polygon to raster
-
     Parameters
     ----------
     line: dict
@@ -1507,7 +1464,6 @@ def prepareArea(line, dem, radius, thList='', combine=True, checkOverlap=True):
     checkOverlap : Boolean
         if True check if features are overlaping and return an error if it is the case
         if False check if features are overlaping and average the value for overlaping areas
-
     Returns
     -------
     updates the line dictionary with the rasterData: Either
@@ -1570,7 +1526,6 @@ def prepareArea(line, dem, radius, thList='', combine=True, checkOverlap=True):
 
 def polygon2Raster(demHeader, Line, radius, th=''):
     """ convert line to raster
-
     Parameters
     ----------
     demHeader: dict
@@ -1583,7 +1538,6 @@ def polygon2Raster(demHeader, Line, radius, th=''):
         thickness value ot the line feature
     Returns
     -------
-
     Mask : 2D numpy array
         updated raster
     """
@@ -1635,7 +1589,6 @@ def polygon2Raster(demHeader, Line, radius, th=''):
 
 def checkParticlesInRelease(particles, line, radius):
     """ remove particles laying outside the polygon
-
     Parameters
     ----------
     particles : dict
@@ -1645,12 +1598,10 @@ def checkParticlesInRelease(particles, line, radius):
     radius: float
         threshold val that decides if a point is in the polygon, on the line or
         very close but outside
-
     Returns
     -------
     particles : dict
         particles dictionary where particles outside of the polygon have been removed
-
     """
     NameRel = line['Name']
     StartRel = line['Start']
@@ -1680,7 +1631,6 @@ def checkParticlesInRelease(particles, line, radius):
 
 def pointInPolygon(demHeader, points, Line, radius):
     """ find particles within a polygon
-
     Parameters
     ----------
     demHeader: dict
@@ -1694,7 +1644,6 @@ def pointInPolygon(demHeader, points, Line, radius):
         very close but outside
     Returns
     -------
-
     Mask : 1D numpy array
         Mask of particles to keep
     """
@@ -1731,7 +1680,6 @@ def pointInPolygon(demHeader, points, Line, radius):
 
 def releaseSecRelArea(cfg, particles, fields, dem):
     """ Release secondary release area if trigered
-
     Initialize particles of the trigured secondary release area and add them
     to the simulation (particles dictionary)
     """
@@ -1777,7 +1725,6 @@ def releaseSecRelArea(cfg, particles, fields, dem):
 
 def savePartToPickle(dictList, outDir, logName):
     """ Save each dictionary from a list to a pickle in outDir; works also for one dictionary instead of list
-
         Parameters
         ---------
         dictList: list or dict
@@ -1797,11 +1744,9 @@ def savePartToPickle(dictList, outDir, logName):
 
 def trackParticles(cfgTrackPart, dem, particlesList):
     """ track particles from initial area
-
         Find all particles in an initial area. Find the same particles in
         the other time steps (+ the children if they were splitted).
         Extract time series of given properties of the tracked particles
-
         Parameters
         -----------
         cfgTrackPart: configParser
@@ -1816,7 +1761,6 @@ def trackParticles(cfgTrackPart, dem, particlesList):
             dem dictionary
         particlesList: list
             list of particles dictionary
-
         Returns
         -------
         particlesList : list
@@ -1864,7 +1808,6 @@ def trackParticles(cfgTrackPart, dem, particlesList):
 
 def readFields(inDir, resType, simName='', flagAvaDir=True, comModule='com1DFA'):
     """ Read ascii files within a directory and return List of dicionaries
-
         Parameters
         -----------
         inDir: str
@@ -1910,7 +1853,6 @@ def readFields(inDir, resType, simName='', flagAvaDir=True, comModule='com1DFA')
 def exportFields(cfg, Tsave, fieldsList, demOri, outDir, logName):
     """ export result fields to Outputs directory according to result parameters and time step
         that can be specified in the configuration file
-
         Parameters
         -----------
         cfg: dict
@@ -1921,12 +1863,9 @@ def exportFields(cfg, Tsave, fieldsList, demOri, outDir, logName):
             list of Fields for each dtSave
         outDir: str
             outputs Directory
-
-
         Returns
         --------
         exported peak fields are saved in Outputs/com1DFA/peakFiles
-
     """
 
     resTypesGen = fU.splitIniValueToArraySteps(cfg['GENERAL']['resType'])
@@ -1972,7 +1911,6 @@ def exportFields(cfg, Tsave, fieldsList, demOri, outDir, logName):
 
 def prepareVarSimDict(standardCfg, inputSimFiles, variationDict, simNameOld=''):
     """ Prepare a dictionary with simulations that shall be run with varying parameters following the variation dict
-
         Parameters
         -----------
         standardCfg : configParser object
@@ -1984,14 +1922,11 @@ def prepareVarSimDict(standardCfg, inputSimFiles, variationDict, simNameOld=''):
         simNameOld: list
             list of simulation names that already exist (optional). If provided,
             only carry on simulation that do not exist
-
-
         Returns
         -------
         simDict: dict
             dicionary with info on simHash, releaseScenario, release area file path,
             simType and contains full configuration configparser object for simulation run
-
     """
 
     # get list of simulation types that are desired
@@ -2045,19 +1980,16 @@ def prepareVarSimDict(standardCfg, inputSimFiles, variationDict, simNameOld=''):
 
 def getSimTypeList(simTypeList, inputSimFiles):
     """ Define available simulation types of requested types
-
         Parameters
         -----------
         standardCfg : configParser object
             default configuration or local configuration
         inputSimFiles: dict
             info dict on available input data
-
         Returns
         --------
         simTypeList: list
             list of requested simTypes where also the required input data is available
-
     """
 
     # read entrainment resistance info

--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -746,10 +746,10 @@ def initializeParticles(cfg, releaseLine, dem, logName='', relThField=''):
     # if the release is not constant but given by a varying function, we need both the mask giving the cells
     # to be initialized and the raster giving the flow depth value
     relRasterMask = releaseLine['rasterData']
-    if relThField != '':
-        relRaster = relThField
-    else:
+    if len(relThField) == 0:
         relRaster = releaseLine['rasterData']
+    else:
+        relRaster = relThField
     areaRaster = dem['areaRaster']
 
     # get the initialization method used
@@ -1263,10 +1263,6 @@ def computeEulerTimeStep(cfg, particles, fields, dt, dem, Tcpu, frictType):
     Tcpu : dict
         computation time dictionary
     """
-
-    headerNeighbourGrid = dem['headerNeighbourGrid']
-    headerNormalGrid = dem['header']
-
     # get forces
     startTime = time.time()
 

--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -48,7 +48,6 @@ featLF = False
 
 def com1DFAMain(avalancheDir, cfgMain, cfgFile='', relThField='', variationDict=''):
     """ preprocess information from ini and run all desired simulations, create outputs and reports
-
         Parameters
         ------------
         avalancheDir: str or pathlib Path
@@ -57,7 +56,6 @@ def com1DFAMain(avalancheDir, cfgMain, cfgFile='', relThField='', variationDict=
             path to configuration file if overwrite is desired
         variationDict: dict
             dictionary with parameter variation info if not provided via ini file
-
         Returns
         --------
         particlesList: list
@@ -163,9 +161,7 @@ def com1DFAMain(avalancheDir, cfgMain, cfgFile='', relThField='', variationDict=
 
 def com1DFACore(cfg, avaDir, cuSimName, inputSimFiles, outDir, relThField=''):
     """ Run main com1DFA model
-
     This will compute a dense flow avalanche
-
     Parameters
     ----------
     cfg : dict
@@ -181,7 +177,6 @@ def com1DFACore(cfg, avaDir, cuSimName, inputSimFiles, outDir, relThField=''):
     relThField: 2D array
         release thickness field with varying release thickness if '', release thickness is taken from
         (a) shapefile or (b) configuration file
-
     Returns
     -------
     reportDictList : list
@@ -251,7 +246,6 @@ def prepareReleaseEntrainment(cfg, rel, inputSimLines):
         path to release file
     inputSimLines: dict
         dictionary with dictionaries with input data infos (releaseLine, entLine, ...)
-
     Returns
     -------
     relName : str
@@ -300,7 +294,6 @@ def prepareReleaseEntrainment(cfg, rel, inputSimLines):
 
 def setThickness(cfg, lineTh, useThFromIni, typeTh):
     """ set thickness in line dictionary for release area, entrainment area
-
     Parameters
     -----------
     lineTh: dict
@@ -309,7 +302,6 @@ def setThickness(cfg, lineTh, useThFromIni, typeTh):
         True if thickness shall be set from ini file
     typeTh: str
         type of thickness to be set (e.g. relTh for release thickness -from ini)
-
     Returns
     --------
     lineTh: dict
@@ -332,7 +324,6 @@ def setThickness(cfg, lineTh, useThFromIni, typeTh):
 
 def prepareInputData(inputSimFiles):
     """ Fetch input data
-
     Parameters
     ----------
     relFiles : str
@@ -349,7 +340,6 @@ def prepareInputData(inputSimFiles):
         entResInfo : flag dict
             flag if Yes entrainment and/or resistance areas found and used for simulation
             flag True if a Secondary Release file found and activated
-
     Returns
     -------
     demOri : dict
@@ -424,7 +414,6 @@ def prepareInputData(inputSimFiles):
 
 def createReportDict(avaDir, logName, relName, inputSimLines, cfgGen, reportAreaInfo):
     """ create simulaton report dictionary
-
     Parameters
     ----------
     logName : str
@@ -439,7 +428,6 @@ def createReportDict(avaDir, logName, relName, inputSimLines, cfgGen, reportArea
         entrainment file name
     resistanceArea : str
         resistance file name
-
     Returns
     -------
     reportST : dict
@@ -510,10 +498,8 @@ def reportAddTimeMassInfo(reportDict, tcpuDFA, infoDict):
 
 def initializeMesh(cfg, demOri, num):
     """ Create rectangular mesh
-
     Reads the DEM information, computes the normal vector field and
     boundries to the DEM. Also generates the grid for the neighbour search
-
     Parameters
     ----------
     demOri : dict
@@ -521,7 +507,6 @@ def initializeMesh(cfg, demOri, num):
     num : int
         chose between 4, 6 or 8 (using then 4, 6 or 8 triangles) or
         1 to use the simple cross product method
-
     Returns
     -------
     dem : dict
@@ -583,7 +568,6 @@ def setDEMoriginToZero(demOri):
 
 def initializeSimulation(cfg, demOri, inputSimLines, logName, relThField=''):
     """ create simulaton report dictionary
-
     Parameters
     ----------
     cfg : str
@@ -604,7 +588,6 @@ def initializeSimulation(cfg, demOri, inputSimLines, logName, relThField=''):
     relThField : 2D numpy array
         inhomogeneous release thickness if wanted (relThField='' by default  - in this case
         release thickness from (a) shapefile or if not provided (b) configuration file is used)
-
     Returns
     -------
     particles : dict
@@ -708,10 +691,8 @@ def initializeSimulation(cfg, demOri, inputSimLines, logName, relThField=''):
 
 def initializeParticles(cfg, releaseLine, dem, logName='', relThField=''):
     """ Initialize DFA simulation
-
     Create particles and fields dictionary according to config parameters
     release raster and dem
-
     Parameters
     ----------
     cfg: configparser
@@ -863,7 +844,6 @@ def initializeParticles(cfg, releaseLine, dem, logName='', relThField=''):
 
 def initializeFields(cfg, dem, particles):
     """Initialize fields and update particles flow depth
-
     Parameters
     ----------
     cfg: configparser
@@ -872,7 +852,6 @@ def initializeFields(cfg, dem, particles):
         dictionary with dem information
     particles : dict
         particles dictionary at initial time step
-
     Returns
     -------
     particles : dict
@@ -906,7 +885,6 @@ def initializeFields(cfg, dem, particles):
 
 def initializeMassEnt(dem, simTypeActual, entLine, reportAreaInfo, thresholdPointInPoly, rhoEnt):
     """ Initialize mass for entrainment
-
     Parameters
     ----------
     dem: dict
@@ -922,7 +900,6 @@ def initializeMassEnt(dem, simTypeActual, entLine, reportAreaInfo, thresholdPoin
         very close but outside
     rhoEnt: float
         density of entrainment snow
-
     Returns
     -------
     entrMassRaster : 2D numpy array
@@ -952,7 +929,6 @@ def initializeMassEnt(dem, simTypeActual, entLine, reportAreaInfo, thresholdPoin
 
 def initializeResistance(cfg, dem, simTypeActual, resLine, reportAreaInfo, thresholdPointInPoly):
     """ Initialize resistance matrix
-
     Parameters
     ----------
     dem: dict
@@ -966,7 +942,6 @@ def initializeResistance(cfg, dem, simTypeActual, resLine, reportAreaInfo, thres
     thresholdPointInPoly: float
         threshold val that decides if a point is in the polygon, on the line or
         very close but outside
-
     Returns
     -------
     cResRaster : 2D numpy array
@@ -999,7 +974,6 @@ def initializeResistance(cfg, dem, simTypeActual, resLine, reportAreaInfo, thres
 def DFAIterate(cfg, particles, fields, dem):
     """ Perform time loop for DFA simulation
      Save results at desired intervals
-
     Parameters
     ----------
     cfg: configparser
@@ -1012,7 +986,6 @@ def DFAIterate(cfg, particles, fields, dem):
         fields dictionary at initial time step
     dem : dict
         dictionary with dem information
-
     Returns
     -------
     particlesList : list
@@ -1179,7 +1152,6 @@ def DFAIterate(cfg, particles, fields, dem):
 
 def appendFieldsParticles(fieldsList, particlesList, particles, fields, resTypes):
     """ append fields and optionally particle dictionaries to list for export
-
         Parameters
         ------------
         particles: dict
@@ -1188,7 +1160,6 @@ def appendFieldsParticles(fieldsList, particlesList, particles, fields, resTypes
             dictionary with all result type fields
         resTypes: list
             list with all result types that shall be exported
-
         Returns
         -------
         Fields: list
@@ -1210,7 +1181,6 @@ def appendFieldsParticles(fieldsList, particlesList, particles, fields, resTypes
 
 def writeMBFile(infoDict, avaDir, logName):
     """ write mass balance info to file
-
         Parameters
         -----------
         infoDict: dict
@@ -1236,7 +1206,6 @@ def writeMBFile(infoDict, avaDir, logName):
 
 def computeEulerTimeStep(cfg, particles, fields, dt, dem, Tcpu, frictType):
     """ compute next time step using an euler forward scheme
-
     Parameters
     ----------
     cfg: configparser
@@ -1253,7 +1222,6 @@ def computeEulerTimeStep(cfg, particles, fields, dt, dem, Tcpu, frictType):
         computation time dictionary
     frictType: int
         indicator for chosen type of friction model
-
     Returns
     -------
     particles : dict
@@ -1269,6 +1237,7 @@ def computeEulerTimeStep(cfg, particles, fields, dt, dem, Tcpu, frictType):
 
     # get forces
     startTime = time.time()
+
     # loop version of the compute force
     log.debug('Compute Force C')
     particles, force, fields = DFAfunC.computeForceC(cfg, particles, fields, dem, dt, frictType)
@@ -1328,8 +1297,6 @@ def computeEulerTimeStep(cfg, particles, fields, dt, dem, Tcpu, frictType):
     startTime = time.time()
     log.debug('update Fields C')
     # particles, fields = updateFields(cfg, particles, force, dem, fields)
-
-    #if flowDepthOption!=1 or viscOption !=2 :
     particles, fields = DFAfunC.updateFieldsC(cfg, particles, dem, fields)
     tcpuField = time.time() - startTime
     Tcpu['Field'] = Tcpu['Field'] + tcpuField
@@ -1358,7 +1325,6 @@ def computeLeapFrogTimeStep(cfg, particles, fields, dt, dem, Tcpu):
         resistance raster
     Tcpu : dict
         computation time dictionary
-
     Returns
     -------
     particles : dict
@@ -1479,7 +1445,6 @@ def computeLeapFrogTimeStep(cfg, particles, fields, dt, dem, Tcpu):
 
 def prepareArea(line, dem, radius, thList='', combine=True, checkOverlap=True):
     """ convert shape file polygon to raster
-
     Parameters
     ----------
     line: dict
@@ -1497,7 +1462,6 @@ def prepareArea(line, dem, radius, thList='', combine=True, checkOverlap=True):
     checkOverlap : Boolean
         if True check if features are overlaping and return an error if it is the case
         if False check if features are overlaping and average the value for overlaping areas
-
     Returns
     -------
     updates the line dictionary with the rasterData: Either
@@ -1560,7 +1524,6 @@ def prepareArea(line, dem, radius, thList='', combine=True, checkOverlap=True):
 
 def polygon2Raster(demHeader, Line, radius, th=''):
     """ convert line to raster
-
     Parameters
     ----------
     demHeader: dict
@@ -1625,7 +1588,6 @@ def polygon2Raster(demHeader, Line, radius, th=''):
 
 def checkParticlesInRelease(particles, line, radius):
     """ remove particles laying outside the polygon
-
     Parameters
     ----------
     particles : dict
@@ -1635,7 +1597,6 @@ def checkParticlesInRelease(particles, line, radius):
     radius: float
         threshold val that decides if a point is in the polygon, on the line or
         very close but outside
-
     Returns
     -------
     particles : dict
@@ -1669,7 +1630,6 @@ def checkParticlesInRelease(particles, line, radius):
 
 def pointInPolygon(demHeader, points, Line, radius):
     """ find particles within a polygon
-
     Parameters
     ----------
     demHeader: dict
@@ -1765,7 +1725,6 @@ def releaseSecRelArea(cfg, particles, fields, dem):
 
 def savePartToPickle(dictList, outDir, logName):
     """ Save each dictionary from a list to a pickle in outDir; works also for one dictionary instead of list
-
         Parameters
         ---------
         dictList: list or dict
@@ -1785,11 +1744,9 @@ def savePartToPickle(dictList, outDir, logName):
 
 def trackParticles(cfgTrackPart, dem, particlesList):
     """ track particles from initial area
-
         Find all particles in an initial area. Find the same particles in
         the other time steps (+ the children if they were splitted).
         Extract time series of given properties of the tracked particles
-
         Parameters
         -----------
         cfgTrackPart: configParser
@@ -1804,7 +1761,6 @@ def trackParticles(cfgTrackPart, dem, particlesList):
             dem dictionary
         particlesList: list
             list of particles dictionary
-
         Returns
         -------
         particlesList : list
@@ -1852,7 +1808,6 @@ def trackParticles(cfgTrackPart, dem, particlesList):
 
 def readFields(inDir, resType, simName='', flagAvaDir=True, comModule='com1DFA'):
     """ Read ascii files within a directory and return List of dicionaries
-
         Parameters
         -----------
         inDir: str
@@ -1898,7 +1853,6 @@ def readFields(inDir, resType, simName='', flagAvaDir=True, comModule='com1DFA')
 def exportFields(cfg, Tsave, fieldsList, demOri, outDir, logName):
     """ export result fields to Outputs directory according to result parameters and time step
         that can be specified in the configuration file
-
         Parameters
         -----------
         cfg: dict
@@ -1958,7 +1912,6 @@ def exportFields(cfg, Tsave, fieldsList, demOri, outDir, logName):
 
 def prepareVarSimDict(standardCfg, inputSimFiles, variationDict, simNameOld=''):
     """ Prepare a dictionary with simulations that shall be run with varying parameters following the variation dict
-
         Parameters
         -----------
         standardCfg : configParser object
@@ -2029,14 +1982,12 @@ def prepareVarSimDict(standardCfg, inputSimFiles, variationDict, simNameOld=''):
 
 def getSimTypeList(simTypeList, inputSimFiles):
     """ Define available simulation types of requested types
-
         Parameters
         -----------
         standardCfg : configParser object
             default configuration or local configuration
         inputSimFiles: dict
             info dict on available input data
-
         Returns
         --------
         simTypeList: list

--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -1268,9 +1268,16 @@ def computeEulerTimeStep(cfg, particles, fields, dt, dem, Tcpu, frictType):
     Tcpu : dict
         computation time dictionary
     """
+
+    flowDepthOption = cfg.getint('flowDepthOption')
+    headerNeighbourGrid = dem['headerNeighbourGrid']
+    headerNormalGrid = dem['header']
+
+    if flowDepthOption==1:
+        particles = DFAfunC.computeFlowDepthSPH(cfg, particles, headerNeighbourGrid, headerNormalGrid)
+
     # get forces
     startTime = time.time()
-
     # loop version of the compute force
     log.debug('Compute Force C')
     particles, force, fields = DFAfunC.computeForceC(cfg, particles, fields, dem, dt, frictType)
@@ -1330,6 +1337,8 @@ def computeEulerTimeStep(cfg, particles, fields, dt, dem, Tcpu, frictType):
     startTime = time.time()
     log.debug('update Fields C')
     # particles, fields = updateFields(cfg, particles, force, dem, fields)
+
+    #if flowDepthOption!=1 or viscOption !=2 :
     particles, fields = DFAfunC.updateFieldsC(cfg, particles, dem, fields)
     tcpuField = time.time() - startTime
     Tcpu['Field'] = Tcpu['Field'] + tcpuField

--- a/avaframe/com1DFA/com1DFACfg.ini
+++ b/avaframe/com1DFA/com1DFACfg.ini
@@ -86,6 +86,12 @@ sphKernelRadius = 5
 # number of particles defined by: MPPDIR= mass per particle direct, MPPDH= mass per particles through release thickness,
 # MPPKR= mass per particles through number of particles per kernel radius
 massPerParticleDeterminationMethod = MPPDH
+# Choice of artificial viscosity
+# 0) No artificial viscosity
+# 1) SAMOS artificial viscosity
+# 2) Ata artificial viscosity
+viscOption = 1
+massPerParticleDeterminationMethod = MPPDH
 # mass per particle [kg] (if MPPDIR is used)
 massPerPart = 1250
 # release thickness per particle (if MPPDH is used)

--- a/avaframe/com1DFA/com1DFACfg.ini
+++ b/avaframe/com1DFA/com1DFACfg.ini
@@ -72,12 +72,10 @@ stopCrit = 0.01
 # SPH gradient option
 # 0) No pressure gradients computed
 # 1) SamosAT style (no reprojecion on the surface, dz = 0 and gz is used)
-# 2) SamostAt but done in the cartesian coord system (will hopefully allow us to add the earth pressure coef)
-# 3) SamostAt but done in the local coord system (will hopefully allow us to add the earth pressure coef)
+# 2) SamosAT done in the cartesian coord system (reprojecion on the surface, dz != 0 and g3 is used)
+# 3) SamosAT but done in the local coord system (will hopefully allow us to add the earth pressure coef)
 # and this time reprojecion on the surface, dz not 0 and g3 is used
-# 4) same as 2) but correcting the gradient to get constant exact gradients
-# 5) same as 2) but correcting the gradient to get linear exact gradients
-sphOption = 2
+sphOption = 1
 # minimum SPH distance [m]
 minRKern = 0.001
 # sph kernel smoothing length [m]

--- a/avaframe/com1DFA/com1DFACfg.ini
+++ b/avaframe/com1DFA/com1DFACfg.ini
@@ -72,11 +72,12 @@ stopCrit = 0.01
 # SPH gradient option
 # 0) No pressure gradients computed
 # 1) SamosAT style (no reprojecion on the surface, dz = 0 and gz is used)
-# 2) SamostAt but done in the local coord system (will hopefully allow us to add the earth pressure coef)
+# 2) SamostAt but done in the cartesian coord system (will hopefully allow us to add the earth pressure coef)
+# 3) SamostAt but done in the local coord system (will hopefully allow us to add the earth pressure coef)
 # and this time reprojecion on the surface, dz not 0 and g3 is used
-# 3) same as 2) but correcting the gradient to get constant exact gradients
-# 4) same as 2) but correcting the gradient to get linear exact gradients
-sphOption = 1
+# 4) same as 2) but correcting the gradient to get constant exact gradients
+# 5) same as 2) but correcting the gradient to get linear exact gradients
+sphOption = 2
 # minimum SPH distance [m]
 minRKern = 0.001
 # sph kernel smoothing length [m]

--- a/avaframe/com1DFA/com1DFACfg.ini
+++ b/avaframe/com1DFA/com1DFACfg.ini
@@ -80,16 +80,15 @@ sphOption = 1
 minRKern = 0.001
 # sph kernel smoothing length [m]
 sphKernelRadius = 5
-
-#++++++++++++++++ Particles
-# number of particles defined by: MPPDIR= mass per particle direct, MPPDH= mass per particles through release thickness,
-# MPPKR= mass per particles through number of particles per kernel radius
-massPerParticleDeterminationMethod = MPPDH
 # Choice of artificial viscosity
 # 0) No artificial viscosity
 # 1) SAMOS artificial viscosity
 # 2) Ata artificial viscosity
 viscOption = 1
+
+#++++++++++++++++ Particles
+# number of particles defined by: MPPDIR= mass per particle direct, MPPDH= mass per particles through release thickness,
+# MPPKR= mass per particles through number of particles per kernel radius
 massPerParticleDeterminationMethod = MPPDH
 # mass per particle [kg] (if MPPDIR is used)
 massPerPart = 1250

--- a/avaframe/data/avaSimilaritySol/Inputs/simiSol_com1DFACfg.ini
+++ b/avaframe/data/avaSimilaritySol/Inputs/simiSol_com1DFACfg.ini
@@ -49,11 +49,12 @@ mindT = 0.01
 # SPH gradient option
 # 0) No pressure gradients computed
 # 1) SamosAT style (no reprojecion on the surface, dz = 0 and gz is used)
-# 2) SamostAt but done in the local coord system (will hopefully allow us to add the earth pressure coef)
+# 2) SamostAt but done in the cartesian coord system (will hopefully allow us to add the earth pressure coef)
+# 3) SamostAt but done in the local coord system (will hopefully allow us to add the earth pressure coef)
 # and this time reprojecion on the surface, dz not 0 and g3 is used
-# 3) same as 2) but correcting the gradient to get constant exact gradients
-# 4) same as 2) but correcting the gradient to get linear exact gradients
-sphOption = 1
+# 4) same as 2) but correcting the gradient to get constant exact gradients
+# 5) same as 2) but correcting the gradient to get linear exact gradients
+sphOption = 2
 # minimum SPH distance [m]
 minRKern = 0.001
 # sph kernel smoothing length [m]

--- a/avaframe/data/avaSimilaritySol/Inputs/simiSol_com1DFACfg.ini
+++ b/avaframe/data/avaSimilaritySol/Inputs/simiSol_com1DFACfg.ini
@@ -52,8 +52,6 @@ mindT = 0.01
 # 2) SamostAt but done in the cartesian coord system (will hopefully allow us to add the earth pressure coef)
 # 3) SamostAt but done in the local coord system (will hopefully allow us to add the earth pressure coef)
 # and this time reprojecion on the surface, dz not 0 and g3 is used
-# 4) same as 2) but correcting the gradient to get constant exact gradients
-# 5) same as 2) but correcting the gradient to get linear exact gradients
 sphOption = 2
 # minimum SPH distance [m]
 minRKern = 0.001

--- a/avaframe/data/avaSimilaritySol/Inputs/simiSol_com1DFACfg.ini
+++ b/avaframe/data/avaSimilaritySol/Inputs/simiSol_com1DFACfg.ini
@@ -48,17 +48,21 @@ mindT = 0.01
 #+++++++++++++SPH parameters
 # SPH gradient option
 # 0) No pressure gradients computed
-# 1) SamosAT style (no reprojecion on the surface, dz = 0 and dz is used)
+# 1) SamosAT style (no reprojecion on the surface, dz = 0 and gz is used)
 # 2) SamostAt but done in the local coord system (will hopefully allow us to add the earth pressure coef)
 # and this time reprojecion on the surface, dz not 0 and g3 is used
 # 3) same as 2) but correcting the gradient to get constant exact gradients
 # 4) same as 2) but correcting the gradient to get linear exact gradients
-sphOption = 2
+sphOption = 1
 # minimum SPH distance [m]
 minRKern = 0.001
 # sph kernel smoothing length [m]
-sphKernelRadius = 7.5
-
+sphKernelRadius = 5
+# Choice of artificial viscosity
+# 0) No artificial viscosity
+# 1) SAMOS artificial viscosity
+# 2) Ata artificial viscosity
+viscOption = 2
 
 #++++++++++++++++ Particles
 # number of particles defined by: MPPDIR= mass per particle direct, MPPDH= mass per particles through release thickness,
@@ -93,9 +97,6 @@ cMaxNPPK = 2.5
 cMinMass = 0.25
 # stop merging if the mass of the particles is bigger than cMaxnMass x massPerPart
 cMaxnMass = 5
-
-
-
 #+++++++++++++Mesh and interpolation
 # interpolation option
 # 3 Options available : -0: nearest neighbor interpolation

--- a/avaframe/tests/data/testCom1DFA/test_com1DFACfg.ini
+++ b/avaframe/tests/data/testCom1DFA/test_com1DFACfg.ini
@@ -72,21 +72,55 @@ stopCrit = 0.01
 # SPH gradient option
 # 0) No pressure gradients computed
 # 1) SamosAT style (no reprojecion on the surface, dz = 0 and gz is used)
-# 2) SamostAt but done in the local coord system (will hopefully allow us to add the earth pressure coef)
+# 2) SamosAT done in the cartesian coord system (reprojecion on the surface, dz != 0 and g3 is used)
+# 3) SamosAT but done in the local coord system (will hopefully allow us to add the earth pressure coef)
 # and this time reprojecion on the surface, dz not 0 and g3 is used
-# 3) same as 2) but correcting the gradient to get constant exact gradients
-# 4) same as 2) but correcting the gradient to get linear exact gradients
 sphOption = 1
 # minimum SPH distance [m]
 minRKern = 0.001
 # sph kernel smoothing length [m]
 sphKernelRadius = 5
-# number of particles defined by: MPPDIR= mass per particle direct, MPPDH= mass per particles through release thickness
+# Choice of artificial viscosity
+# 0) No artificial viscosity
+# 1) SAMOS artificial viscosity
+# 2) Ata artificial viscosity
+viscOption = 1
+
+#++++++++++++++++ Particles
+# number of particles defined by: MPPDIR= mass per particle direct, MPPDH= mass per particles through release thickness,
+# MPPKR= mass per particles through number of particles per kernel radius
 massPerParticleDeterminationMethod = MPPDH
-# mass per particle [kg]
+# mass per particle [kg] (if MPPDIR is used)
 massPerPart = 1250
-# release thickness per particle
+# release thickness per particle (if MPPDH is used)
 deltaTh = 0.25
+# number of particles per kernel radius (if MPPKR is used)
+nPPK = 15
+# splitting option
+# either split particles based on mass (splitOption = 0)
+# or split/merge in order to keep a constant number of particles per kernel radius(splitOption = 1)
+splitOption = 0
+
+# if splitOption=0
+# threshold for splitting particles, split if: mPart > massPerPart x thresholdMassSplit
+thresholdMassSplit = 1.5
+# when splitting a particle, the new one is placed at a distance distSplitPart x rPart
+distSplitPart = 0.41
+
+
+# if splitOption=1
+# in how many particles do we split
+nSplit = 2
+# coefficient ruling the splitting of particles. Split if the number of particles per sph kernel radius is smaller
+# than cMinNPPK x nPPK
+cMinNPPK = 0.25
+# coefficient ruling the merging of particles. Merge if the number of particles per sph kernel radius is bigger
+# than cMaxNPPK x nPPK
+cMaxNPPK = 2.5
+# stop splitting if the mass of the particles is lower than cMinMass x massPerPart
+cMinMass = 0.25
+# stop merging if the mass of the particles is bigger than cMaxnMass x massPerPart
+cMaxnMass = 5
 
 
 #+++++++++++++Mesh and interpolation


### PR DESCRIPTION
Implement Ata Viscosity and an SPH flow depth computation:

-> Ata viscosity: how to use it: viscOption=2
consists as an up-winding of the scheme.
that mean that the centered flux 1/2(F(xk)+F(xl)) is replaced by an upwinded flux : 1/2([F(xk)+F(xl)] - lambdakl(ul-uk)nkl)
It's like adding an SPH viscuous force under the form Pkl = -lambdakl(ul-uk)nkl
I let an option to symetrize the flux too


-> SPH flow depth computation: how to use it: flowDepthOption=1
instead of getting a flow depth bilinar interpolation, one can now use an SPH computation