### PR TITLE
[com1]: changed a function call

### DIFF
--- a/avaframe/com1DFA/particleTools.py
+++ b/avaframe/com1DFA/particleTools.py
@@ -14,6 +14,7 @@ import pickle
 # Local imports
 import avaframe.in3Utils.fileHandlerUtils as fU
 import avaframe.com1DFA.DFAtools as DFAtls
+import avaframe.in3Utils.geoTrans as geoTrans
 import avaframe.com1DFA.DFAfunctionsCython as DFAfunC
 
 
@@ -601,7 +602,7 @@ def getSplitPartPosition(cfg, particles, aPart, Nx, Ny, Nz, csz, nSplit, ind):
     alpha = 2*math.pi*(np.arange(nSplit)/nSplit + rng.random(1))
     cos = rNew*np.cos(alpha)
     sin = rNew*np.sin(alpha)
-    nx, ny, nz = DFAtls.getNormalArray(np.array([x[ind]]), np.array([y[ind]]), Nx, Ny, Nz, csz)
+    nx, ny, nz = geoTrans.getNormalArray(np.array([x[ind]]), np.array([y[ind]]), Nx, Ny, Nz, csz)
     e1x, e1y, e1z, e2x, e2y, e2z = getTangenVectors(nx, ny, nz, np.array([ux[ind]]), np.array([uy[ind]]), np.array([uz[ind]]))
     xNew = x[ind] + cos * e1x + sin * e2x
     yNew = y[ind] + cos * e1y + sin * e2y

--- a/avaframe/com1DFA/testSPH.py
+++ b/avaframe/com1DFA/testSPH.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 
 # Local imports
 import avaframe.out3Plot.plotUtils as pU
-import avaframe.com1DFA.DFAtools as DFAtls
+import avaframe.in3Utils.geoTrans as geoTrans
 import avaframe.com1DFA.com1DFA as com1DFA
 # import avaframe.com1DFA.SPHfunctions as SPH
 from avaframe.in3Utils import cfgUtils
@@ -246,7 +246,7 @@ for nPartPerD in nPartPerDList:
     ux = particles['x']
     uy = particles['y']
     uz = particles['z']
-    nx, ny, nz = DFAtls.getNormalArray(x, y, Nx, Ny, Nz, csz)
+    nx, ny, nz = geoTrans.getNormalArray(x, y, Nx, Ny, Nz, csz)
     # normal component of the velocity
     uN = ux*nx + uy*ny + uz*nz
     # print(nx, ny, nz)


### PR DESCRIPTION
The function ``getNormalArray(..)`` does not exist in ``com1DFA.DFAtools`` but in ``in3Utils.geoTrans``, I guess this one should be called?
Otherwise a AttributeError is raised when particles are splitted:
![Screenshot from 2025-03-13 09-17-47](https://github.com/user-attachments/assets/bd679518-a1d3-4d22-a794-ea46f3b0aab9)
