### PR TITLE
Quickfix for AvaFrame Connector; documentation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include RELEASE-VERSION
+include avaframe/RELEASE-VERSION
 include avaframe/version.py
 include avaframe/in3Utils/logging.conf
 recursive-include avaframe *Cfg.ini

--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -13,7 +13,6 @@ import pickle
 from datetime import datetime
 import matplotlib.path as mpltPath
 from itertools import product
-from shapely.geometry import Polygon
 
 # Local imports
 import avaframe.in2Trans.shpConversion as shpConv

--- a/avaframe/com1DFA/particleInitialisation.py
+++ b/avaframe/com1DFA/particleInitialisation.py
@@ -7,7 +7,6 @@ import time
 import pathlib
 import numpy as np
 import copy
-from shapely.geometry import Polygon
 import matplotlib.pyplot as plt
 
 # Local imports
@@ -220,6 +219,9 @@ def createReleaseBuffer(cfg, inputSimLines):
         inputSimLines: dict
             updated inputSimLines with releaseLineBuffer
     """
+    # Note on this import: it is purely a quickfix for github issue
+    # https://github.com/avaframe/QGisAF/issues/9
+    from shapely.geometry import Polygon
 
     # get start indices and lengths of release polygons
     lengthRels = inputSimLines['releaseLine']['Length']

--- a/avaframe/version.py
+++ b/avaframe/version.py
@@ -50,7 +50,6 @@ def getProjectPath():
     path = os.path.expanduser(path)  # interpret ~
     path = os.path.abspath(path)  # convert to absolute path
     path = os.path.dirname(path)  # containing directory
-    path = os.path.dirname(path)  # containing directory: project dir
     return path
 
 

--- a/docs/Visualisation.rst
+++ b/docs/Visualisation.rst
@@ -4,7 +4,8 @@ Data Visualisation
 
 Main functions for creating visualisations of AvaFrame simulation results can be found in
 :py:mod:`out3Plot` and :py:mod:`out1Peak`.
-:py:mod:`com1DFA` also offers the possibility to export data on particle properties for visualisation using the open-source  application `**ParaView**<https://www.paraview.org/>`_.
+:py:mod:`com1DFA` also offers the possibility to export data on particle properties for visualisation
+using the open-source  application `ParaView <https://www.paraview.org/>`_.
 In order to start analysing particle data of :py:mod:`com1DFA`, follow these steps:
 
 in your local copy of ``com1DFA/com1DFACfg.ini``:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@ General
     * :doc:`logging`
     * :doc:`develop`
     * :doc:`testing`
+    * :doc:`visualisation`
     * :doc:`FAQ`
     * :doc:`releaseNotes`
     * :doc:`api`
@@ -34,6 +35,7 @@ General
    logging.rst
    develop.rst
    testing.rst
+   Visualisation.rst
    FAQ.rst
    releaseNotes.rst
    api.rst

--- a/docs/operational.rst
+++ b/docs/operational.rst
@@ -39,6 +39,8 @@ Setup AvaFrame
 
      python3 -m pip install --user --upgrade numpy pandas
 
+   and restart QGis.
+
 
 
 Setup QGis and run


### PR DESCRIPTION
This PR contains 
- a quickfix for shapely vs QGis problem with the AvaFrameConnector, see https://github.com/avaframe/QGisAF/issues/9
- Move Releseversion file for packaged releases
- Documentation improvements