### PR TITLE
[com1]: Assign values to returned variables in every condition

### DIFF
--- a/avaframe/com1DFA/DFAToolsCython.pyx
+++ b/avaframe/com1DFA/DFAToolsCython.pyx
@@ -163,7 +163,11 @@ cpdef (double, double, double) normalize(double x, double y, double z):
       zn: numpy array
           z component of the normalized vector
   """
-  cdef double norme, xn, yn, zn
+  cdef double norme
+  cdef double xn = 0.0
+  cdef double yn = 0.0
+  cdef double zn = 0.0
+
   norme = norm(x, y, z)
   if norme>0:
     xn = x / norme

--- a/avaframe/com1DFA/DFAfunctionsCython.pyx
+++ b/avaframe/com1DFA/DFAfunctionsCython.pyx
@@ -442,9 +442,11 @@ cpdef (double, double) computeEntMassAndForce(double dt, double entrMassCell,
   rhoEnt: float
     entrainement density
   """
-  cdef double width, ABotSwiped, areaEntrPart
+  cdef double width, ABotSwiped
   # compute entrained mass
-  cdef double dm = 0
+  cdef double dm = 0.0
+  cdef double areaEntrPart = 0.0
+
   if entrMassCell > 0:
       # either erosion or ploughing but not both
 
@@ -527,7 +529,7 @@ cpdef double computeResForce(double areaPart, double rho, double cResCell,
       resistance component for particle
   """
 
-  cdef double cRecResPart
+  cdef double cRecResPart = 0.0
   # explicit formulation (explicitFriction == 1)
   if explicitFriction == 1:
     if resistanceType == 1:
@@ -1100,7 +1102,12 @@ cpdef (double, double, double, double) account4FrictionForce(double ux, double u
   dtStop : float
       time step (smaller then dt if the particle stops during this time step)
   """
-  cdef double xDir, yDir, zDir, uxNew, uyNew, uzNew, uMagNew, dtStop
+  cdef double xDir, yDir, zDir
+  cdef double uxNew = 0.0
+  cdef double uyNew = 0.0
+  cdef double uzNew = 0.0
+  cdef double uMagNew = 0.0
+  cdef double dtStop = 0.0
 
   if explicitFriction == 1:
     # explicite method

--- a/avaframe/com1DFA/checkCfg.py
+++ b/avaframe/com1DFA/checkCfg.py
@@ -218,4 +218,10 @@ def checkCfgFrictionModel(cfg, inputSimFiles, relVolume=""):
                 )
             )
 
+    # check if explicitFriction has valid values
+    if cfg["GENERAL"]["explicitFriction"] not in ["0", "1"]:
+        message = "explicitFriction should be either 0 (implicit method) or 1 (explicit method)."
+        log.error(message)
+        raise ValueError(message)
+
     return cfg

--- a/avaframe/com1DFA/damCom1DFA.pyx
+++ b/avaframe/com1DFA/damCom1DFA.pyx
@@ -308,7 +308,8 @@ cpdef (int, int, double, double, double, double, double, double, double, double,
   zT: float
     z component of the tangent vector to the dam at the intersection point
   """
-  cdef int i, intersection
+  cdef int i
+  cdef int intersection = 0
   cdef double xF1, yF1, zF1, xF2, yF2, zF2
   cdef double xF, yF, zF
   cdef double xC, yC, zC, xC1, yC1, zC1, xC2, yC2, zC2

--- a/avaframe/tests/test_DFAfunctionsCython.py
+++ b/avaframe/tests/test_DFAfunctionsCython.py
@@ -88,7 +88,7 @@ def test_computeEntMassAndForce(capfd):
     )
     #    print(dm, areaEntrPart)
     assert dm == 0
-    assert areaEntrPart == 1
+    assert areaEntrPart == 0
 
     entrMassCell = 200
     entEroEnergy = 0

--- a/avaframe/tests/test_checkCfg.py
+++ b/avaframe/tests/test_checkCfg.py
@@ -74,6 +74,7 @@ def test_checkCfgFrictionModel():
             "Bsamosat": "4.13",
             "muvoellmy": "4000.",
             "xsivoellmy": "4000.",
+            "explicitFriction": "0",
         }
     }
     inputSimFiles = {}
@@ -100,6 +101,7 @@ def test_checkCfgFrictionModel():
             "Bsamosat": "9.13",
             "muvoellmy": "4000.",
             "xsivoellmy": "nan",
+            "explicitFriction": "0",
         }
     }
 
@@ -125,6 +127,7 @@ def test_checkCfgFrictionModel():
             "Bsamosat": "nan",
             "muvoellmy": "4000.",
             "xsivoellmy": "nan",
+            "explicitFriction": "0",
         }
     }
 
@@ -144,6 +147,7 @@ def test_checkCfgFrictionModel():
             "Bsamosat": "test",
             "muvoellmy": "4000.",
             "xsivoellmy": "nan",
+            "explicitFriction": "0",
         }
     }
 
@@ -178,6 +182,7 @@ def test_checkCfgFrictionModel():
             "volClassSmall": "25000.",
             "volClassMedium": "60000.",
             "meshCellSize": "5",
+            "explicitFriction": "1",
         }
     }
 
@@ -219,6 +224,7 @@ def test_checkCfgFrictionModel():
             "volClassSmall": "25000.",
             "volClassMedium": "60000.",
             "meshCellSize": "5",
+            "explicitFriction": "1",
         }
     }
 
@@ -260,6 +266,7 @@ def test_checkCfgFrictionModel():
             "volClassSmall": "25000.",
             "volClassMedium": "60000.",
             "meshCellSize": "5",
+            "explicitFriction": "1",
         }
     }
 

--- a/avaframe/tests/test_com1DFA.py
+++ b/avaframe/tests/test_com1DFA.py
@@ -1917,6 +1917,7 @@ def test_prepareVarSimDict(tmp_path, caplog):
         "muvoellmy": "4000.",
         "xsivoellmy": "4000.",
         "dam": "True",
+        "explicitFriction": 0,
     }
     standardCfg["INPUT"] = {
         "entThThickness": "1.",
@@ -1978,6 +1979,7 @@ def test_prepareVarSimDict(tmp_path, caplog):
         "muvoellmy": "4000.",
         "xsivoellmy": "4000.",
         "dam": "True",
+        "explicitFriction": 0,
     }
 
     testCfg["INPUT"] = {
@@ -2072,6 +2074,7 @@ def test_prepareVarSimDict(tmp_path, caplog):
         "muvoellmy": "4000.",
         "xsivoellmy": "4000.",
         "dam": "True",
+        "explicitFriction": 0,
     }
     testCfg2["INPUT"] = {
         "entThThickness": "1.",


### PR DESCRIPTION
- check if explicitFriction has valid values
- in Cython - files: check that all returned variables are assigned to a value (otherwise no error is raised, but leads to wrong results)