### PR TITLE
[com4FlowPy] added support for .tif and .asc input/output, output files configurable via .ini

### DIFF
--- a/avaframe/com4FlowPy/com4FlowPy.py
+++ b/avaframe/com4FlowPy/com4FlowPy.py
@@ -44,7 +44,7 @@ def com4FlowPyMain(cfgPath, cfgSetup):
     Parameters
     ----------
     cfgPath:  dictionary with paths from .ini file
-    cfgSetup: dictionary with other model configs from .ini file
+    cfgSetup: configparser.SectionProxy Object with "GENERAL" model configs from .ini file
 
     Returns
     ----------
@@ -83,6 +83,15 @@ def com4FlowPyMain(cfgPath, cfgSetup):
 
     modelPaths["resDir"] = cfgPath["resDir"]
     modelPaths["tempDir"] = cfgPath["tempDir"]
+    modelPaths["uid"] = cfgPath["uid"]
+    modelPaths["timeString"] = cfgPath["timeString"]
+    modelPaths["outputFileList"] = cfgPath["outputFiles"].split('|')
+
+    modelPaths["outputFileFormat"] = cfgPath["outputFileFormat"]
+    if modelPaths["outputFileFormat"] in [".asc", ".ASC"]:
+        modelPaths["outputFileFormat"] = '.asc'
+    else:
+        modelPaths["outputFileFormat"] = '.tif'
 
     # check if 'customDirs' are used - alternative is 'default' AvaFrame Folder Structure
     modelPaths["useCustomDirs"] = True if cfgPath["customDirs"] == "True" else False
@@ -145,7 +154,6 @@ def com4FlowPyMain(cfgPath, cfgSetup):
     #            * contradicting options ...
 
     # write model parameters paths, etc. to logfile
-
     startLogging(modelParameters, forestParams, modelPaths, MPOptions)
 
     # check if release file is given als .shp and convert to .tif/.asc in that case
@@ -156,10 +164,17 @@ def com4FlowPyMain(cfgPath, cfgSetup):
     checkInputLayerDimensions(modelParameters, modelPaths)
 
     # get information on cellsize and nodata value from demHeader
-    demHeader = IOf.readASCheader(modelPaths["demPath"])
     rasterAttributes = {}
+
+    demExt = os.path.splitext(modelPaths["demPath"])[1]
+    if demExt in ['.asc', '.ASC']:
+        demHeader = IOf.readASCheader(modelPaths["demPath"])
+        rasterAttributes["nodata"] = demHeader["nodata_value"]
+    elif demExt in ['.tif', '.tiff', '.TIF', '.TIFF']:
+        demHeader = io.read_header(modelPaths["demPath"])
+        rasterAttributes["nodata"] = demHeader["noDataValue"]
+
     rasterAttributes["cellsize"] = demHeader["cellsize"]
-    rasterAttributes["nodata"] = demHeader["nodata_value"]
 
     # tile input layers and write tiles (pickled np.arrays) to temp Folder
     nTiles = tileInputLayers(modelParameters, modelPaths, rasterAttributes, tilingParameters)
