### PR TITLE
 [com4FlowPy] minor Bugfix, documentation update and added feature for "forestFriciton", "forestDetrainment" and "forestFrictionLayer" model options

### DIFF
--- a/avaframe/com4FlowPy/com4FlowPy.py
+++ b/avaframe/com4FlowPy/com4FlowPy.py
@@ -130,7 +130,8 @@ def com4FlowPyMain(cfgPath, cfgSetup):
         forestParams["velThForDetrain"] = cfgSetup.getfloat("velThForDetrain")  # float(cfgSetup["velThForDetrain"])
         # 'forestFrictionLayer' parameter
         forestParams["fFrLayerType"] = cfgSetup.get("forestFrictionLayerType")
-        forestParams["nSkipForest"] = cfgSetup.getint("skipForestCells")
+        # skipForestDist - no forest friciton effect assumed while distance along path <= skipForestDist
+        forestParams["skipForestDist"] = cfgSetup.getfloat("skipForestDist")
 
     else:
         modelPaths["forestPath"] = ""
@@ -612,8 +613,6 @@ def checkConvertReleaseShp2Tif(modelPaths):
             dem = IOf.readRaster(modelPaths["demPath"])
             demHeader = IOf.readRasterHeader(modelPaths["demPath"])
         elif ext in ['.tif', '.tiff', '.TIF', '.TIFF']:
-            #dem = io.read_raster(modelPaths["demPath"])
-            #demHeader = io.read_header(modelPaths["demPath"])
             _errMsg = "using release area in '.shp' format currently only supported in combination with '.asc' DEMs"
             log.error(_errMsg)
             raise ValueError(_errMsg)

--- a/avaframe/com4FlowPy/com4FlowPyCfg.ini
+++ b/avaframe/com4FlowPy/com4FlowPyCfg.ini
@@ -136,13 +136,12 @@ velThForDetrain   = 0
 # ['absolute', 'relative']
 forestFrictionLayerType = absolute
 
-# ['1 cell', '2 cells']
-# if value == 1 forest effect is not considered at the start cell (default behaviour)
-# if value == 2 also first cell after start cell has no forest effect
-# background --> for some processes (e.g.) rockfall it might make sense, if a first
-# acceleration phase is allowed before accounting for forest effects
-# NOTE: this currently only works with 'forestFrictionLayer' module!!
-skipForestCells = 1 
+# skip Forest Effect (added forest friction) for first x meters (calculated in 3D - XYZ)
+# should allow an initial acceleration phase of processes starting in or directly above
+# dense forests (these would in many cases stop otherwise)
+# if e.g. skipForestDist = 40, no added forestFriction will be assumed until 40 m 3D-distance
+# along the path from the startCell.
+skipForestDist = 0 
 
 #++++++++++++ Method to calculate flux distribution
 # We fixed a bug in flowClass.py, which affects the distribution of the remaining flux, 

--- a/avaframe/com4FlowPy/flowCore.py
+++ b/avaframe/com4FlowPy/flowCore.py
@@ -383,8 +383,8 @@ def calculation(args):
         the maximum of flux in every cell
     countArray: numpy array
         the number of hits (GMF paths) in every cell
-    zDeltaPathList: list
-        containing the max zDelta Arrays of all paths
+    zDeltaSumArray: numpy array
+        the maximum of zDelta in every cell per path and the sum over the paths
     backcalc: numpy array
           Array with back calculation, still TODO!!!
     fpTravelAngleArray: numpy array

--- a/avaframe/runCom4FlowPy.py
+++ b/avaframe/runCom4FlowPy.py
@@ -60,7 +60,7 @@ def main():
         initProj.cleanModuleFiles(avalancheDir, com4FlowPy, deleteOutput=False)
 
         # Start logging
-        log = logUtils.initiateLogger(avalancheDir, logName)
+        log = logUtils.initiateLogger(avalancheDir, logName+'_'+uid)
         log.info("==================================")
         log.info("MAIN SCRIPT")
         log.info("Current avalanche: %s", avalancheDir)
@@ -109,19 +109,26 @@ def main():
     # if customPaths == True --> check
     elif cfgCustomPaths["useCustomPaths"] == "True":
         # if "useCustomPaths" == True, we don't need the AvaDir Info for the
-        # creation of the simulaiton uid
+        # creation of the simulation uid
         uid = cfgUtils.cfgHash(cfg)
         cfgPath = {}
 
         # Handling Custom directory creation
         workDir = pathlib.Path(cfgCustomPaths["workDir"])
 
+        if not os.path.isdir(workDir):
+            try:
+                os.makedirs(workDir)
+            except Exception as e:
+                return e
+
+        log = logUtils.initiateLogger(workDir, logName+'_'+uid)
+
         timeString = datetime.now().strftime("%Y%m%d_%H%M%S")
         try:
             os.makedirs(workDir / "res_{}".format(uid))  # (time_string))
             res_dir = workDir / "res_{}".format(uid)   # (time_string)
         except FileExistsError:
-            log.info("folder with same name already exists - aborting")
             log.info("simulation results folder with same .ini parameters already exists: simulation {}".format(uid))
             sys.exit(1)
         try:
@@ -130,7 +137,6 @@ def main():
         except FileExistsError:
             log.info("temp folder for simualtion {} already exists - aborting".format(uid))
             sys.exit(1)
-        log = logUtils.initiateLogger(res_dir, logName)
 
         # writing config to .json file
         successToJSON = writeCfgJSON(cfg, uid, workDir)

--- a/docs/moduleCom4FlowPy.rst
+++ b/docs/moduleCom4FlowPy.rst
@@ -233,22 +233,27 @@ deleted after completion of the model run (can be useful for calculation of larg
 Output
 -------
 
-All outputs are in the .tif or in .asc raster format in the same resolution and extent as the input raster layers.
+All outputs are written in *'.tif'* or in *'.asc'* raster format (controlable via the ``outputFileFormat`` option in ``(local_)com4FlowPyCfg.ini``, default is *'.tif'*) in the same resolution and extent as the input raster layers.
+You can customize which output rasters are written at the end of the model run by selecting the desired output files through the ``outputFiles`` option in ``(local_)com4FlowPyCfg.ini``.
+
+By default the following four output layers are written to disk at the end of the model run:
 
 - ``zdelta``: the maximum z_delta of all paths for every raster cell (geometric measure of process magnitude, can be associated to kinetic energy/velocity)
+- ``cellCounts``: number of paths/release cells that route flux through a raster cell
+- ``travelLength``: the travel length along the flow path
+- ``fpTravelAngle``: the gamma angle along the flow path
+
+In addition these output layers are also available:
+
 - ``flux``: The maximum routing flux of all paths for every raster cell
 - ``zDeltaSum``: z_delta summed up over all paths on every raster cell
-- ``cellCounts``: number of paths/release cells that route flux through a raster cell
-- ``fpTravelAngle``: the gamma angle along the flow path
 - ``slTravelAngle``: gamma angle calculated along a straight-line between release cell and current cell
-- ``travelLength``: the travel length along the flow path
 - ``routFluxSum``: routing flux summed up over all paths
 - ``depFluxSum``: deposited flux summed up over all paths
-- ``forestInteraction``: only if ``forestInteraction = True``: minimum number of forested raster cells a path runs through
 
-.. Note::
-  * **please interpret** ``cell_counts.tif`` **with caution, since absolute cell_count values do currently not reflect the number of release-cells which route flux through a cell - we are currently fixing the implementation of this feature**
-  * we are also working on making the output files configurable via the ``com4FlowPyCfg.ini`` file for improved flexibility (different output files might be desirable for different applications)
+If ``forestInteraction = True`` this layer will be written automatically (no need to separately define in ``outputFiles``):
+
+- ``forestInteraction``: minimum number of forested raster cells a path runs through
 
  .. Model Parameterisation
  .. ------------------------

--- a/docs/theoryCom4FlowPy.rst
+++ b/docs/theoryCom4FlowPy.rst
@@ -12,6 +12,7 @@ com4FlowPy theory
   
   Initial information pertaining to the application of :py:mod:`com4FlowPy` with consideration of forest-effects can be found in:
      - D'Amboise, C.J.L; Teich, M.; Hormes, A.; Steger, S. and Berger, F. (2021). Modeling Protective Forests for Gravitational Natural Hazards and How It Relates to Risk-Based Decision Support Tools. in: *Protective forests as Ecosystem-based solution for Disaster Risk Reduction (ECO-DRR), Teich et al., 2021*. (https://www.intechopen.com/chapters/78979)
+     - Huber, A.; Saxer, L.; Hesselbach, C.; Neuhauser, M.; D'Amboise, C.J.L. and Teich, M. (2024): Regional-scale avalanche modeling with com4FlowPy - potential and limitations for considering avalanche-forest interaction along the avalanche track. *Proceedings, International Snow Science Workshop, Tromso, Norway* (https://arc.lib.montana.edu/snow-science/item.php?id=3194)
 
 
 Background and motivation
@@ -288,7 +289,9 @@ autoATES
 ~~~~~~~~~~~~~~~~~~~
 - Toft, H.B.; Sykes, J.; Schauer, A.; Hendrikx, J. and Hetland, A. (2024). AutoATES v2.0: Automated Avalanche Terrain Exposure Scale mapping. *Nat. Hazards Earth Syst. Sci., 24*, 1779–1793 (https://doi.org/10.5194/nhess-24-1779-2024)
 - Sykes, J.; Toft, H.B.; Haegeli, P. and Statham, G. (2024). Automated Avalanche Terrain Exposure Scale (ATES) mapping – local validation and optimization in western Canada. *Nat. Hazards Earth Syst. Sci., 24*, 947–971 (https://doi.org/10.5194/nhess-24-947-2024)
+- Panayotov, M.; Markov, K.; Tsvetanov, N.; Huber, A.; Hesselbach, C. and Teich, M. (2024). Avalanche Hazard Mapping using the Avalanche Terrain Exposure Scale (ATES) in the high mountain ranges of Bulgaria. *Proceedings, International Snow Science Workshop, Tromso, Norway* (https://arc.lib.montana.edu/snow-science/item.php?id=3366)
 - Spannring, P.; Hesselbach, C.; Mitterer, C. and Fischer, J.-T. (2024). Classification of avalanche terrain: a open-source model chain for the Avalanche Terrain Exposure Scale. *Proceedings Interpraevent 2024, Vienna, Austria* (https://www.interpraevent.at/en/proceeding/proceedings-ip-2024)
+- Spannring, P. (2024). Comparison of two avalanche terrain classification approaches : Avalanche Terrain Exposure scale - Classified Avalanche Terrain. *Masters' Thesis*. University of Innsbruck. (https://ulb-dok.uibk.ac.at/urn/urn:nbn:at:at-ubi:1-155858)
 - von Avis, C.D.; Sykes, J. and Tutt, B. (2023). Development of large scale automated Avalanche Terrain Exposure Scale (ATES) ratings in collaboration with local avalanche experts. *Proceedings, International Snow Science Workshop, Bend, OR, USA* (http://arc.lib.montana.edu/snow-science/item/2998)
 - Huber, A.; Hesselbach, C.; Oesterle, F.; Neuhauser, M.; Adams, M.; Plörer, M.; Stephan, L.; Toft, H.B.; Sykes, J.; Mitterer, C. and Fischer, J.-T. (2023). AutoATES Austria - Testing and application of an automated model-chain for avalanche terrain classification in the Austrian Alps. *Proceedings, International Snow Science Workshop, Bend, OR, USA* (http://arc.lib.montana.edu/snow-science/item/2989)
 - Hesselbach, C. (2023). Adaptaion and application of an automated Avalanche Terrain Classification in Austria. *Masters' Thesis*. University of Life Sciences (BOKU), Vienna (https://forschung.boku.ac.at/de/publications/175549)
@@ -296,5 +299,6 @@ autoATES
 
 other
 ~~~~~~~~~~~~~~~~~~~
+- Huber, A.; Saxer, L.; Hesselbach, C.; Neuhauser, M.; D'Amboise, C.J.L. and Teich, M. (2024): Regional-scale avalanche modeling with com4FlowPy - potential and limitations for considering avalanche-forest interaction along the avalanche track. *Proceedings, International Snow Science Workshop, Tromso, Norway* (https://arc.lib.montana.edu/snow-science/item.php?id=3194)
 - Perzl, F.; Huber, A.; Fromm, R. and Teich, M. (2024). Estimation of potential snow avalanche hazard probability in areas below protective forests in Austria. *Proceedings Interpraevent 2024, Vienna, Austria* (https://www.interpraevent.at/en/proceeding/proceedings-ip-2024)
 - D'Amboise, C.J.L; Teich, M.; Hormes, A.; Steger, S. and Berger, F. (2021). Modeling Protective Forests for Gravitational Natural Hazards and How It Relates to Risk-Based Decision Support Tools. in: *Protective forests as Ecosystem-based solution for Disaster Risk Reduction (ECO-DRR), Teich et al., 2021*. (https://www.intechopen.com/chapters/78979)


### PR DESCRIPTION
Exact copy of PR #1071 on top of current master branch.

- had trouble with resolving conflicts rebasing https://github.com/avaframe/AvaFrame/tree/AH_com4FlowPy_improvForestFricitonDist with current master
- checked out this new branch from current master and applied changes from https://github.com/avaframe/AvaFrame/tree/AH_com4FlowPy_improvForestFricitonDist on top

+++++++++++++++++++

Original PR content:

- fixed minor bug in `runCom4FlowPy.py` that caused an unhandled exception if the `workDir` did not exist a priori with `useCustomPaths` option set to `True`
- updated com4FlowPy documentation (additional references, and small changes)
- new Feature/modelOption `skipForestDist`:
    - `skipForestDist` allows the definition of a length [m] along the track (calculated in X,Y,Z and not in projected distances X,Y- to account for different track inclinations) that needs to be surpassed, before added *forestFriction* is modeled. This affects all *forestFriction* related code if `forestFriction`, `forestFrictionLayer` or `forestDetrainment` are selected.
    - the feature allows to define an *"initial acceleration distance"* for GMFs that release in or directly above dense forest and should provide a mechanism to prevent potential under-estimation of GMF runouts in these cases.
    - By leaving the default value `skipForestDist = 0` the prior model behavior remains unchanged.
- **note: This makes the code ~ 5% to 10% slower in first tests**
