### PR TITLE
Automatic split point

### DIFF
--- a/avaframe/ana1Tests/energyLineTest_com1DFACfg.ini
+++ b/avaframe/ana1Tests/energyLineTest_com1DFACfg.ini
@@ -30,7 +30,7 @@ tEnd = 400
 # to use a variable time step (time step depends on kernel radius)
 sphKernelRadiusTimeStepping = True
 # courant number
-cMax = 0.01
+cMax = 0.02
 # stopCriterion (based on massFlowing or kinEnergy)
 stopCritType = massFlowing
 # if based on massFlowing, specify the velocity threshold for flowing mass (m/s)
@@ -45,14 +45,14 @@ stopCrit = 0.0
 # 2) SamosAT done in the cartesian coord system (reprojecion on the surface, dz != 0 and g3 is used)
 # 3) SamosAT but done in the local coord system (will hopefully allow us to add the earth pressure coef)
 # and this time reprojecion on the surface, dz not 0 and g3 is used
-sphOption = 0
+sphOption = 2
 # sph kernel smoothing length [m]
 sphKernelRadius = 5
 # Choice of artificial viscosity
 # 0) No artificial viscosity
 # 1) SAMOS artificial viscosity
 # 2) Ata artificial viscosity
-viscOption = 0
+viscOption = 1
 
 #++++++++++++++++ Particles
 # number of particles defined by: MPPDIR= mass per particle direct, MPPDH= mass per particles through release thickness,
@@ -80,11 +80,11 @@ meshCellSize = 5
 
 #+++++++++++++Flow model parameters+++++++++
 # subgridMixingFactor
-subgridMixingFactor = 10.
+subgridMixingFactor = 100.
 # curvature acceleration coefficient
 # take curvature term into account in the gravity acceleration term
 # 0 if deactivated, 1 if activated
-curvAcceleration = 0
+curvAcceleration = 1
 
 #++++++++++++Friction model
 # add the friction using an explicit formulation (1)
@@ -94,7 +94,7 @@ explicitFriction = 1
 frictModel = Coulomb
 #+++++++++++++General Friction parameters
 # tan of bed friction angle used for: samosAT, Coulomb, Voellmy
-mu = 0.6
+mu = 0.4
 
 [ENERGYLINETEST]
 # when extrapolating, add steps of extrapolationStepSize * sMax

--- a/avaframe/ana1Tests/simiSolTest.py
+++ b/avaframe/ana1Tests/simiSolTest.py
@@ -80,7 +80,7 @@ def mainSimilaritySol(simiSolCfg):
     eps_y = H/L_y
 
     # Full scale end time
-    T_end = cfgGen.getfloat('tEnd') + cfgGen.getfloat('maxdT')
+    T_end = cfgGen.getfloat('tEnd') + 1
 
     # Non dimensional time for similarity sim calculation
     t_1 = 0.1         # start time for ode solvers, end time for early time sol (we need t_1<<1)

--- a/avaframe/ana5Utils/DFAPathGeneration.py
+++ b/avaframe/ana5Utils/DFAPathGeneration.py
@@ -6,8 +6,11 @@
 import math
 import numpy as np
 import logging
+import pathlib
+import shutil
 
 # Local imports
+import avaframe.in2Trans.shpConversion as shpConv
 from avaframe.in3Utils import cfgUtils
 import avaframe.in3Utils.geoTrans as gT
 import avaframe.com1DFA.particleTools as particleTools
