### PR TITLE
Include py 3.12; add psutil requirement

### DIFF
--- a/.github/workflows/releaseWithManylinux.yml
+++ b/.github/workflows/releaseWithManylinux.yml
@@ -32,7 +32,7 @@ jobs:
       - name: build manylinux wheels
         uses: RalfG/python-wheels-manylinux-build@v0.6.0
         with:
-          python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311'
+          python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311 cp312-cp312'
           build-requirements: 'cython numpy'
       - name: Publish wheels to PyPI
         run: |
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -81,7 +81,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest]
-        python-version: ['3.7','3.8','3.9','3.10','3.11']
+        python-version: ['3.7','3.8','3.9','3.10','3.11','3.12']
     steps:
       - uses: actions/checkout@v4
         with:

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ URL = "http://avaframe.org"
 CLASSIFIERS = [
     # How mature is this project? Common values are
     # 3 - Alpha  4 - Beta  5 - Production/Stable
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     # Indicate who your project is intended for
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: European Union Public Licence 1.2 (EUPL 1.2)",
@@ -39,6 +39,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 DESCRIPTION = "The Open Avalanche Framework"
@@ -57,6 +58,7 @@ req_packages = [
     "tabulate",
     "deepdiff",
     "deepmerge",
+    "psutil",
 ]
 
 


### PR DESCRIPTION
Newest QGis uses python 3.12, this updates the release scripts to include 3.12

Thanks @ Sebastian D. for reporting.