### PR TITLE
[com4FlowPy]: option for dynamic max_z_delta

### DIFF
--- a/avaframe/com4FlowPy/com4FlowPy.py
+++ b/avaframe/com4FlowPy/com4FlowPy.py
@@ -63,6 +63,9 @@ def com4FlowPyMain(cfgPath, cfgSetup):
     modelParameters["infraBool"] = cfgSetup.getboolean("infra")
     modelParameters["forestBool"] = cfgSetup.getboolean("forest")
     modelParameters["forestInteraction"] = cfgSetup.getboolean("forestInteraction")
+    modelParameters["varUmaxBool"] = cfgSetup.getboolean("variableUmaxLim")
+    modelParameters["varAlphaBool"] = cfgSetup.getboolean("variableAlpha")
+    modelParameters["varExponentBool"] = cfgSetup.getboolean("variableExponent")
     # modelParameters["infra"]  = cfgSetup["infra"]
     # modelParameters["forest"] = cfgSetup["forest"]
 
@@ -119,6 +122,23 @@ def com4FlowPyMain(cfgPath, cfgSetup):
     else:
         modelPaths["forestPath"] = ""
         modelParameters["forestInteraction"] = False
+
+    # check if with u_max limit
+    if modelParameters["varUmaxBool"]:
+        modelParameters["varUmaxType"] = cfgSetup.get("varUmaxParameter")
+        modelPaths["varUmaxPath"] = cfgPath["varUmaxPath"]
+    else:
+        modelPaths["varUmaxPath"] = ""
+    # check if we use the variable alpha layer
+    if modelParameters["varAlphaBool"]:
+        modelPaths["varAlphaPath"] = cfgPath["varAlphaPath"]
+    else:
+        modelPaths["varAlphaPath"] = ""
+    # check if we use the variable exponent layer
+    if modelParameters["varExponentBool"]:
+        modelPaths["varExponentPath"] = cfgPath["varExponentPath"]
+    else:
+        modelPaths["varExponentPath"] = ""
 
     # TODO: provide some kind of check for the model Parameters
     #       i.e. * sensible value ranges
@@ -187,6 +207,18 @@ def startLogging(modelParameters, forestParams, modelPaths, MPOptions):
             log.info(f"{'%s:'%param : <20}{value : <5}")
         log.info(f"{'forestInteraction : ' : <20}{'%s'%modelParameters['forestInteraction'] : <5}")
         log.info("------------------------")
+    if modelParameters["varAlphaBool"]:
+        log.info("Calculation using variable Alpha")
+        log.info(f"{'ALPHA LAYER:' : <14}{'%s'%modelPaths['varAlphaPath'] : <5}")
+        log.info("------------------------")
+    if modelParameters["varUmaxBool"]:
+        log.info("Calculation using variable uMax Limit")
+        log.info(f"{'UMAX LAYER:' : <14}{'%s'%modelPaths['varUmaxPath'] : <5}")
+        log.info("------------------------")
+    if modelParameters["varExponentBool"]:
+        log.info("Calculation using variable Alpha")
+        log.info(f"{'ALPHA LAYER:' : <14}{'%s'%modelPaths['varExponentPath'] : <5}")
+        log.info("------------------------")
     if modelParameters["infraBool"]:
         log.info("calculation with Infrastructure")
         log.info(f"{'INFRA LAYER:' : <14}{'%s'%modelPaths['infraPath'] : <5}")
@@ -233,7 +265,31 @@ def checkInputLayerDimensions(modelParameters, modelPaths):
             if _demHeader["ncols"] == _forestHeader["ncols"] and _demHeader["nrows"] == _forestHeader["nrows"]:
                 log.info("Forest Layer ok!")
             else:
