### PR TITLE
Reduce resistance parameters to one parameter [com1]

### DIFF
--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -1607,9 +1607,7 @@ def initializeResistance(cfg, dem, simTypeActual, resLine, reportAreaInfo, thres
     reportAreaInfo: dict
         simulation area information dictionary completed with entrainment area info
     """
-    d = cfg.getfloat("dRes")
-    cw = cfg.getfloat("cw")
-    sres = cfg.getfloat("sres")
+    cRes = cfg.getfloat("cRes")
     # read dem header
     header = dem["originalHeader"]
     ncols = header["ncols"]
@@ -1620,7 +1618,8 @@ def initializeResistance(cfg, dem, simTypeActual, resLine, reportAreaInfo, thres
         log.info("Resistance area features: %s" % (resLine["Name"]))
         resLine = geoTrans.prepareArea(resLine, dem, thresholdPointInPoly)
         mask = resLine["rasterData"]
-        cResRaster = 0.5 * d * cw / (sres * sres) * mask
+        # Combine constants (d, cw, sres) to one parameter cRes
+        cResRaster = cRes * mask
         reportAreaInfo["resistance"] = "Yes"
     else:
         cResRaster = np.zeros((nrows, ncols))

--- a/avaframe/com1DFA/com1DFACfg.ini
+++ b/avaframe/com1DFA/com1DFACfg.ini
@@ -349,12 +349,8 @@ cpIce = 2050.0
 #++++++++++++ Resistance force parameters
 # height of the obstacles
 hRes = 10
-# resistance coeff
-cw = 0.5
-# diameter of obstacles
-dRes = 0.3
-# spacing between obstacles
-sres = 5
+# combine parameters from above for resistance force to one parameter
+cRes = 0.003
 #++++++++++++ Entrainment Erosion Energy
 entEroEnergy = 5000
 entShearResistance = 0

--- a/avaframe/runScripts/runPlotProfile.py
+++ b/avaframe/runScripts/runPlotProfile.py
@@ -27,7 +27,7 @@ resType = "pfv"
 # Load avalanche directory from general configuration file
 cfgMain = cfgUtils.getGeneralConfig()
 avalancheDir = cfgMain["MAIN"]["avalancheDir"]
-outDir = pathlib.Path(avalancheDir, 'Outputs', 'out3Plot')
+outDir = pathlib.Path(avalancheDir, 'Outputs', '../out3Plot')
 
 # Start logging
 logName = "plotProfiles_%s_%s" % (resType, varPar)

--- a/avaframe/tests/test_com1DFA.py
+++ b/avaframe/tests/test_com1DFA.py
@@ -672,7 +672,7 @@ def test_initializeResistance():
 
     # setup required input
     cfg = configparser.ConfigParser()
-    cfg["GENERAL"] = {"dRes": "0.3", "cw": "0.5", "sres": "5"}
+    cfg["GENERAL"] = {"cRes": 0.003}
 
     nrows = 11
     ncols = 15


### PR DESCRIPTION
The resistance parameter c_res is not computed by parameters such as diameter, distance of obstacles and a coefficient. They are summarized to c_res as one input parameter.