### PR TITLE
Update Advanced Usage chapter in docs [doc]

### DIFF
--- a/docs/advancedUsage.rst
+++ b/docs/advancedUsage.rst
@@ -1,10 +1,14 @@
 Advanced Usage (Script)
 =======================
 
-After the installation, the next sections describe on how to get started. The sections configuration and logging
+After the installation, the next sections describe how to get started. The sections configuration and logging
 describe the general methods we use, this is helpful to understand how you can change model parameters and similar. 
 
 .. include:: developinstall.rst
+
+--------------------------
+
+.. include:: developinstallwin.rst
 
 --------------------------
 
@@ -69,3 +73,22 @@ Testing
 - :py:mod:`runScripts.runComparisonModules`
 - :py:mod:`runScripts.runFetchBench`
 - :py:mod:`runScripts.runWriteDesDict`
+
+------------------------------
+
+Update AvaFrame
+------------------------------
+
+To update go to your avaframe repository [YOURDIR]/Avaframe,  pull the latest changes via::
+
+  git pull
+
+and repeat the compilation step from above::
+
+  python setup.py build_ext --inplace
+
+If there are updates on the requirements inside ``setup.py``, it might be necessary to run::
+
+  pip install -e .
+
+again to get the additional requirements installed.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,5 +1,5 @@
 Configuration
-==================
+------------------------------
 
 In order to set the configurations required by all the modules within Avaframe, the python module
 `configparser <https://docs.python.org/3/library/configparser.html>`_ is used.
@@ -53,7 +53,7 @@ In the configuration file itself, there are multiple options to vary a parameter
   single value can be added by appending ``&4.0`` for example
   
 Override configuration
----------------------------
+^^^^^^^^^^^^^^
  
 If tools of one module, let's call this module **A** for now, are called from another module **B**, there is the option to include an *collectionName_A_override* section in the
 configuration file of module **B**. In this case, the default configuration of module **A** is read and the parameters in the *A_override* section 

--- a/docs/develop.rst
+++ b/docs/develop.rst
@@ -174,8 +174,7 @@ repository/origin will be handled by the pull request)::
 Build the documentation
 ------------------------
 
-If you want to work on the documentation you need to install *Sphinx*. If you have followed the conda installation using
-``avaframe_env_spec.txt``, you can omit the following steps. If not, you can install Sphinx, the *ReadTheDocs*
+If you want to work on the documentation you need to install *Sphinx*. You can install Sphinx, the *ReadTheDocs*
 theme, and the *sphinxcontrib-bibtex*, which we use to include references, by running::
 
   pip install sphinx

--- a/docs/developinstall.rst
+++ b/docs/developinstall.rst
@@ -1,12 +1,11 @@
-Advanced (Script) Installation 
+Advanced Installation (Linux)
 ------------------------------
 
 This is a quick guide on how to install AvaFrame
 and the required dependencies on your machine. AvaFrame is developed on **Linux
 machines** (Ubuntu/Manjaro/Arch) with recent Python versions > 3.8.
 These instructions assume you are familiar with working in a terminal. This
-guide is currently described for *Linux* only, but expert users should be able
-to adapt it to *Windows*.
+guide is described for **Linux**. For *Windows*, see :ref:`developinstallwin:Advanced Installation (Windows)`.
 
 Requirements
 ^^^^^^^^^^^^
@@ -60,20 +59,3 @@ Test it by starting ``python`` and do an ``import avaframe``. If no error comes
 up, you are good to go.
 
 Head over to :ref:`gettingstarted:First run` for the next steps.
-
-Update AvaFrame
-^^^^^^^^^^^^^^^
-
-To update go to your avaframe repository [YOURDIR]/Avaframe,  pull the latest changes via::
-
-  git pull
-
-and repeat the compilation step from above::
-  
-  python setup.py build_ext --inplace
-
-If there are updates on the requirements inside ``setup.py``, it might be necessary to run::
-
-  pip install -e . 
-
-again to get the additional requirements installed. 

