### PR TITLE
remove old work dir

### DIFF
--- a/avaframe/runScripts/runProbAnaCom1DFA.py
+++ b/avaframe/runScripts/runProbAnaCom1DFA.py
@@ -61,6 +61,9 @@ for varPar in cfgFiles:
     dem, plotDict, reportDictList, simDF = com1DFA.com1DFAMain(avaDir, cfgMain,
     cfgFile=cfgFiles[varPar]['cfgFile'])
 
+    # Clean input directory(ies) of old work files but keep outputs
+    initProj.cleanSingleAvaDir(avaDir, keep=logName, deleteOutput=False)
+
 # perform pobability analysis
 for probConf in probabilityConfigurations:
 


### PR DESCRIPTION
required for running runProbAnaCom1DFA.py if multiple parameters varied, as for subsequent runs of com1DFA error if workDir already exists. 