### PR TITLE
[out3]: plot extent for values != 0

### DIFF
--- a/avaframe/out3Plot/plotUtils.py
+++ b/avaframe/out3Plot/plotUtils.py
@@ -492,7 +492,7 @@ def constrainPlotsToData(inputData, cellSize, extentOption=False, constrainedDat
     else:
         plotBuffer = int(cfg.getfloat("plotBuffer") / cellSize)
 
-    ind = np.where(inputData > 0)
+    ind = np.where(inputData != 0)
     if len(ind[0]) > 0:
         rowsMin = max(np.amin(ind[0]) - plotBuffer, 0)
         rowsMax = min(np.amax(ind[0]) + plotBuffer, inputData.shape[0] - 1)


### PR DESCRIPTION
e.g., the field surface change can have negative values, so for the report plots we need to take an extent with all values (that are positive and negative).
Since all cells that are not hit by the process are 0, we could define the extent that is shown in the plot with values != 0.