### PR TITLE
[sys] Upgrade twine and install pkginfo before upload 

### DIFF
--- a/.github/workflows/releaseWithManylinux.yml
+++ b/.github/workflows/releaseWithManylinux.yml
@@ -36,7 +36,7 @@ jobs:
           build-requirements: 'cython numpy'
       - name: Publish wheels to PyPI
         run: |
-          pip install twine --break-system-packages
+          pip install -U pkginfo packaging twine --break-system-packages
           twine upload dist/*-manylinux*.whl
         continue-on-error: true
 
@@ -69,6 +69,8 @@ jobs:
       - name: upload source distribution
         run: |
           pip install twine
+          pip install -U pkginfo
+          pip install -U packaging
           twine upload dist/*
         continue-on-error: true
 
@@ -103,5 +105,7 @@ jobs:
       - name: upload wheel
         run: |
           pip install twine
+          pip install -U pkginfo
+          pip install -U packaging
           twine upload dist/*
         continue-on-error: true

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     version=getVersion(),
+
     # The project's main homepage.
     url=URL,
     # Author details


### PR DESCRIPTION
change is necessary due to this bug:
https://github.com/pypa/twine/issues/1216