### PR TITLE
fix particle exiting domain and com3Hybrid

### DIFF
--- a/avaframe/com1DFA/DFAfunctionsCython.pyx
+++ b/avaframe/com1DFA/DFAfunctionsCython.pyx
@@ -10,7 +10,6 @@
 import copy
 import logging
 import math
-import cython
 import numpy as np
 cimport numpy as np
 from libc cimport math as math
@@ -674,7 +673,8 @@ def updatePositionC(cfg, particles, dem, force, int typeStop=0):
     else:
       xNew, yNew, iCellNew, LxNew0, LyNew0, wNew[0], wNew[1], wNew[2], wNew[3] = samosProjectionIteratrive(
         xNew, yNew, zNew, ZDEM, nxArray, nyArray, nzArray, csz, ncols, nrows, interpOption, reprojectionIterations)
-      zNew = getScalar(LxNew0, LyNew0, wNew[0], wNew[1], wNew[2], wNew[3], ZDEM)
+      if iCellNew >= 0:
+        zNew = getScalar(LxNew0, LyNew0, wNew[0], wNew[1], wNew[2], wNew[3], ZDEM)
 
     if iCellNew < 0:
       # if the particle is not on the DEM, memorize it and remove it at the next update
@@ -1879,7 +1879,7 @@ cpdef (double, double, int, int, int, double, double, double, double) samosProje
   iCell = getCells(xNew, yNew, ncols, nrows, csz)
   if iCell < 0:
     # if not on the DEM exit with iCell=-1
-    return xNew, yNew, iCell, 0, 0, 0, 0, 0, 0
+    return xNew, yNew, iCell, -1, -1, 0, 0, 0, 0
   w[0], w[1], w[2], w[3] = getWeights(xNew, yNew, iCell, csz, ncols, interpOption)
   Lx0 = iCell % ncols
   Ly0 = iCell / ncols
@@ -1906,7 +1906,7 @@ cpdef (double, double, int, int, int, double, double, double, double) samosProje
     iCell = getCells(xNew, yNew, ncols, nrows, csz)
     if iCell < 0:
       # if not on the DEM exit with iCell=-1
-      return xNew, yNew, iCell, 0, 0, 0, 0, 0, 0
+      return xNew, yNew, iCell, -1, -1, 0, 0, 0, 0
     w[0], w[1], w[2], w[3] = getWeights(xNew, yNew, iCell, csz, ncols, interpOption)
     Lx0 = iCell % ncols
     Ly0 = iCell / ncols

--- a/avaframe/com1DFA/DFAfunctionsCython.pyx
+++ b/avaframe/com1DFA/DFAfunctionsCython.pyx
@@ -10,6 +10,7 @@
 import copy
 import logging
 import math
+import cython
 import numpy as np
 cimport numpy as np
 from libc cimport math as math
@@ -810,7 +811,6 @@ def updatePositionC(cfg, particles, dem, force, int typeStop=0):
       log.error(message)
       raise AssertionError(message)
 
-
   if stop:
     particles['iterate'] = False
     if typeStop == 1:
@@ -820,8 +820,8 @@ def updatePositionC(cfg, particles, dem, force, int typeStop=0):
 
   # remove particles that are not located on the mesh any more
   if nRemove > 0:
-      mask = np.array(np.asarray(keepParticle), dtype=bool)
-      particles = particleTools.removePart(particles, mask, nRemove, 'because they exited the domain')
+    mask = np.array(np.asarray(keepParticle), dtype=bool)
+    particles = particleTools.removePart(particles, mask, nRemove, 'because they exited the domain')
 
   return particles
 
@@ -1080,7 +1080,7 @@ cpdef double computePressure(double v, double rho):
 
 def computeTravelAngleC(particles, zPartArray0):
   """Compute the travel angle associated to the particles
-  
+
   Parameters
   ----------
   particles : dict
@@ -1879,7 +1879,7 @@ cpdef (double, double, int, int, int, double, double, double, double) samosProje
   iCell = getCells(xNew, yNew, ncols, nrows, csz)
   if iCell < 0:
     # if not on the DEM exit with iCell=-1
-    return xNew, yNew, iCell, -1, -1, 0, 0, 0, 0
+    return xNew, yNew, iCell, 0, 0, 0, 0, 0, 0
   w[0], w[1], w[2], w[3] = getWeights(xNew, yNew, iCell, csz, ncols, interpOption)
   Lx0 = iCell % ncols
   Ly0 = iCell / ncols
@@ -1906,7 +1906,7 @@ cpdef (double, double, int, int, int, double, double, double, double) samosProje
     iCell = getCells(xNew, yNew, ncols, nrows, csz)
     if iCell < 0:
       # if not on the DEM exit with iCell=-1
-      return xNew, yNew, iCell, -1, -1, 0, 0, 0, 0
+      return xNew, yNew, iCell, 0, 0, 0, 0, 0, 0
     w[0], w[1], w[2], w[3] = getWeights(xNew, yNew, iCell, csz, ncols, interpOption)
     Lx0 = iCell % ncols
     Ly0 = iCell / ncols

--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -1561,6 +1561,7 @@ def computeEulerTimeStep(cfg, particles, fields, zPartArray0, dem, tCPU, frictTy
     if cfg.getint('splitOption') == 0:
         # split particles with too much mass
         # this only splits particles that grew because of entrainment
+        log.debug('Split particles')
         particles = particleTools.splitPartMass(particles, cfg)
     elif cfg.getint('splitOption') == 1:
         # split merge operation

--- a/avaframe/com3Hybrid/com3HybridCfg.ini
+++ b/avaframe/com3Hybrid/com3HybridCfg.ini
@@ -29,8 +29,8 @@ nCellsMaxExtend = 20
 
 # for the extrapolation at the bottom, add factBottomExt * sMax to the path
 factBottomExt = 0.2
-bottomExtPrecision = 0.01
-
+maxIterationExtBot = 10
+nBottomExtPrecision = 10
 
 [DFA]
 # starting value for bottom bed friction


### PR DESCRIPTION
Particle exiting domain was not working properly with the new cython flag thing (wraparound boundcheck...)
This is fixed and the hybrid Path ini file is now up to date