### PR TITLE
Handle bug about simName / scenario mismatch in report (Windows QGis GUI); issue #872 [com1]

### DIFF
--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -316,6 +316,8 @@ def com1DFAPostprocess(simDF, tCPUDF, simDFExisting, cfgMain, dem, reportDictLis
 
     if cfgMain["FLAGS"].getboolean("createReport"):
         # write report
+        reportDictList = gR.checkAndCleanReportDictOnWinIssue872(reportDictList)
+
         gR.writeReport(reportDir, reportDictList, cfgMain["FLAGS"].getboolean("reportOneFile"), plotDict)
 
     return dem, plotDict, reportDictList, simDFNew

--- a/avaframe/log2Report/generateReport.py
+++ b/avaframe/log2Report/generateReport.py
@@ -233,3 +233,39 @@ def writeReport(outDir, reportDictList, reportOneFile, plotDict='', standaloneRe
 
                 # Write report file
                 writeReportFile(reportD, pfile)
+
+
+def checkAndCleanReportDictOnWinIssue872(reportDictList):
+    """ Check report dict for inconsistencies in simName. Sometimes the simName is not
+     properly set in the dict report. This is a dirty fix!! (see issue 872). S
+
+        Parameters
+        ----------
+        reportDictList : list
+            of report dictionaries from simulations
+
+        Returns
+        -------
+        reportDictList : list
+            checked and cleaned reportDict
+    """
+
+    for k, listItem in enumerate(reportDictList):
+        simName = listItem['simName']['name']
+        if '_AF_' in simName:
+            nameParts = simName.split('_AF_')
+        else:
+            nameParts = simName.split('_')
+
+        # This is the proper simName
+        simNameClean = nameParts[0]
+
+        if listItem['Simulation Parameters']['Release Area Scenario'] != simNameClean:
+            reportDictList[k]['Simulation Parameters']['Release Area Scenario'] = simNameClean
+            log.warning("Ran into windows QGis simName report problem, set release area scenario to simName.")
+
+        if listItem['Release Area']['Release area scenario'] != simNameClean:
+            reportDictList[k]['Release Area']['Release area scenario'] = simNameClean
+            log.warning("Ran into windows QGis simName report problem, set release area scenario to simName.")
+
+    return reportDictList


### PR DESCRIPTION
Fixes the problem with report sinNames on Windows (#872)

This is a dirty fix, because it does not address the root cause, simply because I cannot find it. It only treats the effect...