### PR TITLE
Remove python 3.7 from Windows and Mac os build

### DIFF
--- a/.github/workflows/releaseWithManylinux.yml
+++ b/.github/workflows/releaseWithManylinux.yml
@@ -81,7 +81,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest]
-        python-version: ['3.7','3.8','3.9','3.10','3.11','3.12']
+        python-version: ['3.8','3.9','3.10','3.11','3.12']
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/runTestSinglePython.yml
+++ b/.github/workflows/runTestSinglePython.yml
@@ -53,7 +53,7 @@ jobs:
       run: |
         pytest -ra --cov --cov-report=xml --cov-config=.coveragerc
     - name: Test & publish code coverage
-      uses: paambaati/codeclimate-action@v3.2.0
+      uses: paambaati/codeclimate-action@v6.0.0
       env:
         CC_TEST_REPORTER_ID: ${{ secrets.CODECLIMATE_ID }}
     - name: Upload coverage to Codecov


### PR DESCRIPTION
- no arm 64 for python version 3.7 is available -> removing it from win and mac os builds