### PR TITLE
[com4] Further mass redistribution/correction modifications

### DIFF
--- a/avaframe/com4FlowPy/flowClass.py
+++ b/avaframe/com4FlowPy/flowClass.py
@@ -391,11 +391,10 @@ class Cell:
             # local flux redistribution to eligible child cells
             self.dist[self.dist >= threshold] += mass_to_distribute / count
             self.dist[self.dist < threshold] = 0
-        if np.sum(self.dist) < self.flux and count > 0:
-            # correction/flux conservation for potential rounding losses
-            self.dist[self.dist >= threshold] += (self.flux - np.sum(self.dist)) / count
-        if np.sum(self.dist) > self.flux and count > 0:
-            # correction/flux conservation for potential rounding gains
+        if np.sum(self.dist) != self.flux and count > 0:
+            # correction/flux conservation for potential rounding losses or gains
+            # (self.flux - np.sum(self.dist)) will either be negative or positive 
+            # depending on the direction of the rounding error
             self.dist[self.dist >= threshold] += (self.flux - np.sum(self.dist)) / count
         if count == 0:
             # if all child cells are below flux_threshold, the flux is deposited

--- a/avaframe/com4FlowPy/flowClass.py
+++ b/avaframe/com4FlowPy/flowClass.py
@@ -389,16 +389,19 @@ class Cell:
 
         if mass_to_distribute > 0 and count > 0:
             # local flux redistribution to eligible child cells
-            self.dist[self.dist > threshold] += mass_to_distribute / count
+            self.dist[self.dist >= threshold] += mass_to_distribute / count
             self.dist[self.dist < threshold] = 0
         if np.sum(self.dist) < self.flux and count > 0:
             # correction/flux conservation for potential rounding losses
-            self.dist[self.dist > threshold] += (self.flux - np.sum(self.dist)) / count
+            self.dist[self.dist >= threshold] += (self.flux - np.sum(self.dist)) / count
+        if np.sum(self.dist) > self.flux and count > 0:
+            # correction/flux conservation for potential rounding gains
+            self.dist[self.dist >= threshold] += (self.flux - np.sum(self.dist)) / count
         if count == 0:
             # if all child cells are below flux_threshold, the flux is deposited
             # TODO: check alternatives (e.g. 'global' redistribution or within generations)
             self.fluxDep = self.flux
-        row_local, col_local = np.where(self.dist > threshold)
+        row_local, col_local = np.where(self.dist >= threshold)
 
         return (
             self.rowindex - 1 + row_local,


### PR DESCRIPTION
Further changes to the mass redistribution/correction procedure in com4FlowPy/flowClass.py:
- Update criterion for the mass redistribution/correction step to be 'self.dist >= threshold' instead of 'self.dist > threshold'. Else, cells with values equal to the specified threshold aren't dealt with
- Add a second adjustment step for scenarios with a net gain of mass due to rounding errors in above arithemetic operations
- Update row_local, col_local to be cells with self.dist >= threshold, consistent with above


I recently uncovered the mass conservation issues in the FlowPy version used in AutoATES prior to finding this updated repo, and in tests with several print statements tracking the values of self.dist and self.flux through this procedure, I found that these changes should lead to mass conservation, notwithstanding any 'mass loss' due to deposition, which you have included here.