### PR TITLE
[com1;com4;com8;com9] Removed Windows-OS-specific conditional imports for `multiprocessing`

### DIFF
--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -23,10 +23,7 @@ import pandas as pd
 from shapely.geometry import Polygon as sPolygon
 
 
-if os.name == "nt":
-    from multiprocessing.pool import ThreadPool as Pool
-else:
-    from multiprocessing import Pool
+from multiprocessing import Pool
 
 # Local imports
 from avaframe.version import getVersion

--- a/avaframe/com4FlowPy/flowCore.py
+++ b/avaframe/com4FlowPy/flowCore.py
@@ -14,10 +14,7 @@ import gc
 import psutil
 import time
 
-if os.name == "nt":
-    from multiprocessing.pool import Pool as Pool
-else:
-    from multiprocessing import Pool
+from multiprocessing import Pool
 
 from avaframe.com4FlowPy.flowClass import Cell
 

--- a/avaframe/com8MoTPSA/com8MoTPSA.py
+++ b/avaframe/com8MoTPSA/com8MoTPSA.py
@@ -9,10 +9,7 @@ import shutil
 
 from avaframe.in3Utils.cfgUtils import cfgToRcf
 
-if os.name == "nt":
-    from multiprocessing.pool import ThreadPool as Pool
-else:
-    from multiprocessing import Pool
+from multiprocessing import Pool
 
 import avaframe.com1DFA.com1DFA as com1DFA
 from avaframe.in3Utils import cfgUtils

--- a/avaframe/com9MoTVoellmy/com9MoTVoellmy.py
+++ b/avaframe/com9MoTVoellmy/com9MoTVoellmy.py
@@ -5,10 +5,7 @@ import pathlib
 import time
 import sys
 
-if os.name == "nt":
-    from multiprocessing.pool import ThreadPool as Pool
-else:
-    from multiprocessing import Pool
+from multiprocessing import Pool
 
 import avaframe.com1DFA.com1DFA as com1DFA
 from avaframe.in3Utils import cfgUtils


### PR DESCRIPTION
Reported by @stnfranck

On Windows recent python versions don't need the distinction for parallel threads anymore. This lead to having multiple processes but only on one core. 

It runs on multiple cores now...