@@ -51,10 +54,13 @@ def generateAveragePath(avalancheDir, pathFromPart, simName, dem, addVelocityInf
         mass averaged profile (x, y, z, 's')
         if addVelocityInfo is True, kinetic energy and velocity information are added to
         the avaProfileMass dict (u2, ekin, totEKin)
+    particlesIni: dict
+        x, y coord of the initial particles or flow thickness field
     """
     if pathFromPart:
         particlesList, timeStepInfo = particleTools.readPartFromPickle(avalancheDir, simName=simName, flagAvaDir=True,
                                                                        comModule='com1DFA')
+        particlesIni = particlesList[0]
         log.info('Using particles to generate avalanche path profile')
         # postprocess to extract path and energy line
         avaProfileMass = getDFAPathFromPart(particlesList, addVelocityInfo=addVelocityInfo)
@@ -66,11 +72,21 @@ def generateAveragePath(avalancheDir, pathFromPart, simName, dem, addVelocityInf
             fieldName.append['FV']
         fieldsList, fieldHeader, timeList = com1DFA.readFields(avalancheDir, fieldName, simName=simName,
                                                                flagAvaDir=True, comModule='com1DFA')
+        # get fields header
+        ncols = fieldHeader['ncols']
+        nrows = fieldHeader['nrows']
+        csz = fieldHeader['cellsize']
+        # we want the origin to be in (0, 0) as it is in the avaProfile that comes in
+        X, Y = gT.makeCoordinateGrid(0, 0, csz, ncols, nrows)
+        indNonZero = np.where(fieldsList[0]['FD'] > 0)
+        # convert this data in a particles style (dict with x, y, z info)
+        particlesIni = {'x': X[indNonZero], 'y': Y[indNonZero]}
+        particlesIni, _ = gT.projectOnRaster(dem, particlesIni)
         log.info('Using fields to generate avalanche path profile')
         # postprocess to extract path and energy line
         avaProfileMass = getDFAPathFromField(fieldsList, fieldHeader, dem)
 
-    return avaProfileMass
+    return avaProfileMass, particlesIni
 
 
 def getDFAPathFromPart(particlesList, addVelocityInfo=False):
@@ -205,72 +221,7 @@ def getDFAPathFromField(fieldsList, fieldHeader, dem):
     return avaProfileMass
 
 
-def extendDFAPath(avalancheDir, cfg, dem, simName, avaProfile):
-    """ extend the DFA path at the top (release) and bottom (runout area)
-    cfg['pathFromPart'] decides if the path is extended from particles dict or fields
-    Call extendDFAPathKernel for extending the path avaProfile with x, y, z, s information
-
-    Parameters
-    -----------
-    avalancheDir: str or pathlib path
-        path to avalanche directory
-    cfg: configParser
-        configuration object with:
-        pathFromPart: boolean
-            read information from particles file or fields file
-        extTopOption: int
-        how to extend towards the top?
-            0 for highest point method
-            a for largest runout method
-        nCellsResample: int
-            resampling length is given by nCellsResample*demCellSize
-        nCellsMinExtend: int
-            when extending towards the bottom, take points at more than nCellsMinExtend*demCellSize
-            from last point to get the direction
-        nCellsMaxExtend: int
-            when extending towards the bottom, take points at less than nCellsMaxExtend*demCellSize
-            from last point to get the direction
-        factBottomExt: float
-            extend the profile from factBottomExt*sMax
-    dem: dict
-        dem dict
-    simName: str
-        simHash or name
-    avaProfile: dict
-        profile to be extended
-    Returns
-    --------
-    avaProfileExt: dict
-        extended profile at top and bottom (x, y, z).
-    """
-    # read inputs from particles or fields
-    if cfg.getboolean('pathFromPart'):
-        # read particles
-        particlesList, timeStepInfo = particleTools.readPartFromPickle(avalancheDir, simName=simName, flagAvaDir=True,
-                                                                       comModule='com1DFA')
-        particlesIni = particlesList[0]
-        log.info('Using particles to generate avalanche path profile')
-    else:
-        # read field
-        fieldsList, fieldHeader, timeList = com1DFA.readFields(avalancheDir, ['FT'], simName=simName,
-                                                               flagAvaDir=True, comModule='com1DFA', timeStep=0)
-        # get fields header
-        ncols = fieldHeader['ncols']
-        nrows = fieldHeader['nrows']
-        csz = fieldHeader['cellsize']
-        # we want the origin to be in (0, 0) as it is in the avaProfile that comes in
-        X, Y = gT.makeCoordinateGrid(0, 0, csz, ncols, nrows)
-        indNonZero = np.where(fieldsList[0]['FT'] > 0)
-        # convert this data in a particles style (dict with x, y, z info)
-        particlesIni = {'x': X[indNonZero], 'y': Y[indNonZero]}
-        particlesIni, _ = gT.projectOnRaster(dem, particlesIni)
-        log.info('Using fields to generate avalanche path profile')
-
-    avaProfileExt = extendDFAPathKernel(cfg, avaProfile, dem, particlesIni)
-    return avaProfileExt
-
-
-def extendDFAPathKernel(cfg, avaProfile, dem, particlesIni):
+def extendDFAPath(cfg, avaProfile, dem, particlesIni):
     """ extend the DFA path at the top and bottom
     avaProfile with x, y, z, s information
 
@@ -301,24 +252,15 @@ def extendDFAPathKernel(cfg, avaProfile, dem, particlesIni):
 
     Returns
     --------
-    avaProfileExt: dict
+    avaProfile: dict
         extended profile at top and bottom (x, y, z).
     """
     # resample the profile
     resampleDistance = cfg.getfloat('nCellsResample') * dem['header']['cellsize']
+    avaProfile, _ = gT.prepareLine(dem, avaProfile, distance=resampleDistance, Point=None)
     avaProfile = extendProfileTop(cfg.getint('extTopOption'), particlesIni, avaProfile)
-    avaProfile, _ =  gT.prepareLine(dem, avaProfile, distance=resampleDistance, Point=None)
     avaProfile = extendProfileBottom(cfg, dem, avaProfile)
-    avaProfile, _ =  gT.prepareLine(dem, avaProfile, distance=resampleDistance, Point=None)
-    # project the profile on the dem
-    avaProfile, _ =  gT.projectOnRaster(dem, avaProfile, interp='bilinear')
-    # remove points that lay outside of the dem
-    isNotNan = ~(np.isnan(avaProfile['z']))
-    avaProfileExt = {}
-    avaProfileExt['x'] = avaProfile['x'][isNotNan]
-    avaProfileExt['y'] = avaProfile['y'][isNotNan]
-    avaProfileExt['z'] = avaProfile['z'][isNotNan]
-    return avaProfileExt
+    return avaProfile
 
 
 def extendProfileTop(extTopOption, particlesIni, profile):
@@ -345,10 +287,13 @@ def extendProfileTop(extTopOption, particlesIni, profile):
     """
     if extTopOption == 0:
         # get highest particle
-        indHighest = np.argmax(particlesIni['z'])
-        xExtTop = particlesIni['x'][indHighest]
-        yExtTop = particlesIni['y'][indHighest]
-        zExtTop = particlesIni['z'][indHighest]
+        indTop = np.argmax(particlesIni['z'])
+        xExtTop = particlesIni['x'][indTop]
+        yExtTop = particlesIni['y'][indTop]
+        zExtTop = particlesIni['z'][indTop]
+        dx = xExtTop - profile['x'][0]
+        dy = yExtTop - profile['y'][0]
+        ds = np.sqrt(dx**2 + dy**2)
     elif extTopOption == 1:
         # get point with the most important runout gain
         # get first particle of the path
@@ -373,11 +318,13 @@ def extendProfileTop(extTopOption, particlesIni, profile):
         xExtTop = particlesIni['x'][indTop]
         yExtTop = particlesIni['y'][indTop]
         zExtTop = particlesIni['z'][indTop]
+        ds = ds[indTop]
 
     # extend profile
     profile['x'] = np.append(xExtTop, profile['x'])
     profile['y'] = np.append(yExtTop, profile['y'])
     profile['z'] = np.append(zExtTop, profile['z'])
+    profile['s'] = np.append(0, profile['s'] + ds)
     if debugPlot:
         debPlot.plotPathExtTop(profile, particlesIni, xFirst, yFirst, zFirst, dz1)
     return profile
@@ -436,19 +383,237 @@ def extendProfileBottom(cfg, dem, profile):
     vDirZ = np.sum(vDirZ)
     vDirX, vDirY, vDirZ = DFAtls.normalize(np.array([vDirX]), np.array([vDirY]), np.array([vDirZ]))
     # extend in this direction
-    gamma = cfg.getfloat('factBottomExt') * sLast / np.sqrt(vDirX**2 + vDirY**2)
+    factExt = cfg.getfloat('factBottomExt')
+    gamma = factExt * sLast / np.sqrt(vDirX**2 + vDirY**2)
     xExtBottom = np.array([xLast + gamma * vDirX])
     yExtBottom = np.array([yLast + gamma * vDirY])
-    # project on cszDEM
-    zExtBottom, _ =  gT.projectOnGrid(xExtBottom, yExtBottom, zRaster, csz=csz)
+    # project on DEM
+    zExtBottom, _ = gT.projectOnGrid(xExtBottom, yExtBottom, zRaster, csz=csz)
+    # Dicothomie method to find the last point on the extention and on the dem
+    if np.isnan(zExtBottom):
+        factExt = factExt/2
+        stepSize = factExt
+        isOut = True
+    else:
+        isOut = False
+        stepSize = 0
+    count = 0
+    # remember last point found inside
+    factLast = 0
+    while count < cfg.getint('maxIterationExtBot') and stepSize * sLast > cfg.getint('nBottomExtPrecision')*csz:
+        count = count + 1
+        gamma = factExt * sLast / np.sqrt(vDirX**2 + vDirY**2)
+        xExtBottom = np.array([xLast + gamma * vDirX])
+        yExtBottom = np.array([yLast + gamma * vDirY])
+        # project on DEM
+        zExtBottom, _ = gT.projectOnGrid(xExtBottom, yExtBottom, zRaster, csz=csz)
+        stepSize = stepSize/2
+        if np.isnan(zExtBottom):
+            factExt = factExt - stepSize
+            isOut = True
+        else:
+            # remember last point found inside
+            factLast = factExt
+            factExt = factExt + stepSize
+            isOut = False
+
+    if isOut:
+        # the last iteration is not in the domain, fall back to last point in domain
+        factExt = factLast
+        gamma = factExt * sLast / np.sqrt(vDirX**2 + vDirY**2)
+        xExtBottom = np.array([xLast + gamma * vDirX])
+        yExtBottom = np.array([yLast + gamma * vDirY])
+        # project on DEM
+        zExtBottom, _ = gT.projectOnGrid(xExtBottom, yExtBottom, zRaster, csz=csz)
+    log.info('found extention after %d iterations, precision is %.2f m' % (count, stepSize * sLast))
+
     # extend profile
     profile['x'] = np.append(profile['x'], xExtBottom)
     profile['y'] = np.append(profile['y'], yExtBottom)
     profile['z'] = np.append(profile['z'], zExtBottom)
+    profile['s'] = np.append(profile['s'], sLast + np.sqrt((xLast-xExtBottom)**2 + (yLast-yExtBottom)**2))
 
     if debugPlot:
         debPlot.plotPathExtBot(profile, xInterest, yInterest, 0*yInterest, xLast, yLast)
     return profile
+
+
+def getParabolicFit(cfg, avaProfile, dem):
+    """fit a parabola on a set of (s, z) points
+
+    first and last point match. Last constraint is given by fitOption (see below)
+    Parameters
+    -----------
+    cfg: configParser
+        configuration object with:
+        fitOption: int
+        how to optimize the fit
+            0 minimize distance between points
+            1 match the end slope
+    avaProfile: dict
+        profile to be extended
+    dem: dict
+        dem dict
+    Returns
+    --------
+    parabolicFit: dict
+        a, b, c coefficients of the parabolic fit (y = a*a*x + b*x + c)
+    """
+    s = avaProfile['s']
+    sE = s[-1]
+    z = avaProfile['z']
+    z0 = z[0]
+    zE = z[-1]
+    # same start and end point, minimize distance between curves
+    if cfg.getfloat('fitOption') == 0:
+        SumNom = np.sum(s*(s-sE)*((zE-z0)/sE*s+z0-z))
+        SumDenom = s*(s-sE)
+        SumDenom = np.dot(SumDenom, SumDenom)
+        a = - SumNom/SumDenom
+        b = (zE-z0)/sE - a*sE
+    elif cfg.getfloat('fitOption') == 1:
+        angleProf, tmpProf, dsProf = gT.prepareAngleProfile(10, avaProfile, raiseWarning=False)
+        r = avaProfile['s'] - avaProfile['s'][-1]
+        resampleDistance = cfg.getfloat('nCellsSlope') * dem['header']['cellsize']
+        pointsOfInterestLast = np.where(np.abs(r) < resampleDistance)
+        slope = np.nansum(angleProf[pointsOfInterestLast])/np.size(pointsOfInterestLast)
+        slope = -np.tan(np.radians(slope))
+        a = (slope*sE + (z0 - zE))/(sE*sE)
+        b = -slope - 2*(z0 - zE)/sE
+    c = z0
+    parabolicFit = {'a': a, 'b': b, 'c': c}
+    return parabolicFit
+
+
+def getSplitPoint(cfg, avaProfile, parabolicFit):
+    """ find the split point corresponding to an avalanche profile, with parabolic fit and the slopeSplitPoint
+
+    Parameters
+    -----------
+    cfg: configParser
+        configuration object with:
+        slopeSplitPoint: float
+            desired slope at split point (in degrees)
+        dsMin: float
+            threshold distance [m] for looking for the split point (at least dsMin meters below
+            split point angle)
+    avaProfile: dict
+        profile to be extended
+    parabolicFit: dict
+        a, b, c coeficients of the parabolic fit (y = a*a*x + b*x + c)
+    Returns
+    --------
+    splitPoint: dict
+        (x, y, z, zPra, s) at split point location.
+    """
+    indFirst = avaProfile['indStartMassAverage']
+    indEnd = avaProfile['indEndMassAverage']
+    s0 = avaProfile['s'][indFirst]
+    sEnd = avaProfile['s'][indEnd]
+    s = avaProfile['s']
+    z = avaProfile['z']
+    sNew = s - s0
+    zPara = parabolicFit['a']*sNew*sNew+parabolicFit['b']*sNew+parabolicFit['c']
+    parabolicProfile = {'s': sNew, 'z': zPara}
+
+    anglePara, tmpPara, dsPara = gT.prepareAngleProfile(cfg.getfloat('slopeSplitPoint'), parabolicProfile,
+                                                        raiseWarning=False)
+    try:
+        indSplitPoint = gT.findAngleProfile(tmpPara, dsPara, cfg.getfloat('dsMin'))
+        splitPoint = {'x': avaProfile['x'][indSplitPoint], 'y': avaProfile['y'][indSplitPoint],
+                      'z': z[indSplitPoint], 'zPara': zPara[indSplitPoint], 's': sNew[indSplitPoint]}
+    except IndexError:
+        noSplitPointFoundMessage = ('Automated split point generation failed as no point where slope is less than %s°'
+                                    'was found, provide the split point manually.' % cfg.getfloat('slopeSplitPoint'))
+        splitPoint = ''
+        log.warning(noSplitPointFoundMessage)
+    if debugPlot:
+        angleProf, tmpProf, dsProf = gT.prepareAngleProfile(cfg.getfloat('slopeSplitPoint'), avaProfile)
+        debPlot.plotFindAngle(avaProfile, angleProf, parabolicProfile, anglePara, s0, sEnd, splitPoint, indSplitPoint)
+    return splitPoint
+
+
+def resamplePath(cfg, dem, avaProfile):
+    """
+    resample the path profile and keep track of indStartMassAverage and indEndMassAverage
+    Parameters
+    -----------
+    cfg: configParser
+        configuration object with:
+            nCellsResample: int
+                resampling length is given by nCellsResample*demCellSize
+    dem: dict
+        dem dict
+    avaProfile: dict
+        profile to be resampled
+    Returns
+    --------
+    avaProfile: dict
+        resampled path profile
+    """
+    resampleDistance = cfg.getfloat('nCellsResample') * dem['header']['cellsize']
+    indFirst = avaProfile['indStartMassAverage']
+    indEnd = avaProfile['indEndMassAverage']
+    s0 = avaProfile['s'][indFirst]
+    sEnd = avaProfile['s'][indEnd]
+    avaProfile, _ = gT.prepareLine(dem, avaProfile, distance=resampleDistance, Point=None)
+    # make sure we get the good start and end point... prepareLine might make a small error on the s coord
+    indFirst = np.argwhere(avaProfile['s'] >= s0 - resampleDistance/3)[0][0]
+    # look for the first point in the extension and take the one before
+    indEnd = np.argwhere(avaProfile['s'] >= sEnd + resampleDistance/3)[0][0]-1
+    avaProfile['indStartMassAverage'] = indFirst
+    avaProfile['indEndMassAverage'] = indEnd
+    return avaProfile
+
+
+def saveSplitAndPath(avalancheDir, simDFrow, splitPoint, avaProfileMass, dem):
+    """
+    Save avaPath and split point to directory
+
+    Parameters
+    -----------
+    avalancheDir: pathlib
+        avalanche directory pathlib path
+    simDFrow: pandas series
+        row of the siulation dataframe coresponding to the current simulation analyzed
+    splitPoint: dict
+        point dictionary
+    avaProfileMass: dict
+        line dictionary
+    dem: dict
+        com1DFA simulation dictionary
+    Returns
+    --------
+    avaProfile: dict
+        resampled path profile
+    """
+    # put path back in original location
+    if splitPoint != '':
+        splitPoint['x'] = splitPoint['x'] + dem['originalHeader']['xllcenter']
+        splitPoint['y'] = splitPoint['y'] + dem['originalHeader']['yllcenter']
+    avaProfileMass['x'] = avaProfileMass['x'] + dem['originalHeader']['xllcenter']
+    avaProfileMass['y'] = avaProfileMass['y'] + dem['originalHeader']['yllcenter']
+    # get projection from release shp layer
+    simName = simDFrow['simName']
+    relName = simName.split('_')[0]
+    inProjection = pathlib.Path(avalancheDir, 'Inputs', 'REL', relName + '.prj')
+    # save profile in Inputs
+    pathAB = pathlib.Path(avalancheDir, 'Outputs', 'DFAPath', 'massAvgPath_%s_AB_aimec' % simName)
+    name = 'massAvaPath'
+    shpConv.writeLine2SHPfile(avaProfileMass, name, pathAB)
+    if inProjection.is_file():
+        shutil.copy(inProjection, pathAB.with_suffix('.prj'))
+    else:
+        message = ('No projection layer for shp file %s' % inProjection)
+        log.warning(message)
+    log.info('Saved path to: %s', pathAB)
+    if splitPoint != '':
+        splitAB = pathlib.Path(avalancheDir, 'Outputs', 'DFAPath', 'splitPointParabolicFit_%s_AB_aimec' % simName)
+        name = 'parabolaSplitPoint'
+        shpConv.writePoint2SHPfile(splitPoint, name, splitAB)
+        if inProjection.is_file():
+            shutil.copy(inProjection, splitAB.with_suffix('.prj'))
+        log.info('Saved split point to: %s', splitAB)
 
 
 def weightedAvgAndStd(values, weights):

--- a/avaframe/ana5Utils/DFAPathGenerationCfg.ini
+++ b/avaframe/ana5Utils/DFAPathGenerationCfg.ini
@@ -1,7 +1,7 @@
 [PATH]
 # the path extracted from the DFA simulation is re-sampled
 # re-sampling step size is defined resampleDistance = nCellsResample x cellSize)
-nCellsResample = 5
+nCellsResample = 10
 
 # extension method at the top
 # option 0: take the highest particle in the release
@@ -14,9 +14,32 @@ extTopOption = 1
 # from the end)
 nCellsMinExtend = 1
 nCellsMaxExtend = 20
+# this value needs to be chosen in accordance with nCellsResample (if nCellsMaxExtend < nCellsResample no points
+# might be found for the path extension process)
 
-# for the extrapolation at the bottom, add factBottomExt * sMax to the path
+# for the extrapolation at the bottom, add factBottomExt * sMax to the path (and then check if the extension
+# is on the DEM, if not iterate by dichotomy until we find a point on the topography or reach a maximum
+# iteration number (integer, in this case we pick the last point found inside the dem)
+# or precision (nBottomExtPrecision * cellSize))
 factBottomExt = 0.3
+maxIterationExtBot = 10
+nBottomExtPrecision = 10
+
+# split point finding
+# first fit a parabola on the non extended path. Start and end point match the profile
+# the 3rd constraint is given by:
+# fitOption == 0: minimize distance between parabola and profile
+# fitOption == 1: match slope of parabola and profile at the end point
+fitOption = 0
+# if fitOption == 1, use the points at distance < nCellsSlope x cellSize to estimate the end slope
+nCellsSlope = 5
+
+# slope angle on parabolic fit for split point
+slopeSplitPoint = 20
+
+# threshold distance [m]. When looking for the split point make sure at least
+# dsMin meters after the split point also have an angle bellow slopeSplitPoint
+dsMin = 20
 
 # True to get the path from particles, False to get the path from fields (FT and FM)
 pathFromPart = True

--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -1279,11 +1279,9 @@ def DFAIterate(cfg, particles, fields, dem, simHash=''):
     # add initial time step to Tsave array
     Tsave = [0]
     # derive time step for first iteration
-    if cfgGen.getboolean('cflTimeStepping') and nIter > cfgGen.getfloat('cflIterConstant'):
-        # overwrite the dt value in the cfg
-        dt = tD.getcflTimeStep(particles, dem, cfgGen)
-    elif cfgGen.getboolean('sphKernelRadiusTimeStepping'):
-        dt = tD.getSphKernelRadiusTimeStep(dem, cfgGen)
+    if cfgGen.getboolean('sphKernelRadiusTimeStepping'):
+        dtSPHKR = tD.getSphKernelRadiusTimeStep(dem, cfgGen)
+        dt = dtSPHKR
     else:
         # get time step
         dt = cfgGen.getfloat('dt')
@@ -1330,11 +1328,8 @@ def DFAIterate(cfg, particles, fields, dem, simHash=''):
             dtSave = updateSavingTimeStep(dtSave, cfg['GENERAL'], t)
 
         # derive time step
-        if cfgGen.getboolean('cflTimeStepping') and nIter > cfgGen.getfloat('cflIterConstant'):
-            # overwrite the dt value in the cfg
-            dt = tD.getcflTimeStep(particles, dem, cfgGen)
-        elif cfgGen.getboolean('sphKernelRadiusTimeStepping'):
-            dt = tD.getSphKernelRadiusTimeStep(dem, cfgGen)
+        if cfgGen.getboolean('sphKernelRadiusTimeStepping'):
+            dt = dtSPHKR
         else:
             # get time step
             dt = cfgGen.getfloat('dt')

--- a/avaframe/com1DFA/com1DFACfg.ini
+++ b/avaframe/com1DFA/com1DFACfg.ini
@@ -106,22 +106,10 @@ entTh =
 dt = 0.1
 # End time [s]
 tEnd = 400
-# only one of the two following options can be activated
-# to use a variable time step (defined by the CFL number)
-cflTimeStepping = False
 # to use a variable time step (time step depends on kernel radius)
 sphKernelRadiusTimeStepping = False
-# courant number if option cflTimeStepping is chosen.
 # Upper time step limit coefficient if option sphKernelRadiusTimeStepping is chosen.
 cMax = 0.5
-# number of iterations with constant time step set to dt at the beginning
-cflIterConstant = 5
-# to constrain the lower margin of the allowed time step
-constrainCFL = False
-# max time step in case of small velocities
-maxdT = 0.5
-# min time step in case of high velocity
-mindT = 0.01
 # stopCriterion (based on massFlowing or kinEnergy)
 stopCritType = kinEnergy
 # if based on massFlowing, specify the velocity threshold for flowing mass (m/s)

--- a/avaframe/com1DFA/timeDiscretizations.py
+++ b/avaframe/com1DFA/timeDiscretizations.py
@@ -4,47 +4,10 @@
 
 # Load modules
 import logging
-import numpy as np
-
-# Local imports
-import avaframe.com1DFA.DFAtools as DFAtls
-
 
 # create local logger
 # change log level in calling module to DEBUG to see log messages
 log = logging.getLogger(__name__)
-
-
-def getcflTimeStep(particles, dem, cfg):
-    """ Compute cfl time step  """
-
-    # determine max velocity of particles
-    vmagnitude = DFAtls.norm(particles['ux'], particles['uy'], particles['uz'])
-    vMax = np.amax(vmagnitude)
-
-    # get cell size
-    cszDEM = dem['header']['cellsize']
-    cszNeighbourGrid = dem['headerNeighbourGrid']['cellsize']
-    # use the smallest of those two values
-    csz = min(cszDEM, cszNeighbourGrid)
-
-    # courant number
-    cMax = float(cfg['cMax'])
-
-    # compute stable time step
-    # if velocity is zero - divided by zero error so to avoid:
-    if vMax <= (cMax * csz)/float(cfg['maxdT']):
-        dtStable = float(cfg['maxdT'])
-    else:
-        dtStable = (cMax * csz) / vMax
-        if cfg.getboolean('constrainCFL'):
-            if dtStable < float(cfg['mindT']):
-                dtStable = float(cfg['mindT'])
-
-    log.debug('dtStable is with cMAX=%.1f is: %.4f with vMax:%.2f' % (cMax, dtStable, vMax))
-
-    # return stable time step
-    return dtStable
 
 
 def getSphKernelRadiusTimeStep(dem, cfg):

--- a/avaframe/com2AB/com2AB.py
+++ b/avaframe/com2AB/com2AB.py
@@ -327,7 +327,11 @@ def calcABAngles(avaProfile, eqParameters, dsMin):
     angle, tmp, ds = geoTrans.prepareAngleProfile(betaValue, avaProfile)
     # find the beta point: first point under the beta angle
     # (make sure that the dsMin next meters are also under te beta angle)
-    indBetaPoint = geoTrans.findAngleProfile(tmp, ds, dsMin)
+    try:
+        indBetaPoint = geoTrans.findAngleProfile(tmp, ds, dsMin)
+    except IndexError:
+        noBetaFoundMessage = 'No Beta point found. Check your pathAB.shp and splitPoint.shp.'
+        raise IndexError(noBetaFoundMessage)
     if debugPlot:
         debPlot.plotSlopeAngle(s, angle, indBetaPoint)
         debPlot.plotProfile(s, z, indBetaPoint)

--- a/avaframe/com3Hybrid/com3Hybrid.py
+++ b/avaframe/com3Hybrid/com3Hybrid.py
@@ -68,7 +68,7 @@ def maincom3Hybrid(cfgMain, cfgHybrid):
         # postprocess to extract path and energy line
         avaProfileMass = DFAPath.getDFAPathFromPart(particlesList, addVelocityInfo=True)
         # make a copy because extendDFAPathKernel might modify avaProfileMass
-        avaProfileMassExt = DFAPath.extendDFAPathKernel(cfgHybrid['PATH'], avaProfileMass.copy(), dem, particlesList[0])
+        avaProfileMassExt = DFAPath.extendDFAPath(cfgHybrid['PATH'], avaProfileMass.copy(), dem, particlesList[0])
         avaProfileMassExtOri = copy.deepcopy(avaProfileMassExt)
         avaProfileMassExtOri['x'] = avaProfileMassExtOri['x'] + demOri['header']['xllcenter']
         avaProfileMassExtOri['y'] = avaProfileMassExtOri['y'] + demOri['header']['yllcenter']

--- a/avaframe/com3Hybrid/com3HybridCfg.ini
+++ b/avaframe/com3Hybrid/com3HybridCfg.ini
@@ -5,7 +5,7 @@
 
 [GENERAL]
 # iterate for maximum nIterMax iteration and as long as the change in alpha > alphaThreshold (degrees)
-nIterMax = 2
+nIterMax = 4
 alphaThreshold = 0.1
 
 
@@ -28,7 +28,8 @@ nCellsMinExtend = 2
 nCellsMaxExtend = 20
 
 # for the extrapolation at the bottom, add factBottomExt * sMax to the path
-factBottomExt = 0.5
+factBottomExt = 0.2
+bottomExtPrecision = 0.01
 
 
 [DFA]

--- a/avaframe/com3Hybrid/hybridModel_com1DFACfg.ini
+++ b/avaframe/com3Hybrid/hybridModel_com1DFACfg.ini
@@ -78,7 +78,7 @@ meshCellSize = 5
 
 #+++++++++++++Flow model parameters+++++++++
 # subgridMixingFactor
-subgridMixingFactor = 10.
+subgridMixingFactor = 100.
 # curvature acceleration coefficient
 # take curvature term into account in the gravity acceleration term
 # 0 if deactivated, 1 if activated
@@ -92,7 +92,7 @@ explicitFriction = 1
 frictModel = Coulomb
 #+++++++++++++General Friction parameters
 # tan of bed friction angle used for: samosAT, Coulomb, Voellmy
-mu = 0.40375846095054385
+mu = 0.6073
 
 [REPORT]
 # which result parameters shall be included as plots in report,  - separated by |

--- a/avaframe/in2Trans/shpConversion.py
+++ b/avaframe/in2Trans/shpConversion.py
@@ -65,11 +65,7 @@ def SHP2Array(infile, defname=None):
     id = None
 
     # get coordinate system
-    prjfile = infile.with_suffix('.prj')
-    if prjfile.is_file():
-        prjf = open(prjfile, 'r')
-        sks = prjf.readline()
-        prjf.close()
+    sks = getSHPProjection(infile)
 
     # Start reading the shapefile
     records = sf.shapeRecords()
@@ -148,6 +144,32 @@ def SHP2Array(infile, defname=None):
     sf.close()
 
     return SHPdata
+
+
+def getSHPProjection(infile):
+    """ Fetch projection from shp file
+
+    Parameters
+    ----------
+    infile: str
+        path to shape file
+
+    Returns
+    -------
+    sks: str
+        projection string (if available, None if not)
+    """
+    # get coordinate system
+    prjfile = infile.with_suffix('.prj')
+    if prjfile.is_file():
+        prjf = open(prjfile, 'r')
+        sks = prjf.readline()
+        prjf.close()
+        return sks
+    else:
+        message = ('No projection layer for shp file %s' % infile)
+        log.warning(message)
+        return None
 
 
 def readThickness(infile, defname=None):
@@ -383,5 +405,30 @@ def writeLine2SHPfile(lineDict, lineName, fileName):
     w.field('name', 'C')
     w.line([line])
     w.record(lineName)
+    w.close()
+    return fileName
+
+
+def writePoint2SHPfile(pointDict, pointName, fileName):
+    """ write a point to shapefile
+
+    Parameters
+    ----------
+    pointDict: dict
+        point dict
+    pointName: str
+        point name
+    fileName: str or pathlib path
+        path where the point will be saved
+    Returns
+    -------
+    fileName : str
+        path where the point has been saved
+    """
+    fileName = str(fileName)
+    w = shapefile.Writer(fileName)
+    w.field('name', 'C')
+    w.point(pointDict['x'], pointDict['y'])
+    w.record(pointName)
     w.close()
     return fileName

--- a/avaframe/in3Utils/geoTrans.py
+++ b/avaframe/in3Utils/geoTrans.py
@@ -633,11 +633,11 @@ def findAngleProfile(tmp, ds, dsMin):
     idsAnglePoint: int
         index of beta point
     """
-    noBetaFoundMessage = 'No Beta point found. Check your pathAB.shp and splitPoint.shp.'
+    noPointFoundMessage = 'No point found. Check the angle and threshold distance.'
     i = 0
     condition = True
     if np.size(tmp) == 0:
-        raise IndexError(noBetaFoundMessage)
+        raise IndexError(noPointFoundMessage)
     while (i <= np.size(tmp) and condition):
         ind = tmp[i]
         j = 0
@@ -647,7 +647,7 @@ def findAngleProfile(tmp, ds, dsMin):
                 condition = condition and (tmp[i+j+1] == ind+j+1)
                 dist = dist + ds[i + j]
             except IndexError:
-                raise IndexError(noBetaFoundMessage)
+                raise IndexError(noPointFoundMessage)
             if not condition:
                 i = i + j + 1
                 break
@@ -659,7 +659,7 @@ def findAngleProfile(tmp, ds, dsMin):
     return idsAnglePoint
 
 
-def prepareAngleProfile(beta, avaProfile):
+def prepareAngleProfile(beta, avaProfile, raiseWarning=True):
     """Prepare inputs for findAngleProfile function
     Read profile (s, z), compute the slope Angle
     look for points for which the slope is under the given Beta value and
@@ -671,6 +671,8 @@ def prepareAngleProfile(beta, avaProfile):
         beta angle in degrees
     avaProfile: dict
         profile dictionary, s, z and a split point(optional)
+    raiseWarning: bool
+        True to raise eventual warnings
     Returns
     -------
     angle: 1D numpy array
@@ -688,12 +690,13 @@ def prepareAngleProfile(beta, avaProfile):
         indSplit = avaProfile['indSplit']
         sSplit = s[indSplit]
     except KeyError:
-        log.warning('No split Point given!')
+        if raiseWarning:
+            log.warning('No split Point given!')
         sSplit = 0
     ds = np.abs(s - np.roll(s, 1))
     dz = np.roll(z, 1) - z
-    ds[0] = 0.0
-    dz[0] = 0.0
+    ds[0] = ds[1]
+    dz[0] = dz[1]
     angle = np.rad2deg(np.arctan2(dz, ds))
     # get all values where Angle < beta but >0
     # get index of first occurance and go one back to get previous value

--- a/avaframe/out3Plot/outCom3Plots.py
+++ b/avaframe/out3Plot/outCom3Plots.py
@@ -1,11 +1,17 @@
 import pathlib
 import numpy as np
 import matplotlib.pyplot as plt
+import matplotlib.patheffects as pe
+from matplotlib.offsetbox import AnchoredText
+from matplotlib.ticker import FormatStrFormatter
 
 # Local imports
 from avaframe.in3Utils import geoTrans
 import avaframe.out3Plot.plotUtils as pU
 import avaframe.out3Plot.outCom1DFA as outCom1DFA
+from avaframe.com1DFA import com1DFA
+from avaframe.ana1Tests import energyLineTest
+
 
 def hybridProfilePlot(avalancheDir, resultsHybrid):
     """Update profile plot with result of curent iteration"""
@@ -81,3 +87,143 @@ def hybridPathPlot(avalancheDir, dem, resultsHybrid, fields, particles, muArray)
     pU.putAvaNameOnPlot(ax, avalancheDir)
     path = pathlib.Path(avalancheDir, 'Outputs', 'com3Hybrid')
     pU.saveAndOrPlot({'pathResult': path}, title, fig)
+
+
+def generateCom1DFAPathPlot(avalancheDir, cfgPath, avaProfileMass, dem, parabolicFit, splitPoint, simName):
+    """ Make energy test analysis and plot results
+
+    Parameters
+    -----------
+    avalancheDir: pathlib
+        avalanche directory pathlib path
+    cfgPath: configParser
+        path finding config
+    avaProfileMass: dict
+        particle mass averaged properties
+    dem: dict
+        com1DFA simulation dictionary
+    fieldsList: list
+        field dictionary list
+    simName: str
+        simulation name
+    """
+    # read field
+    fieldsList, fieldHeader, timeList = com1DFA.readFields(avalancheDir, ['pta'], simName=simName,
+                                                           flagAvaDir=True, comModule='com1DFA')
+    # compute simulation run out angle
+    indStart = avaProfileMass['indStartMassAverage']
+    indEnd = avaProfileMass['indEndMassAverage']
+    runOutAngleRad, runOutAngleDeg = energyLineTest.getRunOutAngle(avaProfileMass, indStart=indStart, indEnd=indEnd)
+    s0 = avaProfileMass['s'][indStart]
+    avaProfileMass['s'] = avaProfileMass['s'] - s0
+    z0 = avaProfileMass['z'][indStart]
+    # get parabola
+    sPara = np.linspace(avaProfileMass['s'][0], avaProfileMass['s'][-1], 500)
+    zPara = parabolicFit['a']*sPara*sPara+parabolicFit['b']*sPara+parabolicFit['c']
+    parabolicProfile = {'s': sPara, 'z': zPara}
+    # get angles of profiles
+    anglePara, tmpPara, dsPara = geoTrans.prepareAngleProfile(cfgPath.getfloat('slopeSplitPoint'), parabolicProfile,
+                                                              raiseWarning=False)
+    angleProf, tmpProf, dsProf = geoTrans.prepareAngleProfile(cfgPath.getfloat('slopeSplitPoint'), avaProfileMass,
+                                                              raiseWarning=False)
+
+
+    # create figures and plots
+    fig = plt.figure(figsize=(pU.figW*2, pU.figH*1.5))
+    # make the bird view plot
+    ax1 = plt.subplot2grid((2, 2), (1, 0), colspan=1)
+    rowsMin, rowsMax, colsMin, colsMax = pU.constrainPlotsToData(fieldsList[-1]['pta'], 5, extentOption=True,
+                                                                 constrainedData=False, buffer='')
+    ax1, extent, cbar0, cs1 = outCom1DFA.addResult2Plot(ax1, dem['header'], fieldsList[-1]['pta'], 'pta')
+    cbar0.ax.set_ylabel('peak travel angle')
+
+    # add DEM hillshade with contour lines
+    ax1 = outCom1DFA.addDem2Plot(ax1, dem, what='hillshade', extent=extent)
+    # add path
+    ax1.plot(avaProfileMass['x'][:indStart+1], avaProfileMass['y'][:indStart+1], '-y.', zorder=20,
+             label='_top extension', lw=2, path_effects=[pe.Stroke(linewidth=3, foreground='b'), pe.Normal()])
+    ax1.plot(avaProfileMass['x'][indEnd:], avaProfileMass['y'][indEnd:], '-y.', zorder=20,
+             label='_bottom extension', lw=2, path_effects=[pe.Stroke(linewidth=3, foreground='g'), pe.Normal()])
+    ax1.plot(avaProfileMass['x'][indStart:indEnd+1], avaProfileMass['y'][indStart:indEnd+1], '-y.', zorder=20,
+             label='_Center of mass path', lw=2, path_effects=[pe.Stroke(linewidth=3, foreground='k'), pe.Normal()])
+    if splitPoint != '':
+        ax1.plot(splitPoint['x'], splitPoint['y'], 'P', color='r', label='_Split point', zorder=20)
+    ax1.set_xlabel('x [m]')
+    ax1.set_ylabel('y [m]')
+    ax1.axis('equal')
+    ax1.set_ylim([rowsMin, rowsMax])
+    ax1.set_xlim([colsMin, colsMax])
+    l1 = ax1.legend()
+    l1.set_zorder(40)
+    ax1.set_title('Avalanche path')
+    pU.putAvaNameOnPlot(ax1, avalancheDir)
+
+
+    # plot angle of profile and parabola
+    ax3 = plt.subplot2grid((2, 2), (1, 1), colspan=1)
+    # add path
+    ax3.plot(sPara, anglePara, 'k', lw=1, label='_parabolic fit')
+
+    ax3.plot(avaProfileMass['s'][:indStart+1], angleProf[:indStart+1], 'y.',
+             label='_top extension', lw=2, path_effects=[pe.Stroke(linewidth=3, foreground='b'), pe.Normal()])
+    ax3.plot(avaProfileMass['s'][indEnd:], angleProf[indEnd:], 'y.',
+             label='_bottom extension', lw=2, path_effects=[pe.Stroke(linewidth=3, foreground='g'), pe.Normal()])
+    ax3.plot(avaProfileMass['s'][indStart:indEnd+1], angleProf[indStart:indEnd+1], 'y.',
+             label='_Center of mass path slope', lw=2, path_effects=[pe.Stroke(linewidth=3, foreground='k'), pe.Normal()])
+    minY, _ = ax3.get_ylim()
+    minX, _ = ax3.get_xlim()
+    if splitPoint != '':
+        ax3.axvline(x=splitPoint['s'], color='r', linewidth=1, linestyle='-.', label='_Split point')
+        ax3.text(splitPoint['s'], minY, "%.2f m" % (splitPoint['s']), color='r', ha="right", va="bottom")
+    ax3.axhline(y=cfgPath.getfloat('slopeSplitPoint'), color='r', linewidth=1, linestyle='-.',
+                label='_Split point angle (%.0f°)' % cfgPath.getfloat('slopeSplitPoint'))
+
+    ax3.text(minX, cfgPath.getfloat('slopeSplitPoint'), "%.0f°" % (cfgPath.getfloat('slopeSplitPoint')), color='r', ha="left", va="bottom")
+    ax3.axhline(y=10, color='0.8', linewidth=1, linestyle='-.', label='_Beta angle (10°)')
+    ax3.text(minX, 10, "%.0f°" % (10), color='0.8', ha="left", va="bottom")
+    # ax3.axvline(x=avaProfileMass['s'][indStart], color='b', linewidth=1, linestyle='-.', label='Start of profile')
+    # ax3.axvline(x=avaProfileMass['s'][indEnd], color='g', linewidth=1, linestyle='-.', label='End of profile')
+    ax3.set_xlabel('s [m]')
+    ax3.set_ylabel('slope angle [°]')
+    ax3.legend()
+    ax3.set_title('Avalanche path profile slope')
+
+    # make profile plot, zoomed out
+    ax2 = plt.subplot2grid((2, 2), (0, 0), colspan=2)
+    # plot mass averaged center of mass
+    ax2.plot(avaProfileMass['s'][:indStart+1], avaProfileMass['z'][:indStart+1], '-y.', label='top extension',
+             lw=1, path_effects=[pe.Stroke(linewidth=3, foreground='b'), pe.Normal()])
+    ax2.plot(avaProfileMass['s'][indEnd:], avaProfileMass['z'][indEnd:], '-y.', label='bottom extension',
+             lw=1, path_effects=[pe.Stroke(linewidth=3, foreground='g'), pe.Normal()])
+    ax2.plot(avaProfileMass['s'][indStart:indEnd+1], avaProfileMass['z'][indStart:indEnd+1], '-y.',
+             label='Center of mass path / profile / angle',
+             lw=1, path_effects=[pe.Stroke(linewidth=3, foreground='k'), pe.Normal()])
+    ax2.plot(sPara, zPara, '-k', label='Parabolic fit')
+    if splitPoint != '':
+        ax2.axvline(x=splitPoint['s'], color='r', linewidth=1, linestyle='-.', label='Split point')
+        ax2.axhline(y=splitPoint['z'], color='r', linewidth=1, linestyle='-.', label='_Split point')
+        minY, _ = ax2.get_ylim()
+        minX, _ = ax2.get_xlim()
+        ax2.text(splitPoint['s'], minY, "%.2f m" % (splitPoint['s']), color='r', ha="left", va="bottom")
+        ax2.text(minX, splitPoint['z'], "%.2f m" % (splitPoint['z']), color='r', ha="left", va="bottom")
+
+    # add runout line
+    s = avaProfileMass['s'][[indStart, indEnd]]
+    # ax2.plot(s, z0-np.tan(runOutAngleRad)*s, '-b', label='com1dfa center of mass runout line (%.2f°)' % runOutAngleDeg)
+    # ax2.axvline(x=s[0], color='b', linewidth=1, linestyle='-.', label='Start of profile')
+    # ax2.axvline(x=s[-1], color='g', linewidth=1, linestyle='-.', label='End of profile')
+    zLim = ax2.get_ylim()
+    sLim = ax2.get_xlim()
+
+    ax2.set_xlabel('s [m]')
+    ax2.set_ylabel('z [m]')
+    ax2.set_xlim(sLim)
+    ax2.set_ylim(zLim)
+    ax2.legend()
+    ax2.set_title('Avalanche path profile')
+
+    outFileName = '_'.join([simName, 'DFAPath'])
+    outDir = pathlib.Path(avalancheDir, 'Outputs', 'DFAPath')
+    plt.tight_layout()
+    outPath = pU.saveAndOrPlot({'pathResult': outDir}, outFileName, fig)
+    return outPath

--- a/avaframe/out3Plot/outDebugPlots.py
+++ b/avaframe/out3Plot/outDebugPlots.py
@@ -2,7 +2,7 @@ import numpy as np
 import pathlib
 import copy
 import matplotlib
-# matplotlib.use('agg')
+matplotlib.use('agg')
 import matplotlib.pyplot as plt
 import matplotlib as mpl
 from mpl_toolkits.axes_grid1 import make_axes_locatable
@@ -274,6 +274,41 @@ def plotSlopeAngle(s, angle, idsBetaPoint):
     plt.plot(s[idsBetaPoint], angle[idsBetaPoint], 'or')
     plt.axhline(y=10, color='0.8',
                 linewidth=1, linestyle='-.', label='Beta angle line')
+    plt.show()
+    plt.close()
+
+
+def plotFindAngle(avaProfile, angleProf, parabolicProfile, anglePara, s0, sEnd, splitPoint, indSplitPoint):
+    """helper plot for the getSplitPoint, findAngleProfile and prepareAngleProfile functions
+    Plots the slope angle and elevation function of s"""
+    plt.figure(figsize=(10, 6))
+    plt.plot(parabolicProfile['s'], anglePara, '.k')
+    plt.plot(avaProfile['s'] - s0, angleProf, '.b')
+    # plt.plot(s[ids10Point], anglePara[indSplitPoint], 'or')
+    plt.axhline(y=10, color='0.8',
+                linewidth=1, linestyle='-.', label='10° line')
+    plt.axhline(y=20, color='0.8',
+                linewidth=1, linestyle='-.', label='10° line')
+    plt.axhline(y=15, color='0.8',
+                linewidth=1, linestyle='-.', label='10° line')
+    plt.axvline(x=0, color='0.8',
+                linewidth=1, linestyle='-.', label='Start')
+    plt.axvline(x=sEnd-s0, color='0.8',
+                linewidth=1, linestyle='-.', label='End')
+    if splitPoint != '':
+        plt.plot(parabolicProfile['s'][indSplitPoint], anglePara[indSplitPoint], '.r')
+        plt.plot(avaProfile['s'][indSplitPoint] - s0, angleProf[indSplitPoint], '.r')
+
+    plt.figure(figsize=(10, 6))
+    plt.plot(parabolicProfile['s'], parabolicProfile['z'], '.k')
+    plt.plot(avaProfile['s'] - s0, avaProfile['z'], '.b')
+    plt.axvline(x=0, color='0.8',
+                linewidth=1, linestyle='-.', label='Start')
+    plt.axvline(x=sEnd-s0, color='0.8',
+                linewidth=1, linestyle='-.', label='End')
+    if splitPoint != '':
+        plt.plot(parabolicProfile['s'][indSplitPoint], parabolicProfile['z'][indSplitPoint], '.r')
+        plt.plot(avaProfile['s'][indSplitPoint] - s0, avaProfile['z'][indSplitPoint], '.r')
     plt.show()
     plt.close()
 

--- a/avaframe/runScripts/runComputeDFAPath.py
+++ b/avaframe/runScripts/runComputeDFAPath.py
@@ -1,5 +1,5 @@
 """
-    Create an avalanch path from DFA simulation results
+    Create an avalanche path from DFA simulation results and create a split point
     Configuration should be specified in DFAPathGenerationCfg.ini
     or the local version of it.
     It is possible to generate a path from particles or from fields.
@@ -8,15 +8,18 @@
     From fields, you need the FT, FM at multiple time steps
 """
 import pathlib
+import numpy as np
 # Local imports
 import avaframe.in3Utils.initializeProject as initProj
-import avaframe.in2Trans.shpConversion as shpConv
 from avaframe.in3Utils import cfgUtils
 from avaframe.in3Utils import logUtils
 import avaframe.ana5Utils.DFAPathGeneration as DFAPath
 from avaframe.in1Data import getInput as gI
 from avaframe.in3Utils import fileHandlerUtils as fU
 from avaframe.com1DFA import com1DFA
+import avaframe.in3Utils.geoTrans as gT
+# import plotting tools
+from avaframe.out3Plot import outCom3Plots
 
 # set to true if you want to run com1DFA first to create the DFA input needed for the path generation
 runDFAModule = True
@@ -27,55 +30,79 @@ logName = 'runComputeDFAPath'
 
 # Load avalanche directory from general configuration file
 cfgMain = cfgUtils.getGeneralConfig()
-avalancheDir = cfgMain['MAIN']['avalancheDir']
+avaList = [cfgMain['MAIN']['avalancheDir']]
+# name of avalanche directory as list, multiple possible
+# avaList = ['avaAlr', 'avaHit', 'avaKot', 'avaMal', 'avaWog', 'avaGar', 'avaHelix',
+#            'avaBowl', 'avaParabola', 'avaHockeySmall', 'avaHockeyChannel']
+# avaList = ['data/' + name for name in avaList]
 
-# Start logging
-log = logUtils.initiateLogger(avalancheDir, logName)
-log.info('MAIN SCRIPT')
-log.info('Current avalanche: %s', avalancheDir)
+for avaName in avaList:
+    # set avaDir
+    avalancheDir = pathlib.Path(avaName)
+    # Start logging
+    log = logUtils.initiateLogger(avalancheDir, logName)
+    log.info('MAIN SCRIPT')
+    log.info('Current avalanche: %s', avalancheDir)
 
-if runDFAModule:
-    # Clean input directory of old work and output files from module
-    initProj.cleanModuleFiles(avalancheDir, com1DFA, deleteOutput=True)
-    # create com1DFA configuration
-    # read the default one (and only this one, no local is read)
-    com1DFACfg = cfgUtils.getModuleConfig(com1DFA, fileOverride='', toPrint=False, onlyDefault=False)
-    # and adapt setting (especially time steps saved and outpus)
-    com1DFACfg['GENERAL']['tSteps'] = '0:5'
-    com1DFACfg['GENERAL']['resType'] = 'particles'
-    com1DFACfg['GENERAL']['simTypeList'] = 'null'
-    outDir = pathlib.Path(avalancheDir, 'Outputs', 'DFAPath')
-    fU.makeADir(outDir)
-    com1DFACfgFile = outDir / 'com1DFAPathGenerationCfg.ini'
-    with open(com1DFACfgFile, 'w') as configfile:
-        com1DFACfg.write(configfile)
-    # call com1DFA and perform simulations
-    dem, plotDict, reportDictList, simDF = com1DFA.com1DFAMain(avalancheDir, cfgMain, cfgFile=com1DFACfgFile)
-else:
-    # read simulation dem
-    demOri = gI.readDEM(avalancheDir)
-    dem = com1DFA.setDEMoriginToZero(demOri)
-    dem['originalHeader'] = demOri['header'].copy()
-    # load DFA results (use runCom1DFA to generate these results for example)
-    # here is an example with com1DFA but another DFA computational module can be used
-    # as long as it produces some particles or FV, FT and FM results
-    # create dataFrame of results (read DFA data)
-    simDF, _ = cfgUtils.readAllConfigurationInfo(avalancheDir)
+    if runDFAModule:
+        # Clean input directory of old work and output files from module
+        initProj.cleanModuleFiles(avalancheDir, com1DFA, deleteOutput=True)
+        # create com1DFA configuration
+        # read the default one (and only this one, no local is read)
+        com1DFACfg = cfgUtils.getModuleConfig(com1DFA, fileOverride='', toPrint=False, onlyDefault=True)
+        # and adapt settings. Especially one needs to save multiple intermediate time steps in order to compute the
+        # path. One also needs to save the correct particle or fields variables in order to compute the path
+        com1DFACfg['GENERAL']['tSteps'] = '0:5'
+        com1DFACfg['GENERAL']['resType'] = 'pta|particles'
+        com1DFACfg['GENERAL']['simTypeList'] = 'null'
+        com1DFACfg['GENERAL']['sphKernelRadiusTimeStepping'] = 'True'
+        com1DFACfg['GENERAL']['cMax'] = '0.01'
+        com1DFACfg['GENERAL']['sphOption'] = '2'
+        com1DFACfg['GENERAL']['massPerParticleDeterminationMethod'] = 'MPPKR'
+        com1DFACfg['GENERAL']['explicitFriction'] = '1'
+        com1DFACfg['GENERAL']['frictModel'] = 'Coulomb'
+        com1DFACfg['GENERAL']['mu'] = '0.42'
+        outDir = pathlib.Path(avalancheDir, 'Outputs', 'DFAPath')
+        fU.makeADir(outDir)
+        # write configuration to file
+        com1DFACfgFile = outDir / 'com1DFAPathGenerationCfg.ini'
+        with open(com1DFACfgFile, 'w') as configfile:
+            com1DFACfg.write(configfile)
+        # call com1DFA and perform simulations
+        dem, plotDict, reportDictList, simDF = com1DFA.com1DFAMain(avalancheDir, cfgMain, cfgFile=com1DFACfgFile)
+    else:
+        # read simulation dem
+        demOri = gI.readDEM(avalancheDir)
+        dem = com1DFA.setDEMoriginToZero(demOri)
+        dem['originalHeader'] = demOri['header'].copy()
+        # load DFA results (use runCom1DFA to generate these results for example)
+        # here is an example with com1DFA but another DFA computational module can be used
+        # as long as it produces some particles or FV, FD and FM results
+        # create dataFrame of results (read DFA data)
+        simDF, _ = cfgUtils.readAllConfigurationInfo(avalancheDir)
 
-
-DFAPathCfgFile = pathlib.Path('ana5Utils', 'DFAPathGenerationCfg.ini')
-DFAPathCfg = cfgUtils.getModuleConfig(DFAPath)
-for simName, simDFrow in simDF.iterrows():
-    log.info('Computing avalanche path from simulation: %s', simName)
-    pathFromPart = DFAPathCfg['PATH'].getboolean('pathFromPart')
-    avaProfileMass = DFAPath.generateAveragePath(avalancheDir, pathFromPart, simName, dem)
-    # here the avaProfileMass given in input is overwriten and returns only a x, y, z extended profile
-    avaProfileMass = DFAPath.extendDFAPath(avalancheDir, DFAPathCfg['PATH'], dem, simName, avaProfileMass)
-    # put path back in original location
-    avaProfileMass['x'] = avaProfileMass['x'] + dem['originalHeader']['xllcenter']
-    avaProfileMass['y'] = avaProfileMass['y'] + dem['originalHeader']['yllcenter']
-    # save profile in Inputs
-    pathAB = pathlib.Path(avalancheDir, 'Outputs', 'DFAPath', 'massAvgPath_%s_AB_aimec' % simName)
-    name = 'massAvaPath'
-    shpConv.writeLine2SHPfile(avaProfileMass, name, pathAB)
-    log.info('Saved path to: %s', pathAB)
+    # load config for path generation (fron DFAPathGenerationCfg.ini or its local)
+    DFAPathCfg = cfgUtils.getModuleConfig(DFAPath)
+    # loop over all simulations
+    for simName, simDFrow in simDF.iterrows():
+        log.info('Computing avalanche path from simulation: %s', simName)
+        pathFromPart = DFAPathCfg['PATH'].getboolean('pathFromPart')
+        resampleDistance = DFAPathCfg['PATH'].getfloat('nCellsResample') * dem['header']['cellsize']
+        # get the mass average path
+        avaProfileMass, particlesIni = DFAPath.generateAveragePath(avalancheDir, pathFromPart, simName, dem)
+        avaProfileMass, _ = gT.prepareLine(dem, avaProfileMass, distance=resampleDistance, Point=None)
+        avaProfileMass['indStartMassAverage'] = 1
+        avaProfileMass['indEndMassAverage'] = np.size(avaProfileMass['x'])
+        # make the parabolic fit
+        parabolicFit = DFAPath.getParabolicFit(DFAPathCfg['PATH'], avaProfileMass, dem)
+        # here the avaProfileMass given in input is overwriten and returns only a x, y, z extended profile
+        avaProfileMass = DFAPath.extendDFAPath(DFAPathCfg['PATH'], avaProfileMass, dem, particlesIni)
+        # resample path and keep track of start and end of mass averaged part
+        avaProfileMass = DFAPath.resamplePath(DFAPathCfg['PATH'], dem, avaProfileMass)
+        # get split point
+        splitPoint = DFAPath.getSplitPoint(DFAPathCfg['PATH'], avaProfileMass, parabolicFit)
+        # make analysis and generate plots
+        _ = outCom3Plots.generateCom1DFAPathPlot(avalancheDir, DFAPathCfg['PATH'], avaProfileMass, dem,
+                                                 parabolicFit, splitPoint, simName)
+        # now save the path and split point as shape file
+        DFAPath.saveSplitAndPath(avalancheDir, simDFrow, splitPoint, avaProfileMass, dem)

--- a/avaframe/tests/test_DFAPathGeneration.py
+++ b/avaframe/tests/test_DFAPathGeneration.py
@@ -8,6 +8,7 @@ import pytest
 import avaframe.ana5Utils.DFAPathGeneration as DFAPathGeneration
 import avaframe.in3Utils.geoTrans as gT
 
+
 def test_appendAverageStd():
     values = np.array([1, 2, 3, 4, 5])
     weights = np.array([2, 1, 2, 1, 2])
@@ -56,12 +57,12 @@ def test_getDFAPathFromPart():
     assert avaProfile['ekinstd'] == pytest.approx(27.69927797, abs=1e-6)
 
 
-def test_extendDFAPathKernel():
+def test_extendDFAPath():
     """"""
     # setup required inputs
     cfg = configparser.ConfigParser()
     cfg['PATH'] = {'nCellsResample': '5', 'extTopOption': '1', 'nCellsMinExtend': '1',
-                      'nCellsMaxExtend': '2', 'factBottomExt': 0.2}
+                   'nCellsMaxExtend': '2', 'factBottomExt': 0.2, 'maxIterationExtBot': 10, 'nBottomExtPrecision': 10}
     avaProfile = {'x': np.array([10, 20, 30]), 'y': np.array([10, 20, 30]), 'z': np.array([40, 30, 20]),
                   's': np.array([0, math.sqrt(200), math.sqrt(800)])}
     particlesIni = {'x': np.array([7, 6.9]),
@@ -78,10 +79,10 @@ def test_extendDFAPathKernel():
                                    [50, 40, 30, 20, 10, 0, 0, 0, 0, 0, 0],
                                    [50, 40, 30, 20, 10, 0, 0, 0, 0, 0, 0]])}
 
