### PR TITLE
only use relthFile if relThFromFile true [com1]

### DIFF
--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -580,7 +580,7 @@ def prepareInputData(inputSimFiles, cfg):
     demOri = gI.initializeDEM(cfg['GENERAL']['avalancheDir'], demPath=cfg['INPUT']['DEM'])
 
     # read data from relThFile
-    if relThFile != None:
+    if relThFile != None and cfg['GENERAL'].getboolean('relThFromFile'):
         relThField = IOf.readRaster(relThFile)
         relThFieldData = relThField['rasterData']
         relThFieldDataOrig = relThFieldData.copy()

--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -427,6 +427,9 @@ def com1DFACore(cfg, avaDir, cuSimName, inputSimFiles, outDir, simHash=''):
             fieldsList[-1][cfg['VISUALISATION']['contourResType']], cfg['VISUALISATION'], cuSimName)
         reportDict['contours'] = contDictXY
 
+    if particlesList[-1]['nExitedParticles'] != 0.:
+        log.warning('%d particles have been removed during simulation because they exited the domain' %  particlesList[-1]['nExitedParticles'])
+
     return dem, reportDict, cfg, infoDict['tCPU'], particlesList
 
 
@@ -1163,6 +1166,7 @@ def initializeParticles(cfg, releaseLine, dem, inputSimLines='', logName='', rel
     particles['simName'] = logName
     particles['xllcenter'] = dem['originalHeader']['xllcenter']
     particles['yllcenter'] = dem['originalHeader']['yllcenter']
+    particles['nExitedParticles'] = 0.
 
     # remove particles that might lay outside of the release polygon
     if not cfg.getboolean('iniStep') and not cfg.getboolean('initialiseParticlesFromFile'):

--- a/avaframe/com1DFA/deriveParameterSet.py
+++ b/avaframe/com1DFA/deriveParameterSet.py
@@ -485,7 +485,7 @@ def setThicknessValueFromVariation(key, cfg, simType, row):
             elif varType == 'RangeFromCi':
                 message = ('Variation using RangeFromCi is only allowed if thFromShp is set to True')
                 log.error(message)
-                raise AssertionError
+                raise AssertionError(message)
             elif varType == 'Percent':
                 cfg['GENERAL'][thType] = str(float(cfg['GENERAL'][thType]) * variationFactor)
             elif varType == 'Dist':

--- a/avaframe/com1DFA/particleTools.py
+++ b/avaframe/com1DFA/particleTools.py
@@ -215,6 +215,8 @@ def removePart(particles, mask, nRemove, reasonString='', snowSlide=0):
     """
     if reasonString != '':
         log.debug('removed %s particles %s' % (nRemove, reasonString))
+    if reasonString == 'because they exited the domain':
+        particles['nExitedParticles'] = particles['nExitedParticles'] + nRemove
     nPart = particles['nPart']
     if snowSlide == 1:
         # if snowSlide is activated, we need to remove the particles as well as the bonds accordingly
@@ -230,6 +232,7 @@ def removePart(particles, mask, nRemove, reasonString='', snowSlide=0):
                 particles[key] = np.extract(mask, particles[key])
 
     particles['mTot'] = np.sum(particles['m'])
+
     return particles
 
 

--- a/avaframe/in1Data/getInput.py
+++ b/avaframe/in1Data/getInput.py
@@ -366,7 +366,12 @@ def updateThicknessCfg(inputSimFiles, avaDir, modName, cfgInitial):
         # update configuration with thickness value to be used for simulations
         cfgInitial = dP.getThicknessValue(cfgInitial, inputSimFiles, releaseA, 'relTh')
         if cfgInitial['GENERAL'].getboolean('relThFromFile'):
-            cfgInitial['INPUT']['relThFile'] = str(pathlib.Path('RELTH', inputSimFiles['relThFile'].name))
+            if inputSimFiles['relThFile'] == None:
+                message = 'relThFromFile set to True but no relTh file found'
+                log.error(message)
+                raise FileNotFoundError(message)
+            else:
+                cfgInitial['INPUT']['relThFile'] = str(pathlib.Path('RELTH', inputSimFiles['relThFile'].name))
 
     # add entrainment and secondary release thickness in input data info and in cfg object
     if inputSimFiles['entFile'] != None and 'entFile' in thTypeList:

--- a/avaframe/tests/test_com1DFA.py
+++ b/avaframe/tests/test_com1DFA.py
@@ -75,6 +75,28 @@ def test_prepareInputData(tmp_path):
     assert inputSimLines['resLine']['Length'] == np.asarray([5.])
     assert inputSimLines['resLine']['Name'] == ['']
 
+    # call function to be tested
+    inputSimFiles = {'entResInfo': {'flagEnt': 'No',
+                                    'flagRes': 'Yes', 'flagSecondaryRelease': 'No'}}
+    dirName = pathlib.Path(__file__).parents[0]
+    avaDir = dirName / '..' / 'data' / 'avaParabola'
+    relFile = avaDir / 'Inputs' / 'REL' / 'release1PF.shp'
+    inputSimFiles['releaseScenario'] = relFile
+    inputSimFiles['demFile'] = avaDir / 'Inputs' / 'DEM_PF_Topo.asc'
+    inputSimFiles['resFile'] = avaDir / 'Inputs' / 'RES' / 'resistance1PF.shp'
+    inputSimFiles['relThFile'] = dirName / 'data' / 'relThFieldTestFile.asc'
+    cfg['GENERAL']['simTypeActual'] = 'res'
+    cfg['GENERAL']['relThFromFile'] = 'False'
+    demOri, inputSimLines = com1DFA.prepareInputData(inputSimFiles, cfg)
+
+    assert demOri['header']['ncols'] == 1001
+    assert demOri['header']['nrows'] == 401
+    assert inputSimLines['releaseLine']['thickness'] == ['1.0']
+    assert inputSimLines['entLine'] is None
+    assert inputSimLines['resLine']['Start'] == np.asarray([0.])
+    assert inputSimLines['resLine']['Length'] == np.asarray([5.])
+    assert inputSimLines['resLine']['Name'] == ['']
+    assert inputSimLines['relThField'] == ''
 
     # call function to be tested
     inputSimFiles = {'entResInfo': {'flagEnt': 'No',
@@ -87,6 +109,7 @@ def test_prepareInputData(tmp_path):
     inputSimFiles['resFile'] = avaDir / 'Inputs' / 'RES' / 'resistance1PF.shp'
     inputSimFiles['relThFile'] = dirName / 'data' / 'relThFieldTestFile.asc'
     cfg['GENERAL']['simTypeActual'] = 'res'
+    cfg['GENERAL']['relThFromFile'] = 'True'
     demOri, inputSimLines = com1DFA.prepareInputData(inputSimFiles, cfg)
 
     print('inputSimLines', inputSimLines)
@@ -114,6 +137,7 @@ def test_prepareInputData(tmp_path):
     IOf.writeResultToAsc(testHeader, testField, testFile, flip=True)
     inputSimFiles['relThFile'] = testFile
     cfg['GENERAL']['simTypeActual'] = 'res'
+    cfg['GENERAL']['relThFromFile'] = 'True'
 
     with pytest.raises(AssertionError) as e:
         assert com1DFA.prepareInputData(inputSimFiles, cfg)
@@ -1082,7 +1106,8 @@ def test_initializeParticles():
                 'xllcenter', 'yllcenter', 'ID', 'nID', 'parentID', 't',
                 'inCellDEM', 'indXDEM', 'indYDEM', 'indPartInCell',
                 'partInCell', 'secondaryReleaseInfo', 'iterate', 'idFixed',
-                'peakForceSPH', 'forceSPHIni', 'totalEnthalpy']
+                'peakForceSPH', 'forceSPHIni', 'totalEnthalpy',
+                'nExitedParticles']
 
     # call function to be tested
     particles = com1DFA.initializeParticles(cfg['GENERAL'], releaseLine, dem)
@@ -1645,7 +1670,7 @@ def test_runCom1DFA(tmp_path, caplog):
                 'inCellDEM', 'indXDEM', 'indYDEM', 'indPartInCell',
                 'partInCell', 'secondaryReleaseInfo', 'iterate',
                 'massEntrained', 'idFixed', 'peakForceSPH', 'forceSPHIni', 'gEff', 'curvAcc',
-                'totalEnthalpy']
+                'totalEnthalpy', 'nExitedParticles']
 
     # read one particles dictionary
     inDir = avaDir / 'Outputs' / 'com1DFA' / 'particles'


### PR DESCRIPTION
* if relThfile found in Inputs/RELTH it was used to set release thickness - should only be used if relThFromFile in cfg is set to True

also include a warning if there were particles exiting the domain at the end of the run and give the number of exited particles