-                log.error("Error: Infra Layer doesn't match DEM!")
+                log.error("Error: Forest Layer doesn't match DEM!")
+                sys.exit(1)
+
+        if modelParameters["varUmaxBool"]:
+            _varUmaxHeader = io.read_header(modelPaths["varUmaxPath"])
+            if _demHeader["ncols"] == _varUmaxHeader["ncols"] and _demHeader["nrows"] == _varUmaxHeader["nrows"]:
+                log.info("uMax Limit Layer ok!")
+            else:
+                log.error("Error: uMax Limit Layer doesn't match DEM!")
+                sys.exit(1)
+
+        if modelParameters["varAlphaBool"]:
+            _varAlphaHeader = io.read_header(modelPaths["varAlphaPath"])
+            if _demHeader["ncols"] == _varAlphaHeader["ncols"] and _demHeader["nrows"] == _varAlphaHeader["nrows"]:
+                log.info("variable Alpha Layer ok!")
+            else:
+                log.error("Error: variable Alpha Layer doesn't match DEM!")
+                sys.exit(1)
+
+        if modelParameters["varExponentBool"]:
+            _varExponentHeader = io.read_header(modelPaths["varExponentPath"])
+            if _demHeader["ncols"] == _varExponentHeader["ncols"] and _demHeader["nrows"] == _varExponentHeader["nrows"]:
+                log.info("variable Alpha Layer ok!")
+            else:
+                log.error("Error: variable Alpha Layer doesn't match DEM!")
                 sys.exit(1)
 
         log.info("========================")