-    particlesIni, _ =  gT.projectOnRaster(dem, particlesIni, interp='bilinear')
+    particlesIni, _ = gT.projectOnRaster(dem, particlesIni, interp='bilinear')
 
     # using the longest runout method
-    avaProfileExt = DFAPathGeneration.extendDFAPathKernel(cfg['PATH'], avaProfile, dem, particlesIni)
+    avaProfileExt = DFAPathGeneration.extendDFAPath(cfg['PATH'], avaProfile, dem, particlesIni)
     print(avaProfileExt)
     atol = 1e-10
     assert avaProfileExt['x'][0] == 7.0
@@ -94,10 +95,10 @@ def test_extendDFAPathKernel():
     # now use the highest point method
     cfg = configparser.ConfigParser()
     cfg['PATH'] = {'nCellsResample': '5', 'extTopOption': '0', 'nCellsMinExtend': '2',
-                      'nCellsMaxExtend': '30', 'factBottomExt': 0.2}
+                   'nCellsMaxExtend': '30', 'factBottomExt': 0.2, 'maxIterationExtBot': 10, 'nBottomExtPrecision': 10}
     avaProfile = {'x': np.array([10, 20, 30]), 'y': np.array([10, 20, 30]), 'z': np.array([40, 30, 20])}
 
