### PR TITLE
disable overlap checking for secrels; fixes #1065 [com1]

### DIFF
--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -1524,7 +1524,12 @@ def initializeSecRelease(inputSimLines, dem, relRaster, reportAreaInfo):
 
         # fetch secondary release areas
         secondaryReleaseInfo = geoTrans.prepareArea(
-            secondaryReleaseInfo, dem, np.sqrt(2), thList=secondaryReleaseInfo["thickness"], combine=False
+            secondaryReleaseInfo,
+            dem,
+            np.sqrt(2),
+            thList=secondaryReleaseInfo["thickness"],
+            combine=False,
+            checkOverlap=False
         )
         # remove overlaping parts of the secondary release area with the main release areas
         noOverlaprasterList = []


### PR DESCRIPTION
Disables overlap check for secondary release areas. 

thicknesses are averaged for those boxes. 