@@ -258,6 +314,12 @@ def tileInputLayers(modelParameters, modelPaths, rasterAttributes, tilingParamet
 
     if modelParameters["infraBool"]:
         SPAM.tileRaster(modelPaths["infraPath"], "infra", modelPaths["tempDir"], _tileCOLS, _tileROWS, _U)
+    if modelParameters["varUmaxBool"]:
+        SPAM.tileRaster(modelPaths["varUmaxPath"], "varUmax", modelPaths["tempDir"], _tileCOLS, _tileROWS, _U)
+    if modelParameters["varAlphaBool"]:
+        SPAM.tileRaster(modelPaths["varAlphaPath"], "varAlpha", modelPaths["tempDir"], _tileCOLS, _tileROWS, _U)
+    if modelParameters["varExponentBool"]:
+        SPAM.tileRaster(modelPaths["varExponentPath"], "varExponent", modelPaths["tempDir"], _tileCOLS, _tileROWS, _U)
     if modelParameters["forestBool"]:
         SPAM.tileRaster(modelPaths["forestPath"], "forest", modelPaths["tempDir"], _tileCOLS, _tileROWS, _U)
     log.info("Finished Tiling All Input Rasters.")

--- a/avaframe/com4FlowPy/com4FlowPyCfg.ini
+++ b/avaframe/com4FlowPy/com4FlowPyCfg.ini
@@ -34,6 +34,29 @@ max_z = 8848
 
 infra = False
 
+#++++++++++++ Use a dynamic u_max Limit
+# Requires an additional tif-file containing the uMax  (in m/s)
+# or zDeltaMax (m) Limits
+# in every cell where a release cell is.
+# the paths for each release cells are calculated with these uMax values
+# (computed to z_delta, similar to the max_z) or zDelta values.
+# In varUmaxParameter the parameter (uMax in m/s or zDeltaMax in m) 
+# provided is given.
+variableUmaxLim = False
+varUmaxParameter = uMax
+
+#++++++++++++ Use a dynamic alpha angle
+# Requires an additional tif-file containing the alpha angles
+# in every cell where a release cell is.
+# The paths for each release cells are calculated with these alpha angles
+variableAlpha = False
+
+#++++++++++++ Use a dynamic exponent
+# Requires an additional tif-file containing the exponents
+# in every cell where a release cell is.
+# The paths for each release cells are calculated with these exponent
+variableExponent = False
+
 #++++++++++++ Use Forest Information
 # NOTE AH 20240408: Dummy settings for Forest Interaction
 # The forest implementation should mimick/reproduce the
@@ -42,7 +65,6 @@ infra = False
 #
 # Forest-Interaction is only used if 'forest' is set to 'True'
 #++++++++++++
-
 forest = False
 
 #++++++++++++
@@ -176,6 +198,9 @@ demPath =
 releasePath =
 infraPath =
 forestPath =
+varUmaxPath = 
+varAlphaPath = 
+varExponentPath = 
 
 # plot save results flags------------------------
 # NOTE-TODO: These Flags still don't do anything,

--- a/avaframe/runCom4FlowPy.py
+++ b/avaframe/runCom4FlowPy.py
@@ -109,6 +109,9 @@ def main():
         cfgPath["releasePath"] = pathlib.Path(cfgCustomPaths["releasePath"])
         cfgPath["infraPath"] = pathlib.Path(cfgCustomPaths["infraPath"])
         cfgPath["forestPath"] = pathlib.Path(cfgCustomPaths["forestPath"])
+        cfgPath["varUmaxPath"] = pathlib.Path(cfgCustomPaths["varUmaxPath"])
+        cfgPath["varAlphaPath"] = pathlib.Path(cfgCustomPaths["varAlphaPath"])
+        cfgPath["varExponentPath"] = pathlib.Path(cfgCustomPaths["varExponentPath"])
         cfgPath["deleteTemp"] = cfgCustomPaths["deleteTempFolder"]
 
         log = logUtils.initiateLogger(cfgPath["outDir"], logName)
@@ -184,6 +187,48 @@ def readFlowPyinputs(avalancheDir, cfgFlowPy, log):
         infraPath = infraPath[0]
         log.info("Infrastructure area file is: %s" % infraPath)
     cfgPath["infraPath"] = infraPath
+
+    # read uMax Limit Raster
+    varUmaxDir = avalancheDir / "Inputs" / "UMAX"
+    varUmaxPath = sorted(list(varUmaxDir.glob("*.tif")))
+    if len(varUmaxPath) == 0 or cfgFlowPy.getboolean("GENERAL", "variableUmaxLim") is False:
+        varUmaxPath = ""
+    elif len(varUmaxPath) > 1:
+        message = "More than one uMax Limit file .%s file in %s not allowed" % (varUmaxDir)
+        log.error(message)
+        raise AssertionError(message)
+    else:
+        varUmaxPath = varUmaxPath[0]
+        log.info("uMax Limit file is: %s" % varUmaxPath)
+    cfgPath["varUmaxPath"] = varUmaxPath
+
+    # read variable Alpha Angle Raster
+    varAlphaDir = avalancheDir / "Inputs" / "ALPHA"
+    varAlphaPath = sorted(list(varAlphaDir.glob("*.tif")))
+    if len(varAlphaPath) == 0 or cfgFlowPy.getboolean("GENERAL", "variableAlpha") is False:
+        varAlphaPath = ""
+    elif len(varAlphaPath) > 1:
+        message = "More than one variable alpha file .%s file in %s not allowed" % (varAlphaDir)
+        log.error(message)
+        raise AssertionError(message)
+    else:
+        varAlphaPath = varAlphaPath[0]
+        log.info("variable Alpha file is: %s" % varAlphaPath)
+    cfgPath["varAlphaPath"] = varAlphaPath
+
+    # read variable Exponent Raster
+    varExponentDir = avalancheDir / "Inputs" / "EXP"
+    varExponentPath = sorted(list(varExponentDir.glob("*.tif")))
+    if len(varExponentPath) == 0 or cfgFlowPy.getboolean("GENERAL", "variableExponent") is False:
+        varExponentPath = ""
+    elif len(varExponentPath) > 1:
+        message = "More than one variable exponent file .%s file in %s not allowed" % (varExponentDir)
+        log.error(message)
+        raise AssertionError(message)
+    else:
+        varExponentPath = varExponentPath[0]
+        log.info("variable Exponent file is: %s" % varExponentPath)
+    cfgPath["varExponentPath"] = varExponentPath
 
     # check if forest should be used (assumed to be in the RES - 'RESISTANCE' directory)
 

--- a/avaframe/tests/test_com4FlowPy.py
+++ b/avaframe/tests/test_com4FlowPy.py
@@ -1,0 +1,25 @@
+"""
+    Pytest for module com1DFA
+"""
+
+import configparser
+import copy
+import logging
+import pathlib
+import pickle
+import shutil
+
+#  Load modules
+import numpy as np
+import pytest
+
+from avaframe.com4FlowPy import flowClass
+
+def test_add_os():
+    cell = flowClass.Cell(1,1,
+                          np.array([[10,10,10], [10,10,10], [10,10,10]]), 10,
+                          1,0, None,
+                          20, 8, 3e-4, 270,
+                          startcell=True)
+    cell.add_os(0.2)
+    assert cell.flux == 1.2

--- a/docs/moduleCom4FlowPy.rst
+++ b/docs/moduleCom4FlowPy.rst
@@ -134,7 +134,21 @@ The user-provided *forest_layer* is treated binary, which means that forest (``c
 If ``forestInteraction = True``, an additional output Layer is computed, which represents the number of forested raster cells a path runs through. In this forest interaction layer, locations (raster cells) of paths are assigned to the number of forested cells previously hit. The output raster layer represents the i) **minimum** forest length within the path (that is from one release cell) and ii) the **minimum** value of overlapping paths. See an application and further description of the forestInteractionLayer in :cite:`SpHeMiFi2024`
 
 