-    avaProfileExt = DFAPathGeneration.extendDFAPathKernel(cfg['PATH'], avaProfile, dem, particlesIni)
+    avaProfileExt = DFAPathGeneration.extendDFAPath(cfg['PATH'], avaProfile, dem, particlesIni)
     print(avaProfileExt)
     atol = 1e-10
     assert np.allclose(avaProfileExt['x'][0], 6.9, atol=atol)
@@ -106,3 +107,88 @@ def test_extendDFAPathKernel():
     assert avaProfileExt['y'][-1] == pytest.approx(34.35700456911144, abs=1e-6)
     assert avaProfileExt['z'][0] == pytest.approx(43.09999999999, abs=1e-6)
     assert avaProfileExt['z'][-1] == pytest.approx(13.589801959658478, abs=1e-6)
+
+    # now If we extend too 1
+    cfg = configparser.ConfigParser()
+    cfg['PATH'] = {'nCellsResample': '5', 'extTopOption': '0', 'nCellsMinExtend': '2',
+                   'nCellsMaxExtend': '30', 'factBottomExt': 1, 'maxIterationExtBot': 10, 'nBottomExtPrecision': 1}
+    avaProfile = {'x': np.array([10, 20, 30, 70]), 'y': np.array([10, 20, 30, 70]), 'z': np.array([40, 30, 20, 0])}
+
+    avaProfileExt = DFAPathGeneration.extendDFAPath(cfg['PATH'], avaProfile, dem, particlesIni)
+    print(avaProfileExt)
+    atol = 1e-10
+    assert np.allclose(avaProfileExt['x'][0], 6.9, atol=atol)
+    assert avaProfileExt['x'][-1] == pytest.approx(87.23446227804479, abs=1e-6)
+    assert np.allclose(avaProfileExt['y'][0], 20.0, atol=atol)
+    assert avaProfileExt['y'][-1] == pytest.approx(86.45811453, abs=1e-6)
+    assert avaProfileExt['z'][0] == pytest.approx(43.09999999999, abs=1e-6)
+    assert avaProfileExt['z'][-1] == pytest.approx(0, abs=1e-6)
+
+
+def test_resamplePath():
+    """"""
+    # setup required inputs
+    cfg = configparser.ConfigParser()
+    cfg['PATH'] = {'nCellsResample': '1'}
+    avaProfile = {'x': np.array([5, 15, 20, 25, 30, 35]), 'y': np.array([5, 15, 20, 25, 30, 35]),
+                  'z': np.array([40, 30, 20, 10, 0, 0]),
+                  's': np.array([0, math.sqrt(200), math.sqrt(450), math.sqrt(800), math.sqrt(1250), math.sqrt(1800)]),
+                  'indStartMassAverage': 1, 'indEndMassAverage': 4}
+    dem = {'header': {'xllcenter': 0, 'yllcenter': 0, 'cellsize': 5, 'nrows': 10, 'ncols': 11},
+           'rasterData': np.array([[50, 40, 30, 20, 10, 0, 0, 0, 0, 0, 0],
+                                   [50, 40, 30, 20, 10, 0, 0, 0, 0, 0, 0],
+                                   [50, 40, 30, 20, 10, 0, 0, 0, 0, 0, 0],
+                                   [50, 40, 30, 20, 10, 0, 0, 0, 0, 0, 0],
+                                   [50, 40, 30, 20, 10, 0, 0, 0, 0, 0, 0],
+                                   [50, 40, 30, 20, 10, 0, 0, 0, 0, 0, 0],
+                                   [50, 40, 30, 20, 10, 0, 0, 0, 0, 0, 0],
+                                   [50, 40, 30, 20, 10, 0, 0, 0, 0, 0, 0],
+                                   [50, 40, 30, 20, 10, 0, 0, 0, 0, 0, 0],
+                                   [50, 40, 30, 20, 10, 0, 0, 0, 0, 0, 0]])}
+
+    # using the longest runout method
+    avaProfile = DFAPathGeneration.resamplePath(cfg['PATH'], dem, avaProfile)
+    print(avaProfile)
+    assert avaProfile['indStartMassAverage'] == 3
+    assert avaProfile['indEndMassAverage'] == 9
+
+
+def test_getParabolicFit():
+    """"""
+    # setup required inputs
+    cfg = configparser.ConfigParser()
+    cfg['PATH'] = {'fitOption': '0', 'nCellsSlope': '2'}
+    avaProfile = {'x': np.array([0, 10, 20, 30, 40, 50, 60, 70, 80]),
+                  'y': np.array([0, 0, 0, 0, 0, 0, 0, 0, 0]),
+                  'z': np.array([50, 40, 30, 20, 10, 0, 0, 0, 0]),
+                  's': np.array([0, 10, 20, 30, 40, 50, 60, 70, 80]),
+                  'indStartMassAverage': 1, 'indEndMassAverage': 8}
+    dem = {'header': {'cellsize': 5}}
+
+    # using the distance minimization method
+    parabolicFit = DFAPathGeneration.getParabolicFit(cfg['PATH'], avaProfile, dem)
+    zPara = parabolicFit['a']*avaProfile['s']*avaProfile['s']+parabolicFit['b']*avaProfile['s']+parabolicFit['c']
+    print(parabolicFit)
+    print(zPara)
+    slope = 2*parabolicFit['a']*avaProfile['s']+parabolicFit['b']
+    print(slope)
+    assert zPara[0] == 50
+    assert zPara[-1] == 0
+    assert slope[-1] != 0
+
+    # using the bottom matching dlope method
+    cfg['PATH'] = {'fitOption': '1', 'nCellsSlope': '2', 'slopeSplitPoint': '30', 'dsMin': '5'}
+    parabolicFit = DFAPathGeneration.getParabolicFit(cfg['PATH'], avaProfile, dem)
+    zPara = parabolicFit['a']*avaProfile['s']*avaProfile['s']+parabolicFit['b']*avaProfile['s']+parabolicFit['c']
+    print(parabolicFit)
+    print(zPara)
+    slope = 2*parabolicFit['a']*avaProfile['s']+parabolicFit['b']
+    angle = np.rad2deg(np.arctan(slope))
+    assert zPara[0] == 50
+    assert zPara[-1] == 0
+    assert slope[-1] == 0
+
+    splitPoint = DFAPathGeneration.getSplitPoint(cfg['PATH'], avaProfile, parabolicFit)
+    print(splitPoint)
+    print(angle)
+    assert splitPoint['s'] == 50

