### PR TITLE
 [com1DFA]: Add options for computing resistance (especially dealing with hEff)

### DIFF
--- a/avaframe/com1DFA/DFAfunctionsCython.pxd
+++ b/avaframe/com1DFA/DFAfunctionsCython.pxd
@@ -10,7 +10,7 @@ cpdef (double, double) computeEntMassAndForce(double, double, double, double, do
 
 cpdef double computeDetMass(double, double, double, double)
 
-cpdef double computeResForce(double, double, double, double, double, double, int)
+cpdef double computeResForce(double, double, double, double, double, double, double, double, int, int)
 
 cdef (double, double, double) addArtificialViscosity(double, double, double, double, double, double, double, double,
                                                      int, int, double, double, double, double,

--- a/avaframe/com1DFA/DFAfunctionsCython.pxd
+++ b/avaframe/com1DFA/DFAfunctionsCython.pxd
@@ -10,7 +10,7 @@ cpdef (double, double) computeEntMassAndForce(double, double, double, double, do
 
 cpdef double computeDetMass(double, double, double, double)
 
-cpdef double computeResForce(double, double, double, double, double, double, double, double, int, int)
+cpdef double computeResForce(double, double, double, double, double, double, int, int)
 
 cdef (double, double, double) addArtificialViscosity(double, double, double, double, double, double, double, double,
                                                      int, int, double, double, double, double,

--- a/avaframe/com1DFA/DFAfunctionsCython.pyx
+++ b/avaframe/com1DFA/DFAfunctionsCython.pyx
@@ -102,7 +102,6 @@ def computeForceC(cfg, particles, fields, dem, int frictType, int resistanceType
   cdef double dt = particles['dt']
   cdef double mu0 = cfg.getfloat('mu0wetsnow')
   cdef double xsiWetSnow = cfg.getfloat('xsiwetsnow')
-  cdef double muResCoulomb = cfg.getfloat('muResCoulomb')
   cdef int nPart = particles['nPart']
   cdef double csz = dem['header']['cellsize']
   cdef int nrows = dem['header']['nrows']
@@ -372,8 +371,7 @@ def computeForceC(cfg, particles, fields, dem, int frictType, int resistanceType
 
       # adding resistance force due to obstacles
       cResCell = cResRaster[indCellY][indCellX]
-      cResPart = computeResForce(hRes, h, areaPart, rho, cResCell, uMag, sigmaB, 
-                                 muResCoulomb, explicitFriction, resistanceType)
+      cResPart = computeResForce(hRes, h, areaPart, rho, cResCell, uMag, explicitFriction, resistanceType)
       forceFrict[k] = forceFrict[k] - cResPart
 
       uxArray[k] = ux
@@ -505,7 +503,7 @@ cpdef double computeDetMass(double dt, double detCell,
 
 
 cpdef double computeResForce(double hRes, double h, double areaPart, double rho, double cResCell,
-                             double uMag, double sigmaB, double muCoulomb, int explicitFriction, int resistanceType):
+                             double uMag, int explicitFriction, int resistanceType):
   """ compute force component due to resistance
 
   Parameters
@@ -522,10 +520,6 @@ cpdef double computeResForce(double hRes, double h, double areaPart, double rho,
       resisance coefficient of cell
   uMag : float
       particle speed (velocity magnitude)
-  sigmaB : float
-      bottom normal stress
-  muCoulomb: float
-      mu for Coulomb friction/resistance
   explicitFriction: int
     if 1 add resistance with an explicit method. Implicit otherwise
   resistanceType: int
@@ -548,18 +542,6 @@ cpdef double computeResForce(double hRes, double h, double areaPart, double rho,
     elif resistanceType == 2:
       # cResH
       cRecResPart = - rho * areaPart * cResCell * uMag * uMag
-    elif resistanceType == 3:
-      #cResCoulomb
-      if cResCell > 0:
-        cRecResPart = - rho * areaPart * hResEff * cResCell * uMag * uMag - sigmaB * muCoulomb
-      else:
-        cRecResPart = 0
-    elif resistanceType == 4:
-      #cResHCoulomb
-      if cResCell > 0:
-        cRecResPart = - rho * areaPart * cResCell * uMag * uMag - sigmaB * muCoulomb
-      else:
-        cRecResPart = 0
   elif explicitFriction == 0:
     if resistanceType == 1:
       # cRes
@@ -567,18 +549,6 @@ cpdef double computeResForce(double hRes, double h, double areaPart, double rho,
     elif resistanceType == 2:
       # cResH
       cRecResPart = - rho * areaPart * cResCell * uMag
-    elif resistanceType == 3:
-      #cResCoulomb
-      if cResCell > 0:
-        cRecResPart = - rho * areaPart * hResEff * cResCell * uMag - sigmaB * muCoulomb
-      else:
-        cRecResPart = 0
-    elif resistanceType == 4:
-      #cResHCoulomb
-      if cResCell > 0:
-        cRecResPart = - rho * areaPart * cResCell * uMag - sigmaB * muCoulomb
-      else:
-        cRecResPart = 0
   return cRecResPart
 
 

--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -1641,12 +1641,10 @@ def initializeResistance(cfg, dem, simTypeActual, resLine, reportAreaInfo, thres
     detrainment = cfg.getboolean("detrainment")
     detWithoutRes = cfg.getboolean("detWithoutRes")
 
-    # TODO: if we keep the ResCoulomb - resistance types,
-    # we should initialize the Coulomb-Value (as the resistamce parameter)
     ResModel = cfg["ResistanceModel"].lower()
-    if ResModel in ["cres", "crescoulomb"]:
+    if ResModel == "cres":
         cRes = cfg.getfloat("cRes")
-    if ResModel in ["cresh", "creshcoulomb"]:
+    if ResModel == "cresh":
         cRes = cfg.getfloat("cResH")
     # read dem header
     header = dem["originalHeader"]
@@ -1761,14 +1759,10 @@ def DFAIterate(cfg, particles, fields, dem, inputSimLines, simHash=""):
     log.debug("Friction Model used: %s, %s" % (frictModelsList[frictType - 1], frictType))
 
     # turn resistance model into integer
-    # TODO: the different resistance parameters are tested experimentally
-    # TODO: unnecessary options should be removed
     ResModel = cfgGen["ResistanceModel"].lower()
     ResModelsList = [
         "cres",
         "cresh",
-        "crescoulomb",
-        "creshcoulomb"
     ]
     resistanceType = ResModelsList.index(ResModel) + 1
     log.debug("Resistance Model used: %s, %s" % (ResModelsList[resistanceType - 1], resistanceType))

--- a/avaframe/com1DFA/com1DFACfg.ini
+++ b/avaframe/com1DFA/com1DFACfg.ini
@@ -350,18 +350,16 @@ entTempRef = -10.0
 cpIce = 2050.0
 
 #++++++++++++ Resistance force parameters
-# Choose model, how resistance and the resistance parameter is computed:
-# cRes : F = cRes *hEff * rho * A* u²; hEff = min(hRes,h) [cRes] = 1/m
-# cResH : F = cResH * rho * A* u², [cResH] =[]
-# cResCoulomb : F = cRes *hEff * rho * A* u² + sigmaB * muResCoulomb; hEff = min(hRes,h) [cRes] = 1/m
-# cResHCoulomb : F = cResH * rho * A* u² + sigmaB * muResCoulomb; [cResH] = []
+# Choose one resistance model:
+# cRes : F = - cRes *hEff * rho * A* u²; hEff = min(hRes,h) [cRes] = 1/m
+# cResH : F = - cResH * rho * A* u², [cResH] =[]
 ResistanceModel = cRes
 # height of the obstacles [m]
 hRes = 10
 # resistance parameters for different models
 cRes = 0.003
 cResH = 0.003
-muResCoulomb = 0.1
+
 #++++++++++++ Detrainment parameter
 # Flag if snow detrainment at obstacles (in resistance area) is computed
 # detrainment can be added to resistance force (DetAndRes = True) or computed solely (DetWithoutRes = True)

--- a/avaframe/com1DFA/com1DFACfg.ini
+++ b/avaframe/com1DFA/com1DFACfg.ini
@@ -350,10 +350,18 @@ entTempRef = -10.0
 cpIce = 2050.0
 
 #++++++++++++ Resistance force parameters
-# height of obstacles [m]
+# Choose model, how resistance and the resistance parameter is computed:
+# cRes : F = cRes *hEff * rho * A* u²; hEff = min(hRes,h) [cRes] = 1/m
+# cResH : F = cResH * rho * A* u², [cResH] =[]
+# cResCoulomb : F = cRes *hEff * rho * A* u² + sigmaB * muResCoulomb; hEff = min(hRes,h) [cRes] = 1/m
+# cResHCoulomb : F = cResH * rho * A* u² + sigmaB * muResCoulomb; [cResH] = []
+ResistanceModel = cRes
+# height of the obstacles [m]
 hRes = 10
-# characteristic coefficient
+# resistance parameters for different models
 cRes = 0.003
+cResH = 0.003
+muResCoulomb = 0.1
 #++++++++++++ Detrainment parameter
 # Flag if snow detrainment at obstacles (in resistance area) is computed
 # detrainment can be added to resistance force (DetAndRes = True) or computed solely (DetWithoutRes = True)
@@ -362,6 +370,7 @@ detWithoutRes = False
 # detrainment parameter defined by Feistl et al. (2014)
 # value need to be refined
 detK = 20  
+
 #++++++++++++ Entrainment Erosion Energy
 # Used to determine speed loss via energy loss due to entrained mass
 entEroEnergy = 5000

--- a/avaframe/tests/test_DFAfunctionsCython.py
+++ b/avaframe/tests/test_DFAfunctionsCython.py
@@ -133,22 +133,60 @@ def test_computeResForce(capfd):
     cResCell = 1
     uMag = 10
     explicitFriction = 0
+    sigmaB = 10
+    muCoulomb = 0.1
+    #cRes
+    resistanceType = 1
     cResPart = DFAfunC.computeResForce(
-        hRes, h, areaPart, rho, cResCell, uMag, explicitFriction)
-#    print(cResPart)
+        hRes, h, areaPart, rho, cResCell, uMag, sigmaB, muCoulomb, explicitFriction, resistanceType)
+    print(cResPart)
     assert cResPart == -2000
 
     h = 3
     cResPart = DFAfunC.computeResForce(
-        hRes, h, areaPart, rho, cResCell, uMag, explicitFriction)
-#    print(cResPart)
+        hRes, h, areaPart, rho, cResCell, uMag, sigmaB, muCoulomb, explicitFriction, resistanceType)
+    print(cResPart)
     assert cResPart == -4000
 
     explicitFriction = 1
     cResPart = DFAfunC.computeResForce(
-        hRes, h, areaPart, rho, cResCell, uMag, explicitFriction)
-#    print(cResPart)
+        hRes, h, areaPart, rho, cResCell, uMag, sigmaB, muCoulomb, explicitFriction, resistanceType)
+    print(cResPart)
     assert cResPart == -40000
+
+    #cResH
+    explicitFriction = 0
+    resistanceType = 2
+    cResPart = DFAfunC.computeResForce(
+        hRes, h, areaPart, rho, cResCell, uMag, sigmaB, muCoulomb, explicitFriction, resistanceType)
+    print(cResPart)
+    assert cResPart == -2000
+
+    h = 1
+    cResPart = DFAfunC.computeResForce(
+        hRes, h, areaPart, rho, cResCell, uMag, sigmaB, muCoulomb, explicitFriction, resistanceType)
+    print(cResPart)
+    assert cResPart == -2000
+
+    #cResCoulomb
+    resistanceType = 3
+    cResPart = DFAfunC.computeResForce(
+        hRes, h, areaPart, rho, cResCell, uMag, sigmaB, muCoulomb, explicitFriction, resistanceType)
+    print(cResPart)
+    assert cResPart == -2001
+
+    h = 3
+    cResPart = DFAfunC.computeResForce(
+        hRes, h, areaPart, rho, cResCell, uMag, sigmaB, muCoulomb, explicitFriction, resistanceType)
+    print(cResPart)
+    assert cResPart == -4001
+
+    #cResHCoulomb
+    resistanceType = 4
+    cResPart = DFAfunC.computeResForce(
+        hRes, h, areaPart, rho, cResCell, uMag, sigmaB, muCoulomb, explicitFriction, resistanceType)
+    print(cResPart)
+    assert cResPart == -2001
 
 
 def test_account4FrictionForce(capfd):

--- a/avaframe/tests/test_DFAfunctionsCython.py
+++ b/avaframe/tests/test_DFAfunctionsCython.py
@@ -133,24 +133,22 @@ def test_computeResForce(capfd):
     cResCell = 1
     uMag = 10
     explicitFriction = 0
-    sigmaB = 10
-    muCoulomb = 0.1
     #cRes
     resistanceType = 1
     cResPart = DFAfunC.computeResForce(
-        hRes, h, areaPart, rho, cResCell, uMag, sigmaB, muCoulomb, explicitFriction, resistanceType)
+        hRes, h, areaPart, rho, cResCell, uMag, explicitFriction, resistanceType)
     print(cResPart)
     assert cResPart == -2000
 
     h = 3
     cResPart = DFAfunC.computeResForce(
-        hRes, h, areaPart, rho, cResCell, uMag, sigmaB, muCoulomb, explicitFriction, resistanceType)
+        hRes, h, areaPart, rho, cResCell, uMag, explicitFriction, resistanceType)
     print(cResPart)
     assert cResPart == -4000
 
     explicitFriction = 1
     cResPart = DFAfunC.computeResForce(
-        hRes, h, areaPart, rho, cResCell, uMag, sigmaB, muCoulomb, explicitFriction, resistanceType)
+        hRes, h, areaPart, rho, cResCell, uMag, explicitFriction, resistanceType)
     print(cResPart)
     assert cResPart == -40000
 
@@ -158,35 +156,15 @@ def test_computeResForce(capfd):
     explicitFriction = 0
     resistanceType = 2
     cResPart = DFAfunC.computeResForce(
-        hRes, h, areaPart, rho, cResCell, uMag, sigmaB, muCoulomb, explicitFriction, resistanceType)
+        hRes, h, areaPart, rho, cResCell, uMag, explicitFriction, resistanceType)
     print(cResPart)
     assert cResPart == -2000
 
     h = 1
     cResPart = DFAfunC.computeResForce(
-        hRes, h, areaPart, rho, cResCell, uMag, sigmaB, muCoulomb, explicitFriction, resistanceType)
+        hRes, h, areaPart, rho, cResCell, uMag, explicitFriction, resistanceType)
     print(cResPart)
     assert cResPart == -2000
-
-    #cResCoulomb
-    resistanceType = 3
-    cResPart = DFAfunC.computeResForce(
-        hRes, h, areaPart, rho, cResCell, uMag, sigmaB, muCoulomb, explicitFriction, resistanceType)
-    print(cResPart)
-    assert cResPart == -2001
-
-    h = 3
-    cResPart = DFAfunC.computeResForce(
-        hRes, h, areaPart, rho, cResCell, uMag, sigmaB, muCoulomb, explicitFriction, resistanceType)
-    print(cResPart)
-    assert cResPart == -4001
-
-    #cResHCoulomb
-    resistanceType = 4
-    cResPart = DFAfunC.computeResForce(
-        hRes, h, areaPart, rho, cResCell, uMag, sigmaB, muCoulomb, explicitFriction, resistanceType)
-    print(cResPart)
-    assert cResPart == -2001
 
 
 def test_account4FrictionForce(capfd):

--- a/avaframe/tests/test_com1DFA.py
+++ b/avaframe/tests/test_com1DFA.py
@@ -690,7 +690,11 @@ def test_initializeResistance():
 
     # setup required input
     cfg = configparser.ConfigParser()
-    cfg["GENERAL"] = {"cRes": 0.003, "detK": 10, "detrainment": False, "detWithoutRes": False}
+    cfg["GENERAL"] = {"cRes": 0.003,
+                      "ResistanceModel": "cRes",
+                       "detK": 10, 
+                      "detrainment": False, 
+                      "detWithoutRes": False}
 
     nrows = 11
     ncols = 15
@@ -737,7 +741,11 @@ def test_initializeResistance():
     assert reportAreaInfo["resistance"] == "Yes"
     assert reportAreaInfo["detrainment"] == "No"
 
-    cfg["GENERAL"] = {"cRes": 0.003, "detK": 10.0, "detrainment": True, "detWithoutRes": False}
+    cfg["GENERAL"] = {"cRes": 0.003,
+                      "ResistanceModel": "cRes",
+                       "detK": 10.0, 
+                      "detrainment": True, 
+                      "detWithoutRes": False}
     cResRaster, detRaster, reportAreaInfo = com1DFA.initializeResistance(
         cfg["GENERAL"], dem, simTypeActual, resLine, reportAreaInfo, thresholdPointInPoly
     )
@@ -751,7 +759,11 @@ def test_initializeResistance():
     assert reportAreaInfo["resistance"] == "Yes"
     assert reportAreaInfo["detrainment"] == "Yes"
 
-    cfg["GENERAL"] = {"cRes": 0.003, "detK": 10.0, "detrainment": True, "detWithoutRes": True}
+    cfg["GENERAL"] = {"cRes": 0.003,
+                      "ResistanceModel": "cRes",
+                       "detK": 10.0, 
+                      "detrainment": True, 
+                      "detWithoutRes": True}
     cResRaster, detRaster, reportAreaInfo = com1DFA.initializeResistance(
         cfg["GENERAL"], dem, simTypeActual, resLine, reportAreaInfo, thresholdPointInPoly
     )
@@ -764,6 +776,45 @@ def test_initializeResistance():
     assert np.sum(cResRaster) == 0.0
     assert reportAreaInfo["resistance"] == "No"
     assert reportAreaInfo["detrainment"] == "Yes"
+
+    cfg["GENERAL"] = {"cRes": 0.003,
+                      "ResistanceModel": "cResCoulomb",
+                     "detK": 10.0, 
+                      "detrainment": False, 
+                      "detWithoutRes": False}
+    cResRaster, detRaster, reportAreaInfo = com1DFA.initializeResistance(
+        cfg["GENERAL"], dem, simTypeActual, resLine, reportAreaInfo, thresholdPointInPoly
+    )
+    assert np.array_equal(cResRaster, testArray)
+    assert np.array_equal(detRaster, np.zeros((nrows, ncols)))
+    assert np.sum(detRaster) == 0.0
+    assert np.sum(cResRaster) == 0.363
+    assert reportAreaInfo["resistance"] == "Yes"
+    assert reportAreaInfo["detrainment"] == "No"
+
+    cfg["GENERAL"] = {"cResH": 0.003,
+                      "ResistanceModel": "cResH",
+                       "detK": 10.0, 
+                      "detrainment": False, 
+                      "detWithoutRes": False}
+    cResRaster, detRaster, reportAreaInfo = com1DFA.initializeResistance(
+        cfg["GENERAL"], dem, simTypeActual, resLine, reportAreaInfo, thresholdPointInPoly
+    )
+    assert np.array_equal(cResRaster, testArray)
+    assert np.sum(cResRaster) == 0.363
+    assert reportAreaInfo["resistance"] == "Yes"
+
+    cfg["GENERAL"] = {"cResH": 0.003,
+                      "ResistanceModel": "cResHCoulomb",
+                       "detK": 10.0, 
+                      "detrainment": False, 
+                      "detWithoutRes": False}         
+    cResRaster, detRaster, reportAreaInfo = com1DFA.initializeResistance(
+        cfg["GENERAL"], dem, simTypeActual, resLine, reportAreaInfo, thresholdPointInPoly
+    )         
+    assert np.array_equal(cResRaster, testArray)
+    assert np.sum(cResRaster) == 0.363
+    assert reportAreaInfo["resistance"] == "Yes"
 
 
 def test_setDEMOriginToZero():
@@ -1841,6 +1892,7 @@ def test_initializeSimulation(tmp_path):
         "entTempRef": "-10.",
         "cpIce": "2050.",
         "TIni": "-10.",
+        "ResistanceModel": "cRes"
     }
     # setup dem input
     demHeader = {}

--- a/avaframe/tests/test_com1DFA.py
+++ b/avaframe/tests/test_com1DFA.py
@@ -777,21 +777,6 @@ def test_initializeResistance():
     assert reportAreaInfo["resistance"] == "No"
     assert reportAreaInfo["detrainment"] == "Yes"
 
-    cfg["GENERAL"] = {"cRes": 0.003,
-                      "ResistanceModel": "cResCoulomb",
-                     "detK": 10.0, 
-                      "detrainment": False, 
-                      "detWithoutRes": False}
-    cResRaster, detRaster, reportAreaInfo = com1DFA.initializeResistance(
-        cfg["GENERAL"], dem, simTypeActual, resLine, reportAreaInfo, thresholdPointInPoly
-    )
-    assert np.array_equal(cResRaster, testArray)
-    assert np.array_equal(detRaster, np.zeros((nrows, ncols)))
-    assert np.sum(detRaster) == 0.0
-    assert np.sum(cResRaster) == 0.363
-    assert reportAreaInfo["resistance"] == "Yes"
-    assert reportAreaInfo["detrainment"] == "No"
-
     cfg["GENERAL"] = {"cResH": 0.003,
                       "ResistanceModel": "cResH",
                        "detK": 10.0, 
@@ -800,18 +785,6 @@ def test_initializeResistance():
     cResRaster, detRaster, reportAreaInfo = com1DFA.initializeResistance(
         cfg["GENERAL"], dem, simTypeActual, resLine, reportAreaInfo, thresholdPointInPoly
     )
-    assert np.array_equal(cResRaster, testArray)
-    assert np.sum(cResRaster) == 0.363
-    assert reportAreaInfo["resistance"] == "Yes"
-
-    cfg["GENERAL"] = {"cResH": 0.003,
-                      "ResistanceModel": "cResHCoulomb",
-                       "detK": 10.0, 
-                      "detrainment": False, 
-                      "detWithoutRes": False}         
-    cResRaster, detRaster, reportAreaInfo = com1DFA.initializeResistance(
-        cfg["GENERAL"], dem, simTypeActual, resLine, reportAreaInfo, thresholdPointInPoly
-    )         
     assert np.array_equal(cResRaster, testArray)
     assert np.sum(cResRaster) == 0.363
     assert reportAreaInfo["resistance"] == "Yes"

--- a/docs/theoryCom1DFA.rst
+++ b/docs/theoryCom1DFA.rst
@@ -217,6 +217,22 @@ coefficient :math:`c_{\text{res}}` that depends on the structure of the obstacle
 
 Note: in previous versions, this formula included information about tree diameter, tree spacing, etc. Please check out previous documentation versions for details.
 
+Three other options for computing resistance force :math:`F_i^{\text{res}}` can be chosen (they are still tested experimentally):
+
+- .. math::
+   F_i^{\text{res}} = -c_{\text{resH}}\,\rho_0\,A\,
+    \overline{u}^2\,
+    \frac{\overline{u}_i}{\|\overline{u}\|}
+- .. math::
+   F_i^{\text{res}} = - c_{\text{resCoulomb}}\,\rho_0\,A\,
+    h^{\text{eff}}\,\overline{u}^2\,
+    \frac{\overline{u}_i}{\|\overline{u}\|} + \sigma^{(b)}\,\mu
+- .. math::
+   F_i^{\text{res}} = - c_{\text{resHCoulomb}}\,\rho_0\,A\,
+   \overline{u}^2\,
+    \frac{\overline{u}_i}{\|\overline{u}\|} + \sigma^{(b)}\,\mu
+    
+with characteristic coefficients :math:`c_{\text{resH}}`, :math:`c_{\text{resCoulomb}}`, :math:`c_{\text{resHCoulomb}}`.
 
 
 Surface integral forces:

--- a/docs/theoryCom1DFA.rst
+++ b/docs/theoryCom1DFA.rst
@@ -217,22 +217,14 @@ coefficient :math:`c_{\text{res}}` that depends on the structure of the obstacle
 
 Note: in previous versions, this formula included information about tree diameter, tree spacing, etc. Please check out previous documentation versions for details.
 
-Three other options for computing resistance force :math:`F_i^{\text{res}}` can be chosen (they are still tested experimentally):
+There is also the option to compute the resistance force :math:`F_i^{\text{res}}`  independent of the effective height :math:`h^{\text{eff}}`:
 
 - .. math::
    F_i^{\text{res}} = -c_{\text{resH}}\,\rho_0\,A\,
     \overline{u}^2\,
     \frac{\overline{u}_i}{\|\overline{u}\|}
-- .. math::
-   F_i^{\text{res}} = - c_{\text{resCoulomb}}\,\rho_0\,A\,
-    h^{\text{eff}}\,\overline{u}^2\,
-    \frac{\overline{u}_i}{\|\overline{u}\|} + \sigma^{(b)}\,\mu
-- .. math::
-   F_i^{\text{res}} = - c_{\text{resHCoulomb}}\,\rho_0\,A\,
-   \overline{u}^2\,
-    \frac{\overline{u}_i}{\|\overline{u}\|} + \sigma^{(b)}\,\mu
     
-with characteristic coefficients :math:`c_{\text{resH}}`, :math:`c_{\text{resCoulomb}}`, :math:`c_{\text{resHCoulomb}}`.
+with characteristic coefficient :math:`c_{\text{resH}}`.
 
 
 Surface integral forces:


### PR DESCRIPTION
added options: 
1. (as before) hEff = min(h, h_res)
2. hEff = const and included in parameter cResH
3. add to option 1 a Coulomb-term 
4. add to option 2 a Coulomb-term 

the options are for experimental tests, we should remove those that are unnecessary.

** Update **
options 3 and 4 are deleted