### PR TITLE
Make syntax compatible with NumPy 2.0

### DIFF
--- a/.github/workflows/runTestSinglePython.yml
+++ b/.github/workflows/runTestSinglePython.yml
@@ -53,7 +53,7 @@ jobs:
       run: |
         pytest -ra --cov --cov-report=xml --cov-config=.coveragerc
     - name: Test & publish code coverage
-      uses: paambaati/codeclimate-action@v6.0.0
+      uses: paambaati/codeclimate-action@v8.0.0
       env:
         CC_TEST_REPORTER_ID: ${{ secrets.CODECLIMATE_ID }}
     - name: Upload coverage to Codecov

--- a/avaframe/com1DFA/testSPH.py
+++ b/avaframe/com1DFA/testSPH.py
@@ -71,8 +71,8 @@ rho = 200
 
 def definePart(dx, dy, Lx, Ly):
     # define particles
-    nx = np.int(Lx/dx)-1
-    ny = np.int(Ly/dy)-1
+    nx = int(Lx/dx)-1
+    ny = int(Ly/dy)-1
     nPart = nx*ny
     x = np.linspace(dx, Lx-dx, nx)
     y = np.linspace(dy, Ly-dy, ny)
@@ -82,8 +82,9 @@ def definePart(dx, dy, Lx, Ly):
     # Xpart = np.array([50., 54.])
     # Ypart = np.array([51., 53.])
     # nPart = 2
-    Xpart = xx + (np.random.rand(nPart) - 0.5) * dx * coef
-    Ypart = yy + (np.random.rand(nPart) - 0.5) * dy * coef
+    rng = np.random.default_rng()
+    Xpart = xx + (rng.random(nPart) - 0.5) * dx * coef
+    Ypart = yy + (rng.random(nPart) - 0.5) * dy * coef
     # adding z component
     Zpart, sx, sy, area = Sfunction(Xpart, Ypart, Lx, Ly)
     Hpart, _, _, _ = Hfunction(Xpart, Ypart, Zpart)
@@ -107,8 +108,8 @@ def definePart(dx, dy, Lx, Ly):
 
 def defineGrid(Lx, Ly, csz):
     # define grid
-    NX = np.int(Lx/csz + 1)
-    NY = np.int(Ly/csz + 1)
+    NX = int(Lx/csz + 1)
+    NY = int(Ly/csz + 1)
     header = {}
     header['ncols'] = NX
     header['nrows'] = NY

--- a/avaframe/com4FlowPy/splitAndMerge.py
+++ b/avaframe/com4FlowPy/splitAndMerge.py
@@ -180,7 +180,7 @@ def mergeRaster(inDirPath, fName, method='max'):
 
     mergedRas = np.zeros((extL[0], extL[1]))
     # create Raster with original size
-    mergedRas[:, :] = np.NaN
+    mergedRas[:, :] = np.nan
 
     for i in range(nTiles[0] + 1):
         for j in range(nTiles[1] + 1):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [build-system]
 # Cython dependency is optional, see setup.py for details.
 # For the package (run-time) dependencies, see setup.cfg.
-requires = ["setuptools", "numpy", "cython"]
+requires = ["setuptools", "wheel", "numpy", "cython"]
+build-backend = "setuptools.build_meta"
 
 [tool.flake8]
 max-line-length = 109
@@ -10,4 +11,3 @@ extend-ignore = ['E203', 'E501']
 
 [tool.black]
 line-length = 109
-

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ from setuptools import Extension, setup, find_packages
 from pathlib import Path
 import sys
 import numpy
+sys.path.append(str(Path(__file__).parent))
 from avaframe.version import getVersion
 
 DISTNAME = "avaframe"
@@ -68,13 +69,14 @@ long_description = (this_directory / "README.md").read_text()
 
 
 # Decide whether a cythonization of the pyx-file is required.
-# if build_ext is supplied -> use cython
 nos = (None, "0", "false")
-subcommand = sys.argv[1] if len(sys.argv) > 1 else None
-use_cython = subcommand == "build_ext"  # This is possibly a bit hacky.
+# if no .c files are found build_ext is required
+use_cython = not list(Path().glob("**/*.c"))
 
+setup_options = {}
 if use_cython:
     print("Package is built with cythonization.")
+    setup_options = {"build_ext": {"inplace": True}}
 
 ext = ".pyx" if use_cython else ".c"
 
@@ -126,6 +128,8 @@ setup(
     install_requires=req_packages,
     # additional groups of dependencies here (e.g. development dependencies).
     extras_require={},
+    # Run build_ext
+    options=setup_options,
     # Executable scripts
     entry_points={},
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ long_description = (this_directory / "README.md").read_text()
 
 
 # Decide whether a cythonization of the pyx-file is required.
-nos = (None, "0", "false")
 # if no .c files are found build_ext is required
 use_cython = not list(Path().glob("**/*.c"))
 


### PR DESCRIPTION
There are some lines of NumPy code that are not compatible with NumPy 2.0. This PR addresses those.

You can check it with 
```
python3 -m pip install ruff
ruff check --preview --select NPY
```
(ruff is a nice and comprehensive linter that I can recomment BTW...)

Since there is no avaframe package available with NumPy 2.0 support yet, I tried to pip-install avaframe from source, but that failed, unfortunately. Reason is that c-files were not created with
```
python3 -m pip install git+https://github.com/avaframe/AvaFrame
```
. I tried to address that in setup.py, and with this PR it should work, see:
```
python3 -m pip install git+https://github.com/ninsbl/AvaFrame@np2
```
...

In order to get a PEP404 compliant version I had to import the tags to my fork though:
```
# Clone my fork
git clone git@github.com:ninsbl/AvaFrame
# Enter my working copy
cd AvaFrame
# Add AvaFrame as upstream reference
git remote add upstream https://github.com/avaframe/AvaFrame
# Fetch tags
git fetch --tags upstream
# Push tags to my fork
git push --tags
```

Maybe worth adding that in the developer documentation somewhere...