--- a/avaframe/tests/test_com2AB.py
+++ b/avaframe/tests/test_com2AB.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 import pathlib
 import shutil
+import logging
 
 # Local imports
 import avaframe.com2AB.com2AB as com2AB
@@ -58,7 +59,7 @@ def test_setEqParameters(capfd):
         assert eqParamRef[key] == eqParams[key]
 
 
-def test_calcABAngles(capfd):
+def test_calcABAngles(caplog):
     '''Simple test for function calcABAngles'''
 
     cfg = cfgUtils.getModuleConfig(com2AB)
@@ -107,6 +108,10 @@ def test_calcABAngles(capfd):
             alphaSD[0] == pytest.approx(alphaSDref[0], rel=tol)) and (
             alphaSD[1] == pytest.approx(alphaSDref[1], rel=tol)) and (
             alphaSD[2] == pytest.approx(alphaSDref[2], rel=tol))
+
+    with pytest.raises(IndexError) as e:
+        eqOut = com2AB.calcABAngles(eqIn, eqParams, 500)
+    assert str(e.value) == ("No Beta point found. Check your pathAB.shp and splitPoint.shp.")
 
 
 def test_writeABtoSHP(tmp_path):

--- a/avaframe/tests/test_geoTrans.py
+++ b/avaframe/tests/test_geoTrans.py
@@ -146,7 +146,7 @@ def test_findAngleProfile(capfd):
     # do we react properly when the input line exceeds the dem?
     with pytest.raises(Exception) as e:
         assert geoTrans.findAngleProfile(tmp, ds, dsMin)
