### PR TITLE
change finding of velocity threshold indices in aimec for thalweg plots [ana3]

### DIFF
--- a/avaframe/ana3AIMEC/ana3AIMECCfg.ini
+++ b/avaframe/ana3AIMEC/ana3AIMECCfg.ini
@@ -24,6 +24,9 @@ resTypes = ppr|pft|pfv
 # data result type for runout analysis (ppr, pft, pfv)
 runoutResType = ppr
 
+# show cross profile max or mean values on slComparisonstat plot (options: Max, Mean)
+runoutCrossType = Max
+
 # limit value for evaluation of runout (depends on the runoutResType chosen)
 thresholdValue = 1
 

--- a/avaframe/tests/test_outAIMEC.py
+++ b/avaframe/tests/test_outAIMEC.py
@@ -1,0 +1,59 @@
+''' Tests for module ana3AIMEC plots '''
+import pandas as pd
+import numpy as np
+import pathlib
+import configparser
+import pytest
+
+# Local imports
+import avaframe.out3Plot.outAIMEC as oA
+import avaframe.in3Utils.fileHandlerUtils as fU
+from avaframe.in3Utils import cfgUtils
+
+def test_getIndicesVel():
+    """ test if indices of a  vector exceeding a threshold are found """
+
+    # setup required input
+    a = np.zeros(10)
+    a[2:8] = 10.
+    a[2] = 2.
+    a[5] = 1.2
+    velocityThreshold = 1.
+
+    # call function
+    indStart, indStop = oA.getIndicesVel(a, velocityThreshold)
+
+    assert indStart == 2
+    assert indStop == 7
+
+    a = np.zeros(10) * np.nan
+    a[2:8] = 10.
+    a[2] = 2.
+    a[5] = 1.2
+    velocityThreshold = 1.
+
+    # call function
+    indStart, indStop = oA.getIndicesVel(a, velocityThreshold)
+
+    assert indStart == 2
+    assert indStop == 7
+
+    a = np.zeros(10)
+    a[2:] = 10.
+    a[2] = 0.9
+    velocityThreshold = 1.
+
+    # call function
+    indStart, indStop = oA.getIndicesVel(a, velocityThreshold)
+
+    assert indStart == 3
+    assert indStop == 9
+
+    a = np.zeros(10)
+    a[2:] = 0.4
+    a[2] = 0.9
+    velocityThreshold = 1.
+
+    with pytest.raises(AssertionError) as e:
+        assert oA.getIndicesVel(a, velocityThreshold)
+    assert 'No peak flow velocity max along thalweg found exceeding' in str(e.value)


### PR DESCRIPTION
change how indVelZero index is found for computation of runoutAngle in thalweg plot (just for plot) angle in dataframe is computed differently as it is based on runoutResType and not on velocity but now same method i used