### PR TITLE
Update documentation to reflect support for raster file formats (.asc and .tif); fixes #1082

### DIFF
--- a/docs/com1DFAAlgorithm.rst
+++ b/docs/com1DFAAlgorithm.rst
@@ -20,7 +20,7 @@ Mesh, particles and fields are subsequently initialized.
 Initialize Mesh
 ~~~~~~~~~~~~~~~~~
 
-Read DEM ascii file provided in the Input folder (only one DEM ascii file allowed).
+Read DEM raster file provided in the Input folder (only one DEM raster file allowed; .asc or .tif).
 If the DEM cell size is different from the :``meshCellSize`` specified in the configuration
 from more than ``meshCellSizeThreshold`` [m] the DEM is remeshed (:py:func:`in3Trans.geoTrans.remesh`).
 
@@ -460,7 +460,8 @@ Go back to :ref:`com1DFAAlgorithm:Algorithm graph`
 Simulation outputs
 -------------------
 
-At the end of the simulation, the result fields are exported to .asc files in
+At the end of the simulation, the result fields are exported to raster files (.asc or .tif; depending on file format
+of the input DEM) in
 :py:func:`com1DFA.com1DFA.exportFields` and the information gathered in an info dictionary is used to
 create a markdown report (:py:func:`log2Report.generateReport.writeReport`).
 Further details on the available outputs can be found in :ref:`moduleCom1DFA:Output`.

--- a/docs/develop.rst
+++ b/docs/develop.rst
@@ -230,7 +230,7 @@ generated. If you plan to add a new benchmark test case, follow these steps
 as a next step, you need to add the benchmark results:
 
   * go to ``AvaFrame/benchmarks`` and add the subdirectory named after your test name
-  * add benchmark data i.e. peak values of result parameters as ascii files. This
+  * add benchmark data i.e. peak values of result parameters as raster files (ascii or geotiff). This
     data will be used as reference for the new test!
   * add the configuration file as ``NameOfAvalanche_com1DFACfg.ini``
   * add a json file with required info on benchmark test - you can use the

--- a/docs/moduleAna3AIMEC.rst
+++ b/docs/moduleAna3AIMEC.rst
@@ -27,7 +27,9 @@ for the full Aimec analysis, as provided in :py:mod:`runScripts/runAna3AIMEC.py`
 Inputs
 -------
 
-*  DEM  (digital elevation model) as .asc file with `ESRI grid format <https://desktop.arcgis.com/en/arcmap/10.3/manage-data/raster-and-images/esri-ascii-raster-format.htm>`_
+*  DEM  (digital elevation model) as raster file with either `ESRI grid format <https://desktop.arcgis.com/en/arcmap/10.3/manage-data/raster-and-images/esri-ascii-raster-format.htm>`_
+   or GeoTIFF format. The format of the DEM determines
+which format is used for the output.
 .. Note:: The spatial resolution of the DEM and its extent can differ from the result raster data.
           Spatial resolution can also differ between simulations. If this is the case, the spatial
           resolution of the reference simulation results raster is used (default) or, if provided,
@@ -88,7 +90,7 @@ To run
       python3 runScripts/runAna3AIMEC.py
 
 .. Note:: 
-   In the default configuration, the analysis is performed on the simulation result files located in ``NameOfAvalanche/Outputs/anaMod/peakFiles``, where anaMod is specified in the aimecCfg.ini. There is also the option to directly provide a path to an input directory to the :py:func:`ana3AIMEC.ana3AIMEC.fullAimecAnalysis`. However, the peak field file names need to have a specific format: *A_B_C_D_E.asc*, where:
+   In the default configuration, the analysis is performed on the simulation result files located in ``NameOfAvalanche/Outputs/anaMod/peakFiles``, where anaMod is specified in the aimecCfg.ini. There is also the option to directly provide a path to an input directory to the :py:func:`ana3AIMEC.ana3AIMEC.fullAimecAnalysis`. However, the peak field file names need to have a specific format: *A_B_C_D_E.*, where:
    
    - A - *releaseAreaScenario*: refers to the name of the release shape file 
    - B - *simulationID*: needs to be unique for the respective simulation