-    assert str(e.value) == "No Beta point found. Check your pathAB.shp and splitPoint.shp."
+    assert str(e.value) == "No point found. Check the angle and threshold distance."
 
     tmp = np.where((angle < 4.0) & (angle >= 0.0))
     tmp = np.asarray(tmp).flatten()
@@ -156,7 +156,7 @@ def test_findAngleProfile(capfd):
     # do we react properly when the input line exceeds the dem?
     with pytest.raises(Exception) as e:
         assert geoTrans.findAngleProfile(tmp, ds, dsMin)
-    assert str(e.value) == "No Beta point found. Check your pathAB.shp and splitPoint.shp."
+    assert str(e.value) == "No point found. Check the angle and threshold distance."
 
 
 def test_prepareAngleProfile(caplog):
@@ -390,7 +390,6 @@ def test_remeshDEM(tmp_path):
     with pytest.raises(FileExistsError) as e:
         assert geoTrans.remeshDEM(avaDEM1, cfg)
     assert str(e.value) == ("Name for saving remeshedDEM already used: %s" % avaDEM.name)
-
 
 
 def test_isCounterClockWise(capfd):

--- a/avaframe/tests/test_shpConversion.py
+++ b/avaframe/tests/test_shpConversion.py
@@ -256,3 +256,29 @@ def test_readPoints(capfd):
     with pytest.raises(ValueError) as e:
         assert shpConv.readPoints(shpFileName, dem)
     assert str(e.value) == 'The split point is not on the dem. Try with another split point'
