### PR TITLE
allow for multiple relTH files and search for matching one

### DIFF
--- a/avaframe/com1DFA/com1DFACfg.ini
+++ b/avaframe/com1DFA/com1DFACfg.ini
@@ -220,7 +220,7 @@ hmin = 0.05
 meshCellSize = 5
 # threshold under which no remeshing is done
 meshCellSizeThreshold = 0.001
-# clean DEMremeshed directory to ensure remeshing if cosen meshCellsize is different from DEM in Inputs/
+# clean DEMremeshed directory to ensure remeshing if chosen meshCellsize is different from DEM in Inputs/
 cleanDEMremeshed = True
 
 # Normal computation on rectangular grid

--- a/avaframe/com1DFA/deriveParameterSet.py
+++ b/avaframe/com1DFA/deriveParameterSet.py
@@ -333,12 +333,17 @@ def checkThicknessSettings(cfg, thName):
     thRV = thName + 'RangeVariation'
     thPV = thName + 'PercentVariation'
     thRCiV = thName + 'RangeFromCiVariation'
+    flagsList = [cfg['GENERAL'][thRV] != '', cfg['GENERAL'][thPV] != '', cfg['GENERAL'][thRCiV] != '']
 
-    if cfg['GENERAL'][thRV] != '' and cfg['GENERAL'][thPV] != '' and cfg['GENERAL'][thRCiV] != '':
-        message = 'Only one variation type is allowed - check %s and %s' % (thRV, thPV)
+    if sum(flagsList) > 1:
+        message = 'Only one variation type is allowed - check %s and %s, %s' % (thRV, thPV, thRCiV)
         log.error(message)
         raise AssertionError(message)
 
+    if cfg['GENERAL'].getboolean(thFile) and (cfg['GENERAL'][thRV] != '' or cfg['GENERAL'][thPV] != '' or cfg['GENERAL'][thRCiV] != ''):
+        message = 'RelThFromFile is True - no variation allowed: check %s, %s or %s' % (thRV, thPV, thRCiV)
+        log.error(message)
+        raise AssertionError(message)
     # if no error ocurred - thickness settings are correct
     thicknessSettingsCorrect = True
 
@@ -484,7 +489,6 @@ def setThicknessValueFromVariation(key, cfg, simType, row):
         # add thickness values for all features if thFromShape = True
         if cfg['GENERAL'][thFlag] == 'True':
             cfg = setVariationForAllFeatures(cfg, key, thType, varType, variationFactor)
-
         else:
             # update ini thValue if thFromShape=False
             if varType == 'Range':

--- a/avaframe/in1Data/getInput.py
+++ b/avaframe/in1Data/getInput.py
@@ -298,7 +298,7 @@ def getAndCheckInputFiles(inputDir, folder, inputType, fileExt="shp", notMultipl
         raise AssertionError(message)
     else:
         available = "Yes"
-        if len(OutputFile) == 1:
+        if notMultiple:
             OutputFile = OutputFile[0]
 
     return OutputFile, available

--- a/avaframe/in1Data/getInput.py
+++ b/avaframe/in1Data/getInput.py
@@ -230,7 +230,6 @@ def getInputDataCom1DFA(avaDir):
     relThFile, entResInfo["releaseThicknessFile"] = getAndCheckInputFiles(
         inputDir, "RELTH", "release thickness data", fileExt="asc", notMultiple=False,
     )
-    print('RELTH file here', relThFile)
 
     # Initialise secondary release areas
     secondaryReleaseFile, entResInfo["flagSecondaryRelease"] = getAndCheckInputFiles(

--- a/avaframe/tests/test_deriveParameterSet.py
+++ b/avaframe/tests/test_deriveParameterSet.py
@@ -237,7 +237,8 @@ def test_checkThicknessSettings():
     # setup required inputs
     cfg = configparser.ConfigParser()
     cfg['GENERAL'] = {'entThFromShp': 'True', 'entTh': '', 'entThPercentVariation': '',
-                      'entThRangeVariation': ''}
+                      'entThRangeVariation': '', 'entThRangeFromCiVariation': ''
+                      }
 
     thName = 'entTh'
 
@@ -273,6 +274,37 @@ def test_checkThicknessSettings():
         assert dP.checkThicknessSettings(cfg, 'relTh')
     assert str(e.value) == ("If %s is set to True - it is not allowed to set %s to True or provide a value in %s" %
         ('relThFromFile', 'relThFromShp', 'relTh'))
+
+    # setup required inputs
+    cfg = configparser.ConfigParser()
+    cfg['GENERAL'] = {'relThFromShp': 'False', 'relTh': '', 'relThPercentVariation': '',
+                      'relThRangeVariation': '', 'relThRangeFromCiVariation': '',
+                      'relThFromFile': 'True'
+                      }
+
+    thName = 'relTh'
+
+    thicknessSettingsCorrect = dP.checkThicknessSettings(cfg, thName)
+
+    assert thicknessSettingsCorrect
+
+    cfg['GENERAL']['relThRangeVariation'] = '50$4'
+
+    with pytest.raises(AssertionError) as e:
+        assert dP.checkThicknessSettings(cfg, 'relTh')
+    assert 'RelThFromFile is True - no variation allowed: check' in str(e.value)
+
+    # setup required inputs
+    cfg = configparser.ConfigParser()
+    cfg['GENERAL'] = {'relThFromShp': 'True', 'relTh': '', 'relThPercentVariation': '',
+                      'relThRangeVariation': '50$4', 'relThRangeFromCiVariation': '50$1',
+                      'relThFromFile': 'False'
+                      }
+
+    thName = 'relTh'
+    with pytest.raises(AssertionError) as e:
+        assert dP.checkThicknessSettings(cfg, 'relTh')
+    assert 'Only one variation type is allowed - check' in str(e.value)
 
 
 def test_appendShpThickness():


### PR DESCRIPTION
* allow multiple RELTH files with different spatial resolution in Inputs/RELTH folder
* when creating simDicts, set path to matching relTh file in configuration 
* this is then loaded when the inputs are loaded for each sim 