### PR TITLE
Change default probAna range; fixes #967 [ana4]

### DIFF
--- a/avaframe/ana4Stats/probAnaCfg.ini
+++ b/avaframe/ana4Stats/probAnaCfg.ini
@@ -26,7 +26,7 @@ varParList = relTh|musamosat
 variationType = rangefromci|percent
 
 # set variation value for each parameter in varParList - separated by |
-variationValue = ci95|35
+variationValue = ci95|30
 
 # There are two option to perform probrun, (1) draw parameter sets from full sample or
 # (2) only vary each parameter one at a time (local approach - doesn't account for interactions)


### PR DESCRIPTION
based on request by WLV (CT;MG)

Be aware: also changes upper limit (since the ranges are symmetrical)