+
+
+def test_writeLine2SHPfile(tmp_path):
+    '''Simple test for function writeLine2SHPfile'''
+    temp = pathlib.Path(tmp_path, 'testSaveLine')
+    linePath = temp / 'line2SHPfile.shp'
+    lineDict = {'x': np.array([0, 1]), 'y': np.array([0, 1])}
+    fileName = shpConv.writeLine2SHPfile(lineDict, 'myLine', linePath)
+    lines = list(temp.glob(('*.shp')))
+    print(lines)
+    print(fileName)
+    print(temp)
+    assert str(lines[0]) == str(linePath)
+
+
+def test_writePoint2SHPfile(tmp_path):
+    '''Simple test for function writePoint2SHPfile'''
+    temp = pathlib.Path(tmp_path, 'testSaveLine')
+    pointpath = temp / 'line2SHPfile.shp'
+    pointDict = {'x': np.array([0]), 'y': np.array([1])}
+    fileName = shpConv.writePoint2SHPfile(pointDict, 'myPoint', pointpath)
+    points = list(temp.glob(('*.shp')))
+    print(points)
+    print(fileName)
+    print(temp)
+    assert str(points[0]) == str(pointpath)

--- a/avaframe/tests/test_timeDiscretization.py
+++ b/avaframe/tests/test_timeDiscretization.py
@@ -6,30 +6,31 @@ import configparser
 import avaframe.com1DFA.timeDiscretizations as tD
 
 