-iv) tiling and multiprocessing parameters
+iv) variable parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There are options to set for each path variable parameters:
+
+- alpha (``variableAlpha = True``), 
+- max. zDelta (``variableUmaxLim = True``),
+- exponent (``variableExponent = True``). 
+
+When an option is switched on (set ``True``), the user needs to provide a raster file, that contains values for the respective parameter in each grid cell that is assigned to a release cell. The paths are computed with the respective parameters.
+If the value of the variable layer in the cell that is assigned to a release cell is not > 0, the default parameters are used as described in i).
+When ``variableUmaxLim = True``, the type of the provided parameter is required: ``varUmaxParameter = uMax`` (in m/s) or ``varUmaxParameter = zDeltaMax`` (in m). (A layer containing release cells is still required).
+
+
+v) tiling and multiprocessing parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If the model extent (i.e. number of cells and/or rows in the input layers) is larger than ``tileSize``, then :py:mod:`com4FlowPy` 
@@ -171,6 +185,9 @@ the following folder structure inside the ``avalancheDir`` directory inside whic
         REL/      - release area file (can be either .asc, .tif, or .shp) <required>
         RES/      - forest structure information (FSI) (.asc or .tif) <optional>
         INFRA/    - infrastructure layer (.asc or .tif) <optional>
+        ALPHA/	  - variable alpha angle layer (.tif) <optional>
+        UMAX/	  - variable uMax layer (.tif) <optional>
+        EXP/	  - variable exponent layer (.tif) <optional>
       Outputs/
       Work/
 
@@ -183,6 +200,9 @@ inputs and working directories/model outputs in different places, which might be
 - ``releasePath`` :math:`\ldots` path to release area raster (``.asc, .tif``)
 - ``infraPath`` :math:`\ldots` path to infrastructure raster (``.asc, .tif``) (required if ``infra = True``)
 - ``forestPath`` :math:`\ldots` path to forest (FSI) raster (``.asc, .tif``) (required if ``forest = True``)
+- ``varAlphaPath`` :math:`\ldots` path to variable alpha angle raster (``.tif``) (required if ``variableAlpha = True``)
+- ``varUmaxPath`` :math:`\ldots` path to variable uMax raster (``.tif``) (required if ``variableUmaxLim = True``)
+- ``varExponentPath`` :math:`\ldots` path to variable Exponent raster (``.tif``) (required if ``variableExponent = True``)
 
 
 **All rasters need the same resolution (we recommend 10x10 meters) and raster extent!!**


### PR DESCRIPTION
Add an option ``u_max_lim`` to use a dynamic max_z_delta and alpha.
- requires a tif file in Inputs/UMAX/ (same extent and resolution as DEM) with the u_max_limit values for each release cell
- requires a tif file in Inputs/RES/ (same extent and resolution as DEM) with the absolute alpha angles for each release cell
- the paths are calculated with the alpha angle and u_max_limit (calculated into z_delta_max) individually for each release cell

Further possible extenstions:
- calculate alpha and u_max dependent on the release area and elevation (would require release area in the REL-file) in FlowPy
- path statistics (also for segmented paths) 