### PR TITLE
Adds a try except for cmcrameri lipari colormap (missing in older versions)[out3]

### DIFF
--- a/avaframe/out3Plot/plotUtils.py
+++ b/avaframe/out3Plot/plotUtils.py
@@ -223,7 +223,13 @@ cmapProb = {"cmap": cmapProbmap, "colors": colorsProb, "levels": levProb}
 cmapEnergy = {"cmap": cmapE, "colors": colorsE, "levels": levE}
 
 # for zdelta
-cmapZdelta = {"cmap": copy.copy(cmapCrameri.lipari), "colors": [], "levels": []}
+# Remark FSO: the try except comes from cmcrameri v1.5 not having lipari, but it is still
+# widely used (Okt 2024). TODO: remove in future versions
+try:
+    cmapZdelta = {"cmap": copy.copy(cmapCrameri.lipari), "colors": [], "levels": []}
+except AttributeError:
+    cmapZdelta = {"cmap": copy.copy(cmapCrameri.lapaz), "colors": [], "levels": []}
+
 
 colorMaps = {
     "ppr": cmapPres,


### PR DESCRIPTION
cmcrameri version 1.5 does not have lipari colormap, but is still widely used in oder QGis versions