--- a/docs/moduleAna4Stats.rst
+++ b/docs/moduleAna4Stats.rst
@@ -17,7 +17,8 @@ using a parameter variation, different release-, entrainment- or resistance scen
 An example run script is given by :py:mod:`runAna4ProbAna.py`: where firstly, :py:mod:`com1DFA` is used to
 perform avalanche simulations varying parameters set in the ``ana4Stats/probAnaCfg.ini`` file.
 Using these simulations, a probability map is generated.
-The output is a raster file (.asc) with values ranging from 0-1. 0 meaning that no simulation exceeded the threshold
+The output is a raster file (.asc or .tif) with values ranging from 0-1. 0 meaning that no simulation exceeded the
+threshold
 in this point in space. 1 on the contrary means that all simulations exceeded the threshold.
 Details on this function, as for example required inputs can be found in: :py:mod:`ana4Stats.probAna`.
 In addition, there is the option to use the run script :py:mod:`runProbAnalysisOnly.py`: to create probability maps
@@ -68,7 +69,7 @@ can be set in ``ana4Stats/probAnaCfg.ini`` in the sections GENERAL and PLOT. The
 ``avaName/Outputs/comMod/peakfiles`` directory, where ``comMod`` refers to the name of the computational module that has been
 used to create the simulation results. If com1DFA has been used, the full configuration information is accessible and hence
 also filtering is implemented. For other modules the only requirement is that simulation results have to be named in the following format:
-``nameOfReleaseArea_uniqueSimulationIndicator_ModificationIndicator_simType_modelType_resultType.asc``
+``nameOfReleaseArea_uniqueSimulationIndicator_ModificationIndicator_simType_modelType_resultType.*``
 
 * *uniqueSimulationIndicator*: a string that is unique for each simulation (can also be a combination of parameter names and values in case of com1DFA this is the simHash)
 * *ModificationIndicator*: **C** for changed or **D** for default model configuration

--- a/docs/moduleCom1DFA.rst
+++ b/docs/moduleCom1DFA.rst
@@ -50,7 +50,8 @@ folder structure described below.
 In the directory ``Inputs``, the following files are required. Be aware that ALL inputs have to be provided in the same
 projection:
 
-* digital elevation model as .asc file with `ESRI grid format <https://desktop.arcgis.com/en/arcmap/10.3/manage-data/raster-and-images/esri-ascii-raster-format.htm>`_
+* digital elevation model as raster file with either `ESRI grid format <https://desktop.arcgis.com/en/arcmap/10.3/manage-data/raster-and-images/esri-ascii-raster-format.htm>`_
+  or GeoTIFF format. The format of the DEM determines the format of the output files.
 
 * release area scenario as (multi-) polygon shapefile (in Inputs/REL; multiple features are possible)
 
@@ -87,7 +88,7 @@ and the following files are optional:
 * raster files for the Voellmy friction parameters :math:`\mu` and :math:`\xi` (in Inputs/RASTERS)
 
   - spatial field of :math:`\mu` and :math:`\xi` values with same extent as DEM
-  - file names need to end with ``_mu.asc`` and ``_xi.asc``
+  - file names need to end with ``_mu.*`` and ``_xi.*``
   - only one file per parameter allowed
   - if ``meshCellSize`` is different from simulation ``meshCellSize`` fields will be remeshed
   - only used if ``frictionModel`` is set to ``spatialVoellmy``
@@ -145,7 +146,7 @@ Only available for release thickness:
 
   - set the flag 'relThFromShp' to False
   - set the flag 'relThFromFile' to True