@@ -186,8 +201,9 @@ def startLogging(modelParameters, forestParams, modelPaths, MPOptions):
     only performs logging at the start of the simulation
     """
     # Start of Calculation (logging...)
-    log.info("Starting...")
-    log.info("========================")
+    log.info("==================================")
+    log.info("Starting calculation ...")
+    log.info("==================================")
     log.info(f"{'Alpha Angle:' : <20}{modelParameters['alpha'] : <5}")
     log.info(f"{'Exponent:' : <20}{modelParameters['exp'] : <5}")
     log.info(f"{'Flux Threshold:' : <20}{modelParameters['flux_threshold'] : <5}")
@@ -243,8 +259,14 @@ def checkInputLayerDimensions(modelParameters, modelPaths):
     try:
         log.info("checking input layer alignment ...")
 
-        _demHeader = IOf.readASCheader(modelPaths["demPath"])
-        _relHeader = io.read_header(modelPaths["releasePathWork"])
+        ext = os.path.splitext(modelPaths["demPath"])[1]
+
+        if ext in ['.asc', '.ASC']:
+            _demHeader = IOf.readASCheader(modelPaths["demPath"])
+            _relHeader = io.read_header(modelPaths["releasePathWork"])
+        elif ext in ['.tif', '.tiff', '.TIF', '.TIFF']:
+            _demHeader = io.read_header(modelPaths["demPath"])
+            _relHeader = io.read_header(modelPaths["releasePathWork"])
 
         if _demHeader["ncols"] == _relHeader["ncols"] and _demHeader["nrows"] == _relHeader["nrows"]:
             log.info("DEM and Release Layer ok!")
@@ -294,8 +316,9 @@ def checkInputLayerDimensions(modelParameters, modelPaths):
 
         log.info("========================")
 
-    except:
+    except Exception as ex:
         log.error("could not read all required Input Layers, please re-check files and paths provided in .ini files")
+        log.error('Error occured: %s' % ex)
         # return
         sys.exit(1)
 
@@ -359,18 +382,20 @@ def mergeAndWriteResults(modelPaths, modelOptions):
     """function handles merging of results for all tiles inside the temp Folder
     and also writing result files to the resultDir
     """
+    _uid = modelPaths["uid"]
+    _outputs = set(modelPaths['outputFileList'])
 
     log.info(" merging results ...")
     log.info("-------------------------")
 
     # Merge calculated tiles
-    z_delta = SPAM.mergeRaster(modelPaths["tempDir"], "res_z_delta")
+    zDelta = SPAM.mergeRaster(modelPaths["tempDir"], "res_z_delta")
     flux = SPAM.mergeRaster(modelPaths["tempDir"], "res_flux")
-    cell_counts = SPAM.mergeRaster(modelPaths["tempDir"], "res_count")
-    z_delta_sum = SPAM.mergeRaster(modelPaths["tempDir"], "res_z_delta_sum")
-    fp_ta = SPAM.mergeRaster(modelPaths["tempDir"], "res_fp")
-    sl_ta = SPAM.mergeRaster(modelPaths["tempDir"], "res_sl")
-    travel_length = SPAM.mergeRaster(modelPaths["tempDir"], "res_travel_length")
+    cellCounts = SPAM.mergeRaster(modelPaths["tempDir"], "res_count")
+    zDeltaSum = SPAM.mergeRaster(modelPaths["tempDir"], "res_z_delta_sum")
+    fpTa = SPAM.mergeRaster(modelPaths["tempDir"], "res_fp")
+    slTa = SPAM.mergeRaster(modelPaths["tempDir"], "res_sl")
+    travelLength = SPAM.mergeRaster(modelPaths["tempDir"], "res_travel_length")
 
     if modelOptions["infraBool"]:
         backcalc = SPAM.mergeRaster(modelPaths["tempDir"], "res_backcalc")
@@ -382,25 +407,44 @@ def mergeAndWriteResults(modelPaths, modelOptions):
     log.info("-------------------------")
     log.info(" writing output files ...")
     log.info("-------------------------")
-    output_format = ".tif"
-    io.output_raster(modelPaths["demPath"], modelPaths["resDir"] / ("flux%s" % (output_format)), flux)
-    io.output_raster(modelPaths["demPath"], modelPaths["resDir"] / ("z_delta%s" % (output_format)), z_delta)
-    io.output_raster(modelPaths["demPath"], modelPaths["resDir"] / ("FP_travel_angle%s" % (output_format)), fp_ta)
-    io.output_raster(modelPaths["demPath"], modelPaths["resDir"] / ("SL_travel_angle%s" % (output_format)), sl_ta)
-    io.output_raster(modelPaths["demPath"], modelPaths["resDir"] / ("travel_length%s" % (output_format)), travel_length)
+    _oF = modelPaths["outputFileFormat"]
+    _ts = modelPaths["timeString"]
+
+    if 'flux' in _outputs:
+        io.output_raster(modelPaths["demPath"], modelPaths["resDir"] / "com4_{}_{}_flux{}".format(_uid, _ts, _oF),
+        flux)
+    if 'zDelta' in _outputs:
+        io.output_raster(modelPaths["demPath"], modelPaths["resDir"] / "com4_{}_{}_zdelta{}".format(_uid, _ts, _oF),
+        zDelta)
+    if 'cellCounts' in _outputs:
+        io.output_raster(modelPaths["demPath"], modelPaths["resDir"] / "com4_{}_{}_cellCounts{}".format(_uid, _ts, _oF),
+        cellCounts)
+    if 'zDeltaSum' in _outputs:
+        io.output_raster(modelPaths["demPath"], modelPaths["resDir"] / "com4_{}_{}_zDeltaSum{}".format(_uid, _ts, _oF),
+        zDeltaSum)
+    if 'fpTravelAngle' in _outputs:
+        io.output_raster(modelPaths["demPath"], modelPaths["resDir"] / "com4_{}_{}_fpTravelAngle{}".format(_uid,
+        _ts, _oF), fpTa)
+    if 'slTravelAngle' in _outputs:
+        io.output_raster(modelPaths["demPath"], modelPaths["resDir"] / "com4_{}_{}_slTravelAngle{}".format(_uid,
+        _ts, _oF), slTa)
+    if 'travelLength' in _outputs:
+        io.output_raster(modelPaths["demPath"], modelPaths["resDir"] / "com4_{}_{}_travelLength{}".format(_uid,
+        _ts, _oF), travelLength)
 
     # TODO: List of result files, which are produced should be specified also in the .ini file!!!!
     # NOTE: Probably good to have "default" output files (z_delta,FP_travel_angle,cell_counts)
     #      and only write other output files if set accordingly
-    if not modelOptions["infraBool"]:  # if no infra
-        io.output_raster(modelPaths["demPath"], modelPaths["resDir"] / ("cell_counts%s" % (output_format)), cell_counts)
-        io.output_raster(modelPaths["demPath"], modelPaths["resDir"] / ("z_delta_sum%s" % (output_format)), z_delta_sum)
+    # NOTE:
+    # if not modelOptions["infraBool"]:  # if no infra
+        # io.output_raster(modelPaths["demPath"], modelPaths["resDir"] / ("cell_counts%s" %(output_format)),cell_counts)
+        # io.output_raster(modelPaths["demPath"], modelPaths["resDir"] / ("z_delta_sum%s" %(output_format)),z_delta_sum)
     if modelOptions["infraBool"]:  # if infra
-        io.output_raster(modelPaths["demPath"], modelPaths["resDir"] / ("backcalculation%s" % (output_format)),
-                         backcalc)
+        io.output_raster(modelPaths["demPath"], modelPaths["resDir"] / "com4_{}_{}_backcalculation{}".format(_uid,
+                         _ts, _oF), backcalc)
     if modelOptions["forestInteraction"]:
-        io.output_raster(modelPaths["demPath"], modelPaths["resDir"] / ("forestInteraction%s" % (output_format)),
-                         forestInteraction)
+        io.output_raster(modelPaths["demPath"], modelPaths["resDir"] / "com4_{}_{}_forestInteraction{}".format(_uid,
+                         _ts, _oF), forestInteraction)
 
 
 def checkConvertReleaseShp2Tif(modelPaths):
@@ -417,10 +461,17 @@ def checkConvertReleaseShp2Tif(modelPaths):
     """
     # the release is a shp polygon, we need to convert it to a raster
     # releaseLine = shpConv.readLine(releasePath, 'releasePolygon', demDict)