-def test_getcflTimeStep(capfd):
+def test_getSphKernelRadiusTimeStep(capfd):
     cfg = configparser.ConfigParser()
-    cfg['GENERAL'] = {'cMax': '0.5', 'maxdT': '0.5', 'constrainCFL': 'False', 'mindT': '0.01'}
+    cfg['GENERAL'] = {'cMax': '0.01'}
     dem = {'header': {'cellsize': 1}, 'headerNeighbourGrid': {'cellsize': 2}}
-    particles = {}
-    particles['ux'] = np.array([100.])
-    particles['uy'] = np.array([0.])
-    particles['uz'] = np.array([0.])
 
-    dtStable = tD.getcflTimeStep(particles, dem, cfg['GENERAL'])
-    print(dtStable)
-    assert dtStable == 0.005
-
-    cfg['GENERAL']['constrainCFL'] = 'True'
-    dtStable = tD.getcflTimeStep(particles, dem, cfg['GENERAL'])
+    dtStable = tD.getSphKernelRadiusTimeStep(dem, cfg['GENERAL'])
     print(dtStable)
     assert dtStable == 0.01
 
-    particles['ux'] = np.array([0.5])
-    dtStable = tD.getcflTimeStep(particles, dem, cfg['GENERAL'])
+    cfg['GENERAL']['constrainCFL'] = 'True'
+    dtStable = tD.getSphKernelRadiusTimeStep(dem, cfg['GENERAL'])
     print(dtStable)
-    assert dtStable == 0.5
+    assert dtStable == 0.01
 
-    particles['ux'] = np.array([5])
-    dtStable = tD.getcflTimeStep(particles, dem, cfg['GENERAL'])
+    dem['header']['cellsize'] = 2
+    dtStable = tD.getSphKernelRadiusTimeStep(dem, cfg['GENERAL'])
     print(dtStable)
-    assert dtStable == 0.1
+    assert dtStable == 0.02
+
+    dem['header']['cellsize'] = 3
+    dtStable = tD.getSphKernelRadiusTimeStep(dem, cfg['GENERAL'])
+    print(dtStable)
+    assert dtStable == 0.02
+
+    cfg['GENERAL']['cMax'] = '0.02'
+    dtStable = tD.getSphKernelRadiusTimeStep(dem, cfg['GENERAL'])
+    print(dtStable)
+    assert dtStable == 0.04

--- a/docs/moduleAna5Utils.rst
+++ b/docs/moduleAna5Utils.rst
@@ -124,11 +124,13 @@ Automated path generation
 
 Computational modules like :math:`\alpha\beta` (:ref:`moduleCom2AB`) or analysis modules like
 the Thalweg-time diagram (:ref:`moduleAna5Utils`) or Aimec (:ref:`moduleAna3AIMEC`) require
-an avalanche path as input. This avalanche path is usually created manually based on an expert opinion.
-The objective of this module is to automatically generate an avalanche path from a dense flow avalanche (DFA) simulation.
+an avalanche path and split point as input. This avalanche path and split point are usually
+created manually based on an expert opinion. The objective of this module is to automatically
+generate an avalanche path from a dense flow avalanche (DFA) simulation and placing a split point.
 The path is generated from the center of mass position of the dense material, so it is called the mass
 averaged path. It is extended towards the top of the release area and at the bottom. Therefore it covers
 the entire length of the avalanche with some buffer in the runout area.
+The split point is extracted from the parabola that is fitted on to the avalanche path profile.
 
 Input
 =====
@@ -221,3 +223,15 @@ It is also necessary to extend the profile in the runout area. This is done by f
 direction of the path given by the few last points in the path in (x,y) (all points at a distance
 ``nCellsMinExtend`` x cellSize < distance < ``nCellsMaxExtend`` x cellSize)) and extending in
 this direction for a given percentage (``factBottomExt``) of the total length of the path :math:`s`.
+
+
+Split point generation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A parabolic curve is fitted to the avalanche path profile extracted from the DFA simulation (non-extended profile),
+where the first and last point of the parabolic profile match the avalanche path profile. To find the
+best fitting parabolic profile, an additional constraint is needed. Two options are available:
+the default one (``fitOption``= 0) minimises the distance between the parabolic profile and the avalanche path
+profile. The second option (``fitOption``= 1) matches the end slope of the parabola to the profile.
+This parabolic fit determines the split point location. It is the first point for which the slope is
+lower than the ``slopeSplitPoint`` angle. This point is then projected on the avalanche path profile.


### PR DESCRIPTION
- Add automatic split point generation:
  - First run a DFA simulation, either using the runDFAModule flag in runComputeDFAPath.py or yourself (do not forget that you   need to saves particles or FD, FM, FV for multiple time steps)
  - What DFA parameters to use is not yet clear. I would use the BenMoussa time stepping and particles parameters, sphOption 2, explicit friction option 1, some artificial viscosity, and maybe activate curvature (with all this and a mu=0.42, I get ok results)
  - Then runComputeDFAPath computes the mass average path, extends it and defines a splitPoint
  
- fix #706 
- fix #668

![b602d803c6_DFAPath](https://user-images.githubusercontent.com/68691577/168291018-7304b642-20ef-42cb-bf18-866455fd7d7b.png)