--- a/docs/developinstallwin.rst
+++ b/docs/developinstallwin.rst
@@ -1,0 +1,129 @@
+Advanced Installation (Windows)
+------------------------------
+
+This is a quick guide on how to install AvaFrame
+and the required dependencies on your machine. AvaFrame is developed on **Linux
+machines** (Ubuntu/Manjaro/Arch) with recent Python versions > 3.8.
+These instructions assume you are familiar with working in a terminal. This
+guide is described for **Windows**. For *Linux*, see :ref:`developinstall:Advanced Installation (Linux)`.
+
+Requirements
+^^^^^^^^^^^^
+
+Install `git <https://github.com/git-guides/install-git>`_ and python, we
+suggest to work with miniconda/anaconda. For installation see `miniconda
+<https://docs.conda.io/en/latest/miniconda.html>`_ or
+`anaconda <https://docs.anaconda.com/anaconda/install/linux/>`_.
+
+Install `Microsoft C++ compiler <https://wiki.python.org/moin/WindowsCompilers>`_.
+Follow the installation steps for the version corresponding to the installed python version.
+
+Setup AvaFrame
+^^^^^^^^^^^^^^
+
+Open conda shell and create a new `conda environment
+<https://conda.io/projects/conda/en/latest/user-guide/concepts/environments.html>`_
+for AvaFrame, activate it and install pip, numpy and cython in this environment::
+
+  conda create --name avaframe_env
+  conda activate avaframe_env
+  conda install pip numpy cython
+
+Clone the AvaFrame repository (in a directory of your choice: [YOURDIR]) and change into it::
+
+  cd [YOURDIR]
+  git clone https://github.com/avaframe/AvaFrame.git
+  cd AvaFrame
+
+Compile the cython com1DFA part::
+
+   python setup.py build_ext --inplace
+
+.. Warning::
+   You will have to do this compilation every time something changes in the cython code. We also suggest
+   to do this everytime updates from the repositories are pulled.
+
+   **Before** compilation in Windows, make sure to delete ``AvaFrame/build`` directory, in addition to any .pyd, .c, and
+   .pycache files in ``AvaFrame/avaframe/com1DFA``
+
+Install avaframe and its requirements by **either** doing::
+
+  pip install -e .
+
+or if this fails (see `github issue 986 <https://github.com/avaframe/AvaFrame/issues/986>`_), do::
+
+  python setup.py develop
+
+This installs avaframe in editable mode, so every time you import avaframe the
+current (local) version will be used.
+
+Test it by starting ``python`` and do an ``import avaframe``. If no error comes
+up, you are good to go.
+
+If wanted: Integrate conda environment into editor of your choice (i.e. PyCharm, Spyder or any other)
+
+Head over to :ref:`gettingstarted:First run` for the next steps.
+
+Using QGIS from Conda
+^^^^^^^^^^^^^^
+It is possible to have the script installation and the plugin installed on your machine at the same time.
+However, be aware: Depending on your mode of QGis installation (direct installer, conda, OSGeo4W...) your script AvaFrame installation might be overruled.  
+
+The steps below install QGis and the Connector plugin in a separate *conda* environment. If the steps above have been followed, this method will result in two script installations where one will be used by QGis and the other can be worked on separately, preventing any overlap.
+
+If you have another QGis installation somewhere, make sure that the AvaFrame plugin is not installed.
+To create and activate a new environment, which will contain your installation of QGis open your conda terminal and run::
+
+  conda create -n qgis_latest
+  conda activate qgis_latest
+
+To **install the latest QGIS version**, use::
+
+  conda install qgis --channel conda-forge
+
+.. Note::
+   Conda will always try to install the latest version. If you want to use another version, you need to specify it, e.g.:
+
+  ``conda install qgis=3.34.11 --channel conda-forge``
+
+Now install the avaframe requirements::
+
+  conda install pip numpy cython
+
+Now find the directory where your environment is located. The path should be something like:
+``C:\Users\USER\miniconda3\envs\qgis_latest``. Change into it::
+
+  cd \miniconda3\envs\qgis_latest
+
+Clone the AvaFrame repository and change into it::
+
+  git clone https://github.com/avaframe/AvaFrame.git
+  cd AvaFrame
+
+.. Note::
+  This will pull the latest developer version of AvaFrame, if you want the current release version for the plugin,
+  you need to specify the version, e.g.:
+
+  ``https://github.com/avaframe/AvaFrame/tree/1.8.3``
+
+Compile the cython com1DFA part and create an editable avaframe version in your environment::
+
+  python setup.py build_ext --inplace
+  pip install -e .
+
+Run QGIS::
+
+  qgis
+
+Now you can **install the AvaFrameConnector plugin** via QGIS as per usual (:ref:`installation:Operational Installation`).
+
+AvaFrame should now be installed, and both installations should work and be editable separately. To display the installed version and installation location, use
+``pip show avaframe`` in the respective environment, or use the *getVersion* function in the plugin. Note that the script
+versions are separate, and changes in one installation will not affect the other.
+
+**Updating QGIS**
+
+To update QGIS to the most recent version, you need to run the following command with the respective environment active::
+
+  conda update qgis -c conda-forge
+

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -92,7 +92,7 @@ the module you want to use (for example ``com1DFACfg.ini`` for module com1DFA).
 If you want to use different settings, create a ``local_`` copy of the ``.ini``
 file and modify the desired parameters.
 