+
     if modelPaths["releasePath"].suffix == ".shp":
 
-        dem = IOf.readRaster(modelPaths["demPath"])
-        demHeader = IOf.readASCheader(modelPaths["demPath"])
+        ext = os.path.splitext(modelPaths["demPath"])[1]
+
+        if ext in ['.asc', '.ASC']:
+            dem = IOf.readRaster(modelPaths["demPath"])
+            demHeader = IOf.readASCheader(modelPaths["demPath"])
+        elif ext in ['.tif', '.tiff', '.TIF', '.TIFF']:
+            dem = io.read_raster(modelPaths["demPath"])
+            demHeader = io.read_header(modelPaths["demPath"])
 
         dem['originalHeader'] = demHeader
 

--- a/avaframe/com4FlowPy/com4FlowPy.py
+++ b/avaframe/com4FlowPy/com4FlowPy.py
@@ -173,6 +173,10 @@ def com4FlowPyMain(cfgPath, cfgSetup):
     elif demExt in ['.tif', '.tiff', '.TIF', '.TIFF']:
         demHeader = io.read_header(modelPaths["demPath"])
         rasterAttributes["nodata"] = demHeader["noDataValue"]
+    else:
+        _errMsg = f"file format '{demExt}' for DEM is not supported, please provide '.tif' or '.asc'"
+        log.error(_errMsg)
+        raise ValueError(_errMsg)
 
     rasterAttributes["cellsize"] = demHeader["cellsize"]
 
