### PR TITLE
Bugfixes in rangeTimePlots (contr. Anselm K.)

### DIFF
--- a/.github/workflows/releaseWithManylinux.yml
+++ b/.github/workflows/releaseWithManylinux.yml
@@ -14,7 +14,7 @@ jobs:
       TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
       TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Install dependencies
@@ -51,7 +51,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - name: Install dependencies
@@ -83,11 +83,11 @@ jobs:
         os: [macos-latest, windows-latest]
         python-version: ['3.6','3.7','3.8','3.9','3.10']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: build wheel

--- a/.github/workflows/runTestSinglePython.yml
+++ b/.github/workflows/runTestSinglePython.yml
@@ -50,11 +50,11 @@ jobs:
       run: |
         pytest -ra --cov --cov-report=xml --cov-config=.coveragerc
     - name: Test & publish code coverage
-      uses: paambaati/codeclimate-action@v2.7.5
+      uses: paambaati/codeclimate-action@v3.1.0
       env:
         CC_TEST_REPORTER_ID: ${{ secrets.CODECLIMATE_ID }}
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: false
         name: codecov-umbrella

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ _build
 
 *.log
 
+# neglect PyCharm files
+.idea
+
 Work
 
 *_cache

--- a/avaframe/ana5Utils/distanceTimeAnalysis.py
+++ b/avaframe/ana5Utils/distanceTimeAnalysis.py
@@ -736,8 +736,8 @@ def approachVelocity(mtiInfo, minVelTimeStep):
         for k in range(i+1, len(timeListSorted+1)):
             if abs(timeListSorted[i] - timeListSorted[k]) >= minVelTimeStep:
                 appVel = ((rangeListSorted[i] - rangeListSorted[k]) / (timeListSorted[i] - timeListSorted[k]))
-                if abs(appVel) > maxVel:
-                    maxVel = abs(appVel)
+                if appVel > maxVel:
+                    maxVel = appVel
                     locationIndex = int(i + 0.5*(k-i))
                     rangeVel = rangeListSorted[locationIndex] - abs(np.nanmin(np.asarray(rangeList)))
                     timeVel = timeListSorted[locationIndex]

--- a/avaframe/ana5Utils/distanceTimeAnalysisCfg.ini
+++ b/avaframe/ana5Utils/distanceTimeAnalysisCfg.ini
@@ -5,7 +5,7 @@
 
 [GENERAL]
 # result type used for creating range time diagram e.g. FT, FV, ....
-rangeTimeResType = FT
+rangeTimeResType = FV
 # time steps used for creating diagram
 distanceTimeSteps = 0:1
 # threshold - below this result data is ignored - used to create mask

--- a/avaframe/com1DFA/particleInitialisation.py
+++ b/avaframe/com1DFA/particleInitialisation.py
@@ -3,11 +3,9 @@
 """
 
 import logging
-import time
 import pathlib
 import numpy as np
 import copy
-import matplotlib.pyplot as plt
 
 # Local imports
 import avaframe.com1DFA.DFAfunctionsCython as DFAfunC
@@ -20,6 +18,7 @@ import avaframe.out3Plot.outDebugPlots as debPlot
 log = logging.getLogger(__name__)
 cfgAVA = cfgUtils.getGeneralConfig()
 debugPlot = cfgAVA['FLAGS'].getboolean('debugPlot')
+
 
 def getIniPosition(cfg, particles, dem, fields, inputSimLines, relThField):
     """ Redistribute particles so that SPH force reduces with fixed particles as boundaries

--- a/avaframe/com1DFA/particleInitialisation.py
+++ b/avaframe/com1DFA/particleInitialisation.py
@@ -11,7 +11,6 @@ import matplotlib.pyplot as plt
 
 # Local imports
 import avaframe.com1DFA.DFAfunctionsCython as DFAfunC
-import avaframe.out3Plot.outDebugPlots as debPlot
 from avaframe.in3Utils import cfgUtils
 import avaframe.com1DFA.com1DFA as com1DFA
 import avaframe.com1DFA.particleTools as particleTools

--- a/avaframe/out3Plot/outDistanceTimeAnalysis.py
+++ b/avaframe/out3Plot/outDistanceTimeAnalysis.py
@@ -77,6 +77,7 @@ def plotRangeTime(mtiInfo, cfgRangeTime):
     rangeTimeVelocityLegend(timeListNew, rangeGates, ax, maxVel, width=width, height=height, lw=lw, textsize=textsize)
     # add max velocity location
     ax.plot(timeVel, rangeVel, 'r*', label='max velocity location')
+    cbar.ax.axhline(y=maxVel, color='r', lw=1, label='max velocity')
 
     # add info on avalanche front in legend
     plt.legend(facecolor='grey', framealpha=0.2, loc='lower right', fontsize=8)

--- a/avaframe/runScripts/runThalwegTimeDiagram.py
+++ b/avaframe/runScripts/runThalwegTimeDiagram.py
@@ -77,7 +77,7 @@ else:
     configDir = pathlib.Path(avalancheDir, 'Outputs', 'com1DFA', 'configurationFiles')
     if (configDir.is_dir() is False) or (len(list(configDir.glob('*.ini'))) == 0):
         fU.fileNotFoundMessage(('No configuration files found in %s - consider first running avalanche simulations' %
-            configDir))
+                                configDir))
 
     # fetch info on available simulations
     simDF = cfgUtils.createConfigurationInfo(avalancheDir, standardCfg='', writeCSV=False, specDir='')
