### PR TITLE
Immediate bugFixes to com4FlowPy and minor mode enhancement [com4]

### DIFF
--- a/avaframe/com4FlowPy/com4FlowPy.py
+++ b/avaframe/com4FlowPy/com4FlowPy.py
@@ -113,6 +113,7 @@ def com4FlowPyMain(cfgPath, cfgSetup):
         forestParams["velThForDetrain"] = cfgSetup.getfloat("velThForDetrain")  # float(cfgSetup["velThForDetrain"])
         # 'forestFrictionLayer' parameter
         forestParams["fFrLayerType"] = cfgSetup.get("forestFrictionLayerType")
+        forestParams["nSkipForest"] = cfgSetup.getint("skipForestCells")
 
     else:
         modelPaths["forestPath"] = ""
@@ -208,7 +209,7 @@ def checkInputLayerDimensions(modelParameters, modelPaths):
         log.info("checking input layer alignment ...")
 
         _demHeader = IOf.readASCheader(modelPaths["demPath"])
-        _relHeader = io.read_header(modelPaths["releasePath"])
+        _relHeader = io.read_header(modelPaths["releasePathWork"])
 
         if _demHeader["ncols"] == _relHeader["ncols"] and _demHeader["nrows"] == _relHeader["nrows"]:
             log.info("DEM and Release Layer ok!")
@@ -349,6 +350,8 @@ def checkConvertReleaseShp2Tif(modelPaths):
 
         dem = IOf.readRaster(modelPaths["demPath"])
         demHeader = IOf.readASCheader(modelPaths["demPath"])
+
+        dem['originalHeader'] = demHeader
 
         releaseLine = shpConv.SHP2Array(modelPaths["releasePath"], "releasePolygon")
         thresholdPointInPoly = 0.01

--- a/avaframe/com4FlowPy/com4FlowPyCfg.ini
+++ b/avaframe/com4FlowPy/com4FlowPyCfg.ini
@@ -109,6 +109,14 @@ velThForDetrain   = 0
 # ['absolute', 'relative']
 forestFrictionLayerType = absolute
 
+# ['1 cell', '2 cells']
+# if value == 1 forest effect is not considered at the start cell (default behaviour)
+# if value == 2 also first cell after start cell has no forest effect
+# background --> for some processes (e.g.) rockfall it might make sense, if a first
+# acceleration phase is allowed before accounting for forest effects
+# NOTE: this currently only works with 'forestFrictionLayer' module!!
+skipForestCells = 1 
+
 #++++++++++++ Parameters for Tiling
 # tileSize: size of tiles in x and y direction in meters (if total size of) x
 #           or y of input DEM is larger than tileSize, then the input raster

--- a/avaframe/com4FlowPy/flowClass.py
+++ b/avaframe/com4FlowPy/flowClass.py
@@ -91,6 +91,7 @@ class Cell:
 
                 self.AlphaFor = max(self.AlphaFor, self.alpha)  # Friction in Forest can't be lower than without forest
                 self.tanAlphaFor = np.tan(np.deg2rad(self.AlphaFor))
+                self.nSkipForestCells = forestParams["nSkipForest"]
 
             # NOTE: This is a quick hack to check if all values for Detrainment are set to 0 (as provided in the
             #      .ini file)
@@ -171,7 +172,15 @@ class Cell:
 
         if self.forestBool:
             if self.forestModule == "forestFrictionLayer":
-                _tanAlpha = self.tanAlphaFor
+                # default behavior - forest effect only neglected for start-cells
+                if (self.nSkipForestCells == 1) and (not self.is_start):
+                    _tanAlpha = self.tanAlphaFor
+                # forest effect also neglected for direct successors to the start-cell if nSkipForestCells==2
+                elif ((self.nSkipForestCells == 2) and (not self.is_start) and
+                      (True not in [x.is_start for x in self.lOfParents])):
+                    _tanAlpha = self.tanAlphaFor
+                else:
+                    _tanAlpha = self.tanAlpha
 
             elif (self.forestModule == "forestFriction") or (self.forestModule == "forestDetrainment"):
 


### PR DESCRIPTION
- Fixes 1 Bug in com4FlowPy with .shp release areas not working correctly and com4FlowPy crashing if .shp and .tif files are present in the /REL folder.
- Fixes undesired model behavior in 'ForestFrictionLayer' forest module:
    - Now also in this module no forest-effect is considered, if the cell is a start-cell (which is the desired behavior)
- Adds an additional option to extend the zone where forest-effects are not considered to the first row of child cells of each start cell ('skipForestCells = 2') if the  'ForestFrictionLayer' is used (ÖKO-/Prio- SchuWa specific feature)
  