@@ -267,6 +271,9 @@ def checkInputLayerDimensions(modelParameters, modelPaths):
         elif ext in ['.tif', '.tiff', '.TIF', '.TIFF']:
             _demHeader = io.read_header(modelPaths["demPath"])
             _relHeader = io.read_header(modelPaths["releasePathWork"])
+        else:
+            _errMsg = f"file format '{ext}' for DEM is not supported, please provide '.tif' or '.asc'"
+            raise ValueError(_errMsg)
 
         if _demHeader["ncols"] == _relHeader["ncols"] and _demHeader["nrows"] == _relHeader["nrows"]:
             log.info("DEM and Release Layer ok!")
@@ -470,8 +477,15 @@ def checkConvertReleaseShp2Tif(modelPaths):
             dem = IOf.readRaster(modelPaths["demPath"])
             demHeader = IOf.readASCheader(modelPaths["demPath"])
         elif ext in ['.tif', '.tiff', '.TIF', '.TIFF']:
-            dem = io.read_raster(modelPaths["demPath"])
-            demHeader = io.read_header(modelPaths["demPath"])
+            #dem = io.read_raster(modelPaths["demPath"])
+            #demHeader = io.read_header(modelPaths["demPath"])
+            _errMsg = "using release area in '.shp' format currently only supported in combination with '.asc' DEMs"
+            log.error(_errMsg)
+            raise ValueError(_errMsg)  
+        else:
+            _errMsg = f"file format '{ext}' for DEM is not supported, please provide '.tif' or '.asc'"
+            log.error(_errMsg)
+            raise ValueError(_errMsg)
 
         dem['originalHeader'] = demHeader
 

--- a/avaframe/com4FlowPy/com4FlowPyCfg.ini
+++ b/avaframe/com4FlowPy/com4FlowPyCfg.ini
@@ -175,6 +175,23 @@ maxChunks = 500
 
 # Optional Custom Paths
 [PATHS]
+
+# define format of output raster files (default = .tif)
+# available options: [.tif, .asc]
+# if you plan to utilize avaFrame tools to analyse result rasters
+# then you should choose '.asc' here!
+outputFileFormat = .tif
+
+# define the different output files that are written to disk
+# default = 'zDelta|cellCounts|travelLength|fpTravelAngle'
+# additional options: 
+#                    slTravelAngle
+#                    flux
+#                    zDeltaSum
+# if forestInteraction: forestInteraction is automatically added to outputs
+# if infra: backCalculation is automatically  added to output
+outputFiles = zDelta|cellCounts|travelLength|fpTravelAngle
+
 #++++++++++++ Custom paths True/False
 # default: False
 # if set to 'False':

--- a/avaframe/runCom4FlowPy.py
+++ b/avaframe/runCom4FlowPy.py
@@ -8,6 +8,7 @@ import os
 import sys
 from datetime import datetime
 import logging
+import json
 
 # Local imports
 import avaframe.in3Utils.initializeProject as initProj
@@ -88,6 +89,15 @@ def main():
             cfgPath["tempDir"] = cfgPath["workDir"] / "temp"
             fU.makeADir(cfgPath["tempDir"])
 
+        # writing config to .json file
+        successToJSON = writeCfgJSON(cfg, uid, cfgPath['outDir'])
+
+        if successToJSON is True:
+            log.info('wrote config to {}/{}.json'.format(cfgPath['outDir'], uid))
+        else:
+            log.info('could not write  config to {}/{}.json'.format(cfgPath['outDir'], uid))
+            log.error("Exception occurred: %s", str(successToJSON), exc_info=True)
+
         cfgPath["deleteTemp"] = "False"
 
         cfgPath["uid"] = uid