@@ -101,16 +101,16 @@ else:
         mtiInfo = dtAna.setupThalwegTimeDiagram(dem, cfgRangeTime)
         mtiInfo['plotTitle'] = 'thalweg-time diagram %s' % index
         mtiInfo['textbox'] = 'beta point: %.2f, %.2f' % (mtiInfo['betaPoint'][0],
-            mtiInfo['betaPoint'][1])
+                                                         mtiInfo['betaPoint'][1])
 
         # fetch all flow parameter result fields
         flowFieldsDir = pathlib.Path(avalancheDir, 'Outputs', 'com1DFA', 'peakFiles', 'timeSteps')
-        simNameSuffix = index + '_' + cfgRangeTime['GENERAL']['rangeTimeResType']
-        flowFields =  fU.fetchFlowFields(flowFieldsDir, suffix=simNameSuffix)
+        simNameSuffix = simDFrow['simName'] + '_' + cfgRangeTime['GENERAL']['rangeTimeResType']
+        flowFields = fU.fetchFlowFields(flowFieldsDir, suffix=simNameSuffix)
 
         if len(flowFields) == 0:
             fU.fileNotFoundMessage(('No flow variable results found in %s - consider first running avalanche simulations' %
-                flowFieldsDir))
+                                    flowFieldsDir))
 
         for flowField in flowFields:
 

--- a/avaframe/runStandardTestsCom1DFA.py
+++ b/avaframe/runStandardTestsCom1DFA.py
@@ -20,7 +20,6 @@ from avaframe.in3Utils import initializeProject as initProj
 from avaframe.in3Utils import cfgUtils
 from avaframe.in3Utils import cfgHandling
 from avaframe.in3Utils import logUtils
-from benchmarks import simParametersDict
 
 
 # +++++++++REQUIRED+++++++++++++

--- a/avaframe/tests/test_outDistanceTimeAnalysis.py
+++ b/avaframe/tests/test_outDistanceTimeAnalysis.py
@@ -25,6 +25,7 @@ def test_plotRangeTime(tmp_path):
     cfgRangeTime = configparser.ConfigParser()
     cfgRangeTime['GENERAL'] = {'avalancheDir': avaDir, 'rangeTimeResType': 'FT', 'simHash': 'simDI',
         'minVelTimeStep': 2.}
+        # 'minVelTimeStep': 2., 'maxOrMean': 'max'}
     cfgRangeTime['PLOTS'] = {'width': 0.25, 'height': 0.25, 'lw': 0.25, 'textsize': 7}
 
     # call function to be tested


### PR DESCRIPTION
Hi Avaframe Team,

Thank you for the great simulation tool, I am really impressed how easy to use the tool is as soon one got a little starting help (thanks @matthiasto).

I had a look at the rangeTimePlots for the thalweg-time-diagrams (thanks @awirb for the great work), and fixed some bugs. Namely:
- the small velocity legend did not react to zoom/pan events of the figure, e.g. as soon as one programmatically changes the xlim or ylim of the plot, the legend was wrong.
- the max of the front velocity suffered some inconsistencies, thus, I tried to find a way how to neglect obviously (to large) velocities. For example, I found one case where the were 400m/s in the first second inside the release area... The first commit 3e516ad is overwritten from the last commit 4f5b9c8, however, the way the max front velocity was calculated before is still in the code and can be activated with the flag `old_algo=True` in `ana5Utils.distanceTimeAnalysis.approachVelocity`

Other small changes include a found double import, explicit setting of mpl backend 'agg' in some debugPlots function, and some PyCharm files were not excluded in the gitignore file.

Here 2 plots that show the correction of the velocity legend, with the following steps
- make range-time-plot with legend filling the full axes
- zoom to 0-100s and -1000m-0m (from beta point)
- now: diagonal should equate to 10m/s

Not working: zoom does not change the velocity legend...
![thalwegTime_FV_e557d4d8f9_wrong_legend_after_zooming](https://user-images.githubusercontent.com/20665817/181520579-c922611c-da31-43c0-9428-7306b3c0d8b3.png)

Working: zoom causes velocity legend to update and shows the expected result fro the diagonal velocity:
![thalwegTime_FV_e557d4d8f9_correct_legend_after_zooming](https://user-images.githubusercontent.com/20665817/181520721-ec946ec4-a183-487f-a9d7-5b1ea608e9bf.png)

And here 2 plots that show the updated way to calculate the max front velocity:

Not working: Max velocity found at first timestep somewhere in release area:
![thalwegTime_FV_e557d4d8f9_old_algo_True](https://user-images.githubusercontent.com/20665817/181520876-242056e5-72f0-45b6-83ff-035e5c847cfb.png)

Working: max velocity found in the steepest part of the flowing front:
![thalwegTime_FV_e557d4d8f9_correct_maxvel](https://user-images.githubusercontent.com/20665817/181521084-8aef7615-f118-4bfc-9adb-b19722d6566d.png)

Note: the small kink in the front at 30s and -1300m distance is also neglected. We should discuss how strong the max front algorithm should filter those kinks.

Cheers, Anselm