-More information about the configuration can be found here: :ref:`configuration:Configuration`
+More information about the configuration can be found here: :ref:`advancedUsage:Configuration`
 
 Building your run script
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -17,7 +17,7 @@ Installation
 
 
   Advanced (Script) 
-    If you want to contribute and develop AvaFrame, head over to :ref:`advancedUsage:Advanced (Script) Installation`.
+    If you want to contribute and develop AvaFrame, head over to :ref:`advancedUsage:Advanced Usage (Script)`.
     Use this if you want to:
 
     - work on the code itself

--- a/docs/moduleCom1DFA.rst
+++ b/docs/moduleCom1DFA.rst
@@ -52,6 +52,7 @@ projection:
 
 * release area scenario as (multi-) polygon shapefile (in Inputs/REL; multiple features are possible)
 
+  - the release area polygon must not contain any "holes" or inner rings
   - the release area name should not contain an underscore, if so '_AF' is added.
   - recommended attributes are *name*, *thickness* (see :ref:`moduleCom1DFA:Release-, entrainment thickness settings`)
     and *ci95* (see :ref:`moduleAna4Stats:probAna - Probability maps`)
@@ -65,11 +66,13 @@ and the following files are optional:
 
   - marks the (multiple) areas where entrainment can occur.
   - attribute *thickness* (see :ref:`moduleCom1DFA:Release-, entrainment thickness settings`)
+  - must not contain any "holes" or inner rings
 
 
 * one resistance area (multi-) polygon shapefile (in Inputs/RES)
 
   - marks the (multiple) areas where resistance is considered
+  - resistance areas must not contain any "holes" or inner rings
 
 
 * one secondary release area (multi-) polygon shapefile (in Inputs/SECREL)
@@ -77,6 +80,7 @@ and the following files are optional:
   - can have multiple release areas, each as one feature
   - same setup as the release area scenario (see above)
   - features will release as soon as at least one particle enters its area
+  - release area polygons must not contain any "holes" or inner rings
 
 
 


### PR DESCRIPTION
Added installation description for Windows, reorganized some (so e.g. Configuration is under Advanced Usage in docs, as well as moving update to the bottom), adjusted :refs: so they properly match

https://docs.avaframe.org/en/wininstalldoc/