@@ -121,6 +131,15 @@ def main():
             print("temp folder already exists - aborting")
             sys.exit(1)
         log = logUtils.initiateLogger(res_dir, logName)
+
+        # writing config to .json file
+        successToJSON = writeCfgJSON(cfg, uid, workDir)
+
+        if successToJSON is True:
+            log.info('wrote config to {}/{}.json'.format(workDir, uid))
+        else:
+            log.info('could not write  config to {}/{}.json'.format(workDir, uid))
+            log.error("Exception occurred: %s", str(successToJSON), exc_info=True)
 
         cfgPath["workDir"] = pathlib.Path(workDir)
         cfgPath["outDir"] = pathlib.Path(res_dir)
@@ -346,6 +365,36 @@ def checkOutputFilesFormat(strOutputFiles):
     except ValueError:
         # else we return the default options
         return 'zDelta|cellCounts|travelLength|fpTravelAngle'
+
+
+def writeCfgJSON(cfg, uid, workDir):
+    """
+    writes a JSON file containing all the input parameters from the configFile
+    using the same uid as the simulation results
+
+    Parameters:
+    ---------------
+    cfg: configParser object - all the model configs are in here
+    uid: string - UID created based on the cfg object
+    workDir: string - workDirectory (place to write the .json file to)
+
+    Returns:
+    ---------------
+    success: boolean/Exception - True if file is written successfully, else Exception
+
+    """
+
+    cfgDict = cfgUtils.convertConfigParserToDict(cfg)
+
+    try:
+        with open(workDir / "{}.json".format(uid), 'w') as outfile:
+            jsonDict = json.dumps(cfgDict, sort_keys=True, ensure_ascii=True)
+            outfile.write(jsonDict)
+
+        return True
+
+    except Exception as e:
+        return e
 
 
 if __name__ == "__main__":

--- a/avaframe/runCom4FlowPy.py
+++ b/avaframe/runCom4FlowPy.py
@@ -32,8 +32,6 @@ def main():
     * handling creation of working directories ...
 
     NOTE-TODO:
-        * Forest Interaction currently only works with customDirs set to True
-          Currently this is not implemented in the with the AvaFrame File structure ...
         * This function needs clean-up!
     """
     # log file name; leave empty to use default runLog.log
@@ -42,12 +40,19 @@ def main():
     cfgMain = cfgUtils.getGeneralConfig()
     cfg = cfgUtils.getModuleConfig(com4FlowPy)
 
+    # check and handle outputFiles list provided in (local_)com4FlowPyCfg.ini
+    cfg["PATHS"]["outputFiles"] = checkOutputFilesFormat(cfg["PATHS"]["outputFiles"])
+
     cfgSetup = cfg["GENERAL"]
     cfgFlags = cfg["FLAGS"]
     cfgCustomPaths = cfg["PATHS"]
 
     # if customPaths == False --> use AvaFrame Folder structure
     if cfgCustomPaths["useCustomPaths"] == "False":
+        # if "useCustomPaths" == False, we also use the AvaDir Info for the
+        # creation of the simulaiton uid
+        cfg['GENERAL']['avaDir'] = cfgMain["MAIN"]["avalancheDir"]
+        uid = cfgUtils.cfgHash(cfg)
         # Load avalanche directory from general configuration file
         avalancheDir = cfgMain["MAIN"]["avalancheDir"]
         # Clean input directory of old work and output files from module
@@ -55,12 +60,13 @@ def main():
 
         # Start logging
         log = logUtils.initiateLogger(avalancheDir, logName)
+        log.info("==================================")
+        log.info("MAIN SCRIPT")
+        log.info("Current avalanche: %s", avalancheDir)
+        log.info("==================================")
 
         # Extract input file locations
         cfgPath = readFlowPyinputs(avalancheDir, cfg, log)
-
-        log.info("MAIN SCRIPT")
-        log.info("Current avalanche: %s", avalancheDir)
 
         # IMPORTANT!! - this is a quick'n'dirty hack to set nSims to 9999, so that
         # min(nCPU,nSims) in cfgUtils.getNumberOfProcesses returns nCPU
@@ -70,29 +76,43 @@ def main():
         # Create result directory
         # NOTE-TODO: maybe move into separate function as well ...
         timeString = datetime.now().strftime("%Y%m%d_%H%M%S")
-        cfgPath["resDir"] = cfgPath["outDir"] / "res_{}".format(timeString)
-        fU.makeADir(cfgPath["resDir"])
-        cfgPath["tempDir"] = cfgPath["workDir"] / "temp"
-        fU.makeADir(cfgPath["tempDir"])
+
+        cfgPath["resDir"] = cfgPath["outDir"] / "peakFiles" / "res_{}".format(uid)  # (timeString)
+        # check if simulation with same uid already has results folder
+        if os.path.isdir(cfgPath["resDir"]):
+            log.info("folder with same name already exists - aborting")
+            log.info("simulation results folder with same .ini parameters already exists")
+            sys.exit(1)
+        else:
+            fU.makeADir(cfgPath["resDir"])
+            cfgPath["tempDir"] = cfgPath["workDir"] / "temp"
+            fU.makeADir(cfgPath["tempDir"])
 
         cfgPath["deleteTemp"] = "False"
+
+        cfgPath["uid"] = uid
+        cfgPath["timeString"] = timeString
+        cfgPath["outputFiles"] = cfgCustomPaths["outputFiles"]
 
         com4FlowPy.com4FlowPyMain(cfgPath, cfgSetup)
 
     # if customPaths == True --> check
     elif cfgCustomPaths["useCustomPaths"] == "True":
-
+        # if "useCustomPaths" == True, we don't need the AvaDir Info for the
+        # creation of the simulaiton uid
+        uid = cfgUtils.cfgHash(cfg)
         cfgPath = {}
 
         # Handling Custom directory creation
         workDir = pathlib.Path(cfgCustomPaths["workDir"])
 
-        time_string = datetime.now().strftime("%Y%m%d_%H%M%S")
+        timeString = datetime.now().strftime("%Y%m%d_%H%M%S")
         try:
-            os.makedirs(workDir / "res_{}".format(time_string))
-            res_dir = workDir / "res_{}".format(time_string)
+            os.makedirs(workDir / "res_{}".format(uid))  # (time_string))
+            res_dir = workDir / "res_{}".format(uid)   # (time_string)
         except FileExistsError:
             print("folder with same name already exists - aborting")
+            print("simulation results folder with same .ini parameters already exists")
             sys.exit(1)
         try:
             os.makedirs(workDir / res_dir / "temp")
@@ -100,6 +120,7 @@ def main():
         except FileExistsError:
             print("temp folder already exists - aborting")
             sys.exit(1)
+        log = logUtils.initiateLogger(res_dir, logName)
 
         cfgPath["workDir"] = pathlib.Path(workDir)
         cfgPath["outDir"] = pathlib.Path(res_dir)
@@ -113,11 +134,14 @@ def main():
         cfgPath["varAlphaPath"] = pathlib.Path(cfgCustomPaths["varAlphaPath"])
         cfgPath["varExponentPath"] = pathlib.Path(cfgCustomPaths["varExponentPath"])
         cfgPath["deleteTemp"] = cfgCustomPaths["deleteTempFolder"]
-
-        log = logUtils.initiateLogger(cfgPath["outDir"], logName)
+        cfgPath["outputFileFormat"] = cfgCustomPaths["outputFileFormat"]
+        cfgPath["outputFiles"] = cfgCustomPaths["outputFiles"]
 
         cfgSetup["cpuCount"] = str(cfgUtils.getNumberOfProcesses(cfgMain, 9999))
         cfgPath["customDirs"] = cfgCustomPaths["useCustomPaths"]
+
+        cfgPath["uid"] = uid
+        cfgPath["timeString"] = timeString
 
         com4FlowPy.com4FlowPyMain(cfgPath, cfgSetup)
 
@@ -260,7 +284,29 @@ def readFlowPyinputs(avalancheDir, cfgFlowPy, log):
     cfgPath["forestPath"] = forestPath
 
     # read DEM
-    demPath = gI.getDEMPath(avalancheDir)
+    demDir = avalancheDir / "Inputs"
+    patterns = ("*.tif", "*.asc", "*.TIF", "*.tiff", "*.TIFF", "*.ASC")
+
+    _demPath = [f for f in demDir.iterdir() if any(f.match(p) for p in patterns)]
+
+    if len(_demPath) == 0:
+        message = (
+                "Please provide a DEM file in %s" % demDir
+                  )
+        log.error(message)
+        raise AssertionError(message)
+    elif len(_demPath) > 1:
+        message = (
+                "Please provide exactly 1 (One!) DEM file in %s" % demDir
+                  )
+        log.error(message)
+        raise AssertionError(message)
+    else:
+        if os.path.splitext(_demPath[0])[1] in [".asc", ".ASC"]:
+            demPath = gI.getDEMPath(avalancheDir)
+        else:
+            demPath = _demPath[0]
+
     log.info("DEM file is: %s" % demPath)
     cfgPath["demPath"] = demPath
 
@@ -269,7 +315,37 @@ def readFlowPyinputs(avalancheDir, cfgFlowPy, log):
     cfgPath["outDir"] = outDir
     cfgPath["workDir"] = workDir
 
+    cfgPath["outputFileFormat"] = cfgFlowPy["PATHS"]["outputFileFormat"]
+
     return cfgPath
+
+
+def checkOutputFilesFormat(strOutputFiles):
+    """check if outputFiles option is provided in proper format, else return
+    default string in right format
+
+    Parameters:
+    ---------------
+    strOutputFiles: string - outputFiles string from (local_)com4FlowPy.ini
+
+    Returns:
+    ---------------
+    strOutputFiles: string - returns the input if the format is ok, else default
+                    value string is returned
+    """
+
+    try:
+        setA = set(strOutputFiles.split('|'))
+        setB = set(['zDelta', 'cellCounts', 'fpTravelAngle', 'travelLength',
+                    'slTravelAngle', 'flux', 'zDeltaSum'])
+        # if there is at least 1 correct ouputfile defined, we use the string provided in the .ini file
+        if (setA & setB):
+            return strOutputFiles
+        else:
+            raise ValueError('outputFiles defined in .ini have wrong format - using default settings')
+    except ValueError:
+        # else we return the default options
+        return 'zDelta|cellCounts|travelLength|fpTravelAngle'
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The PR introduces a few feature-enhancements to com4FlowPy:

1. Support for DEM input in ```.tif``` format (previously DEM was required in ```.asc``` format, but all other input layers could be provided in either format)
2. Support for output of model results in either ```.asc``` or ```.tif``` raster format (some ```avaframe``` moduels require ```.asc``` rasters) $\rightarrow$ now configurable via ```com4FlowPy.ini```
3. Added option to define a list of output files for com4FlowPy in ```com4FlowPy.ini``` $\rightarrow$ not all outputs are required for every application + disk space can be saved in case of i) application on large areas of interest or (ii) large numbers of simulations with varying parameters.
4. output fileNames have been restructured to (loosely) adhere to ```avaframe``` conventions
    -  *A_B_C_D_E.asc* where:
        - A -  *com4*
        - B - unique identifier (uid) based on model configuration (```cfgUtils.cfgHash()```)
        - C - date (yyyymmdd)
        - D - time (HHMMSS)
        - E - output file type (*flux*, $z^{\delta}$, *cellCounts*, *travelLength*)
    - if model run is performed in ```avaframe``` folder structure (```useCustomPaths = False``` option) the result files are placed in:
        - ```<avaDir>/Outputs/com4FlowPy/peakFiles/res_<uid>/A_B_C_D_E.asc```
5. if simulation results with the exact same ```uid```, i.e. configurations exist, the model is not run again for this configuration (user has to manually delete the results folder first, if she wishes to re-run the model)
6. The model configuration from ```(local_)avaframeCfg.ini``` and ```(local_)com4FlowPyCfg.ini``` is stored to a .json file ```<uid>.json``` inside the workDir - the ```.json``` file can be used to fetch utilized model parameterizations for saved result files - providing an alternative to parsing the .log files, which might not contain all info from the cfgs.