### PR TITLE
fix unexpected keyword error

### DIFF
--- a/avaframe/out3Plot/plotUtils.py
+++ b/avaframe/out3Plot/plotUtils.py
@@ -524,7 +524,7 @@ def addColorBar(
     """
 
     cbar = ax2.figure.colorbar(
-        im, ax=ax2, ticks=ticks, extend=extend, pad=pad, shrink=0.9, location=location
+        im, ax=[ax2], ticks=ticks, extend=extend, pad=pad, shrink=0.9, location=location
     )
     cbar.outline.set_visible(False)
     # make sure the cbar title does not overlap with the cbar itself


### PR DESCRIPTION
With Python 3.8.10 (default, Nov 14 2022, 12:59:47) and Matlplotlib 3.3.4 I get an "unexpected keyword error" The brackets should fix issue. See also:
https://stackoverflow.com/questions/37280557/can-i-place-a-vertical-colorbar-to-the-left-of-the-plot-in-matplotlib#comment112236764_61090677