### PR TITLE
chore(release): add support for `python 3.13`

### DIFF
--- a/.github/workflows/releaseWithManylinux.yml
+++ b/.github/workflows/releaseWithManylinux.yml
@@ -32,7 +32,7 @@ jobs:
       - name: build manylinux wheels
         uses: RalfG/python-wheels-manylinux-build@v0.7.1
         with:
-          python-versions: 'cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311 cp312-cp312'
+          python-versions: 'cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311 cp312-cp312 cp313-cp313'
           build-requirements: 'cython numpy'
       - name: Publish wheels to PyPI
         run: |
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.12
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -83,7 +83,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest]
-        python-version: ['3.8','3.9','3.10','3.11','3.12']
+        python-version: [ '3.8','3.9','3.10','3.11','3.12','3.13' ]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Adds Python 3.13 to the release github action, since it is landing as default on various OS's