-  - save a raster file with info on release thickness as .asc file in
+  - save a raster file with info on release thickness as raster file in
     ``Inputs/RELTH`` the number of rows and columns must match the DEM raster
     with desired meshCellSize
 

--- a/docs/moduleCom2AB.rst
+++ b/docs/moduleCom2AB.rst
@@ -11,7 +11,8 @@ Input
 
 Please be aware that all input data have to be provided in the same projection.
 
-* digital elevation model as .asc file with `ESRI grid format <https://desktop.arcgis.com/en/arcmap/10.3/manage-data/raster-and-images/esri-ascii-raster-format.htm>`_
+* digital elevation model as raster file with either `ESRI grid format <https://desktop.arcgis.com/en/arcmap/10.3/manage-data/raster-and-images/esri-ascii-raster-format.htm>`_
+  or GeoTIFF format. The format of the DEM determines the format of the output files.
 * set of avalanche paths as (multi-) line shapefile. I.e there can be multiple paths in the shapefile
 
   - recommended attribute *name*

--- a/docs/moduleCom3Hybrid.rst
+++ b/docs/moduleCom3Hybrid.rst
@@ -21,7 +21,7 @@ the :math:`\mu` or :math:`\alpha` value stops varying.
 Input
 -----
 
-* raster of the DEM (.asc file)
+* raster of the DEM (raster file; .asc or .tif)
 * a release feature (shapefile) in ``Inputs/REL``
 * Split point (shapefile). This requirement is planned to be automated as well.
 

--- a/docs/moduleIn2Trans.rst
+++ b/docs/moduleIn2Trans.rst
@@ -2,12 +2,12 @@
 in2Trans: Transformation Utilities
 ##################################
 
-Working with ASCII files
+Working with RASTER files
 ==========================
 
-:py:mod:`in2Trans.ascUtils` is a module created to handle raster ASCII files. It
-contains different functions to read ASCII files and write the data to a numpy
-array, to compare raster file headers or to write a raster to an ASCII file.
+:py:mod:`in2Trans.rasterUtils` is a module created to handle raster  files. It
+contains different functions to read ASCII or GeoTIFF files and write the data to a numpy
+array, to compare raster file headers or to write a raster to file.
 A description of the functions is available in
 :py:mod:`in2Trans.ascUtils`.
 

--- a/docs/moduleIn3Utils.rst
+++ b/docs/moduleIn3Utils.rst
@@ -36,7 +36,7 @@ Extra features can be added to the above topographies:
 		or by cutting them into the original topography (``topoAdd=False``).
 	* **in case of the parabola topography, a dam can be added by setting ``dam=True``.**
 
-This modules returns a 3D plot of the generated topography as well as an .asc
+This modules returns a 3D plot of the generated topography as well as an raster
 file of the DEM data. The input parameters are defined in the respective
 configuration file ``in3Utils.generateTopoCfg.ini``. Detailed information on the
 individual functions used to create the topographies can be found in
@@ -180,7 +180,7 @@ creates the folder structure required to perform avalanche simulations: ::
 				REL/		- release area scenario
 				RES/		- resistance areas
 				SECREL/ - secondary release areas
-				.asc		- DEM
+				.asc or .tif		- DEM
 			Outputs/
 			Work/
 

--- a/docs/moduleOut1Peak.rst
+++ b/docs/moduleOut1Peak.rst
@@ -24,7 +24,7 @@ Plot all fields
 simulation result field provided in the specified input directory. This function
 is designed to work for result fields that follow a certain naming convention in
 order to provide full functionality:
-*releaseAreaName_simulationType_modelType_simulationIdentifier_resultType.asc*
+*releaseAreaName_simulationType_modelType_simulationIdentifier_resultType.{asc/tif}*
 
 One plot for each field is saved using the name of the input field. By default,
 the plot is constrained to where there is data, however this can be turned off


### PR DESCRIPTION
https://docs.avaframe.org/en/addtiffdocu/