### PR TITLE
[com4]: all output rasters have value -9999 in not affected cells

### DIFF
--- a/avaframe/com4FlowPy/com4FlowPy.py
+++ b/avaframe/com4FlowPy/com4FlowPy.py
@@ -516,6 +516,7 @@ def mergeAndWriteResults(modelPaths, modelOptions):
     log.info("-------------------------")
 
     # Merge calculated tiles
+    affectedCells = SPAM.mergeRaster(modelPaths["tempDir"], "res_affected")
     zDelta = SPAM.mergeRaster(modelPaths["tempDir"], "res_z_delta")
     flux = SPAM.mergeRaster(modelPaths["tempDir"], "res_flux")
     cellCounts = SPAM.mergeRaster(modelPaths["tempDir"], "res_count", method="sum")
@@ -554,18 +555,23 @@ def mergeAndWriteResults(modelPaths, modelOptions):
         output = IOf.writeResultToRaster(outputHeader, flux,
                                          modelPaths["resDir"] / "com4_{}_{}_flux".format(_uid, _ts), flip=True)
     if 'zDelta' in _outputs:
+        defineNotAffectedCells(zDelta, affectedCells)
         output = IOf.writeResultToRaster(outputHeader, zDelta,
                                          modelPaths["resDir"] / "com4_{}_{}_zdelta".format(_uid, _ts), flip=True)
     if 'cellCounts' in _outputs:
+        defineNotAffectedCells(cellCounts, affectedCells)
         output = IOf.writeResultToRaster(outputHeader, cellCounts,
                                          modelPaths["resDir"] / "com4_{}_{}_cellCounts".format(_uid, _ts), flip=True)
     if 'zDeltaSum' in _outputs:
+        defineNotAffectedCells(zDeltaSum, affectedCells)
         output = IOf.writeResultToRaster(outputHeader, zDeltaSum,
                                          modelPaths["resDir"] / "com4_{}_{}_zDeltaSum".format(_uid, _ts), flip=True)
     if 'routFluxSum' in _outputs:
+        defineNotAffectedCells(routFluxSum, affectedCells)
         output = IOf.writeResultToRaster(outputHeader, routFluxSum,
                                          modelPaths["resDir"] / "com4_{}_{}_routFluxSum".format(_uid, _ts), flip=True)
     if 'depFluxSum' in _outputs:
+        defineNotAffectedCells(depFluxSum, affectedCells)
         output = IOf.writeResultToRaster(outputHeader, depFluxSum,
                                          modelPaths["resDir"] / "com4_{}_{}_depFluxSum".format(_uid, _ts), flip=True)
     if "fpTravelAngle" in _outputs or "fpTravelAngleMax" in _outputs:
@@ -701,3 +707,25 @@ def deleteTempFolder(tempFolderPath):
         log.info(" isDir:{} isTemp:{}}".format(isDir, validTemp))
 
     log.info("+++++++++++++++++++++++")
+
+
+def defineNotAffectedCells(raster, affectedCells, noDataValue=-9999):
+    """
+    define not affected cells as -9999
+
+    Parameters
+    -----------
+    raster: np.array
+        raster whose not affected cells are specified
+    affectedCells: np.array
+        mask for affected cells
+    noDataValue: float
+        value for not affected cells (default: -9999)
+
+    Returns
+    -----------
+    raster: np. array
+        raster with not affected cells have the value noDataValue
+    """
+    raster[affectedCells == 0] = noDataValue
+    return raster

--- a/avaframe/com4FlowPy/com4FlowPyCfg.ini
+++ b/avaframe/com4FlowPy/com4FlowPyCfg.ini
@@ -204,6 +204,11 @@ maxChunks = 500
 # then you should choose '.asc' here!
 outputFileFormat = .tif
 
+# define noData value that is assigned in output rasters in cells that are not affected by the process (default: -9999)
+# when changing this value BE AWARE that noData values can have same values as a affected cells
+# (e.g., when using outputNoDataValue = 0)
+outputNoDataValue = -9999
+
 # define the different output files that are written to disk
 # default = 'zDelta|cellCounts|travelLengthMax|fpTravelAngleMax'
 # additional options: 

--- a/avaframe/runCom4FlowPy.py
+++ b/avaframe/runCom4FlowPy.py
@@ -111,6 +111,7 @@ def main(avalancheDir=''):
         cfgPath["uid"] = uid
         cfgPath["timeString"] = timeString
         cfgPath["outputFiles"] = cfgCustomPaths["outputFiles"]
+        cfgPath["outputNoDataValue"] = cfgCustomPaths["outputNoDataValue"]
 
         com4FlowPy.com4FlowPyMain(cfgPath, cfgSetup)
 
@@ -169,6 +170,7 @@ def main(avalancheDir=''):
         cfgPath["deleteTemp"] = cfgCustomPaths["deleteTempFolder"]
         cfgPath["outputFileFormat"] = cfgCustomPaths["outputFileFormat"]
         cfgPath["outputFiles"] = cfgCustomPaths["outputFiles"]
+        cfgPath["outputNoDataValue"] = cfgCustomPaths.getfloat("outputNoDataValue")
 
         cfgSetup["cpuCount"] = str(cfgUtils.getNumberOfProcesses(cfgMain, 9999))
         cfgPath["customDirs"] = cfgCustomPaths["useCustomPaths"]

--- a/docs/moduleCom4FlowPy.rst
+++ b/docs/moduleCom4FlowPy.rst
@@ -224,6 +224,7 @@ Output
 
 All outputs are written in *'.tif'* or in *'.asc'* raster format (controlable via the ``outputFileFormat`` option in ``(local_)com4FlowPyCfg.ini``, default is *'.tif'*) in the same resolution and extent as the input raster layers.
 You can customize which output rasters are written at the end of the model run by selecting the desired output files through the ``outputFiles`` option in ``(local_)com4FlowPyCfg.ini``.
+In the output rasters, the cells, that are not affected by the process, are specified by the value -9999.
 
 By default the following four output layers are written to disk at the end of the model run:
 


### PR DESCRIPTION
- There is a new parameter in the (local_)com4FlowPyCfg.ini `outputNoDataValue` (default: -9999) that defines the nodata value for the output rasters
-  Then ALL output rasters have the same value in cells taht are not affected by the process (default -9999)
- I've tested in one example, if all -9999 values are at the same locations in every output-raster.
- A further question/ issue?: Should we initialize the rasterArrays consistently? (see a comment below)