### PR TITLE
[com1]: write time depedent release infos into report

### DIFF
--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -424,7 +424,7 @@ def com1DFACore(cfg, avaDir, cuSimName, inputSimFiles, outDir, simHash=""):
     # write report dictionary
     reportDict = createReportDict(avaDir, cuSimName, relName, inputSimLines, cfg, reportAreaInfo)
     # add time and mass info to report
-    reportDict = reportAddTimeMassInfo(reportDict, tCPUDFA, infoDict)
+    reportDict = reportAddTimeMassInfo(reportDict, tCPUDFA, infoDict, cfg)
 
     if cfg["EXPORTS"].getboolean("exportData") == False:
         reportDict["contours"] = contourDictXY
@@ -543,7 +543,7 @@ def setThickness(cfg, lineTh, typeTh):
     # set thickness value info read from ini file that has been updated from shp or ini previously
     for count, id in enumerate(lineTh["id"]):
         if cfg["GENERAL"].getboolean("timeDependentRelease"):
-            lineTh["thickness"][count] = float(lineTh["thickness"][count])
+            lineTh["thickness"][count] = float(lineTh["thickness"][count].item())
 
         elif cfg["GENERAL"].getboolean(thFlag):
             thName = typeTh + id
@@ -639,7 +639,7 @@ def prepareInputData(inputSimFiles, cfg):
     if cfg["GENERAL"].getboolean("timeDependentRelease"):
         releaseLine["type"] = "time dependent Release"
         timeDepRelValues, _ = gI.getTimeDepRelCsv(inputSimFiles["timeDepRelCsv"])
-        releaseLine["thickness"] = [timeDepRelValues["thickness"][timeDepRelValues["timeStep"] == 0]]
+        releaseLine["thickness"] = [timeDepRelValues["thickness"][timeDepRelValues["timeStep"] == 0].item()]
         releaseLine["thicknessSource"] = ["csv file"]
         releaseLine["velocity"] = timeDepRelValues["velocity"][timeDepRelValues["timeStep"] == 0]
         releaseLine["timeDepRelValues"] = timeDepRelValues
@@ -847,6 +847,12 @@ def createReportDict(avaDir, logName, relName, inputSimLines, cfg, reportAreaInf
             "Release thickness [m]": relDict["thickness"],
         },
     }
+    if cfgGen.getboolean("timeDependentRelease"):
+        reportST["Release Area"].pop("Release thickness [m]")
+        reportST["Release Area"]["Release thickness (at timestep 0 s) [m]"] = relDict["thickness"]
+        reportST["Release Area"]["Release thickness (summed over timesteps) [m]"] = np.sum(
+            relDict["timeDepRelValues"]["thickness"]
+        )
 
     # add frict parameters
     if cfgGen["frictModel"].lower() == "samosat":
@@ -984,7 +990,7 @@ def createReportDict(avaDir, logName, relName, inputSimLines, cfg, reportAreaInf
     return reportST
 
 
-def reportAddTimeMassInfo(reportDict, tCPUDFA, infoDict):
+def reportAddTimeMassInfo(reportDict, tCPUDFA, infoDict, cfg):
     """Add time and mass info to report"""
 
     # add mass info
@@ -996,6 +1002,16 @@ def reportAddTimeMassInfo(reportDict, tCPUDFA, infoDict):
     reportDict["Simulation Parameters"].update(
         {"Entrained volume [m3]": ("%.2f" % infoDict["entrained volume"])}
     )
+    reportDict["Simulation Parameters"].update(
+        {"Detrained mass [kg]": ("%.2f" % infoDict["detrained mass"])}
+    )
+    reportDict["Simulation Parameters"].update(
+        {"Total initialized mass [kg]": ("%.2f" % infoDict["initialized mass"])}
+    )
+    if cfg["GENERAL"].getboolean("timeDependentRelease"):
+        reportDict["Release Area"].update(
+            {"Model release volume (summed over timesteps) [m3]": ("%.2f" % infoDict["initialized volume"])}
+        )
 
     # add stop info
     reportDict["Simulation Parameters"].update(infoDict["stopInfo"])
@@ -1233,6 +1249,11 @@ def initializeSimulation(cfg, outDir, demOri, inputSimLines, logName):
     reportAreaInfo["Release area info"]["Model release volume [m3]"] = "%.2f" % (
         particles["mTot"] / cfgGen.getfloat("rho")
     )
+    if cfgGen.getboolean("timeDependentRelease"):
+        # rename column
+        reportAreaInfo["Release area info"]["Model release volume (at timestep 0 s) [m3]"] = reportAreaInfo[
+            "Release area info"
+        ].pop("Model release volume [m3]")
 
     # initialize Dam
     damLine = inputSimLines["damLine"]
@@ -2337,6 +2358,8 @@ def DFAIterate(cfg, particles, fields, dem, inputSimLines, outDir, cuSimName, si
         "entrained volume": (np.sum(massEntrained) / cfgGen.getfloat("rhoEnt")),
         "pfvTimeMax": pfvTimeMax,
         "massInitialized": massInitialized,
+        "initialized mass": np.sum(massInitialized),
+        "initialized volume": np.sum(massInitialized) / cfgGen.getfloat("rho"),
     }
 
     # determine if stop criterion is reached or end time
@@ -2349,7 +2372,7 @@ def DFAIterate(cfg, particles, fields, dem, inputSimLines, outDir, cuSimName, si
             {
                 "stopInfo": {
                     "Stop criterion": "end Time reached: %.2f" % avaTime,
-                    "Avalanche run time [s]": "%.2f" % avaTime,
+                    "Process run time [s]": "%.2f" % avaTime,
                 }
             }
         )
@@ -2358,7 +2381,7 @@ def DFAIterate(cfg, particles, fields, dem, inputSimLines, outDir, cuSimName, si
             {
                 "stopInfo": {
                     "Stop criterion": "< %.2f percent of PKE" % stopCritPer,
-                    "Avalanche run time [s]": "%.2f" % avaTime,
+                    "Process run time [s]": "%.2f" % avaTime,
                 }
             }
         )
@@ -3686,7 +3709,8 @@ def initializeRelVol(cfg, demVol, releaseFile, radius, releaseType="primary", ti
         releaseLine = shpConv.readLine(releaseFile, "release1", demVol)
         if releaseType == "timeDepRel":
             timeDepRelValues, _ = gI.getTimeDepRelCsv(timeDepRelFile)
-            releaseLine["thickness"] = [timeDepRelValues["thickness"][0]]
+            # for time dependent release use the release volume summed up over all timesteps
+            releaseLine["thickness"] = [np.sum(timeDepRelValues["thickness"])]
         # check if release features overlap between features
         thresholdPointInPoly = cfg["GENERAL"].getfloat("thresholdPointInPoly")
         geoTrans.prepareArea(releaseLine, demVol, thresholdPointInPoly, combine=True, checkOverlap=True)

--- a/avaframe/log2Report/generateReport.py
+++ b/avaframe/log2Report/generateReport.py
@@ -90,9 +90,9 @@ def writeReportFile(reportD, pfile):
         if reportD[key][subKey] == 'title':
             addLineBlock('#', reportD[key], pfile, onlyFirstLine=True)
 
-        # Avalanche name
+        # Simulation directory
         if reportD[key][subKey] == 'avaName':
-            addLineBlock('### Avalanche directory:', reportD[key], pfile, italicFont=True)
+            addLineBlock('### Simulation directory:', reportD[key], pfile, italicFont=True)
 
         # Simulation name
         if reportD[key][subKey] == 'simName':

--- a/avaframe/tests/test_com1DFA.py
+++ b/avaframe/tests/test_com1DFA.py
@@ -29,9 +29,7 @@ def test_prepareInputData(tmp_path):
     """test preparing input data"""
 
     # setup requuired input data
-    inputSimFiles = {
-        "entResInfo": {"flagEnt": "Yes", "flagRes": "No", "flagSecondaryRelease": "No"}
-    }
+    inputSimFiles = {"entResInfo": {"flagEnt": "Yes", "flagRes": "No", "flagSecondaryRelease": "No"}}
     dirName = pathlib.Path(__file__).parents[0]
     avaDir = dirName / ".." / "data" / "avaAlr"
     relFile = avaDir / "Inputs" / "REL" / "relAlr.shp"
@@ -76,9 +74,7 @@ def test_prepareInputData(tmp_path):
     assert inputSimLines["entLine"]["initializedFrom"] == "shapefile"
 
     # call function to be tested
-    inputSimFiles = {
-        "entResInfo": {"flagEnt": "No", "flagRes": "Yes", "flagSecondaryRelease": "No"}
-    }
+    inputSimFiles = {"entResInfo": {"flagEnt": "No", "flagRes": "Yes", "flagSecondaryRelease": "No"}}
     dirName = pathlib.Path(__file__).parents[0]
     avaDir = dirName / ".." / "data" / "avaParabola"
     relFile = avaDir / "Inputs" / "REL" / "release1PF.shp"
@@ -108,9 +104,7 @@ def test_prepareInputData(tmp_path):
     assert inputSimLines["resLine"]["initializedFrom"] == "shapefile"
 
     # call function to be tested
-    inputSimFiles = {
-        "entResInfo": {"flagEnt": "No", "flagRes": "Yes", "flagSecondaryRelease": "No"}
-    }
+    inputSimFiles = {"entResInfo": {"flagEnt": "No", "flagRes": "Yes", "flagSecondaryRelease": "No"}}
     dirName = pathlib.Path(__file__).parents[0]
     avaDir = dirName / ".." / "data" / "avaParabola"
     relFile = avaDir / "Inputs" / "REL" / "release1PF.shp"
@@ -139,9 +133,7 @@ def test_prepareInputData(tmp_path):
     assert inputSimLines["relThField"] == ""
 
     # call function to be tested
-    inputSimFiles = {
-        "entResInfo": {"flagEnt": "No", "flagRes": "Yes", "flagSecondaryRelease": "No"}
-    }
+    inputSimFiles = {"entResInfo": {"flagEnt": "No", "flagRes": "Yes", "flagSecondaryRelease": "No"}}
     dirName = pathlib.Path(__file__).parents[0]
     avaDir = dirName / ".." / "data" / "avaParabola"
     relFile = avaDir / "Inputs" / "REL" / "release1PF.shp"
@@ -171,16 +163,11 @@ def test_prepareInputData(tmp_path):
     assert inputSimLines["releaseLine"]["initializedFrom"] == "raster"
     assert inputSimLines["releaseLine"]["Name"] == "from raster"
     assert inputSimLines["releaseLine"]["thickness"] == "from raster"
-    assert (
-        inputSimLines["releaseLine"]["file"]
-        == dirName / "data" / "relThFieldTestFile.asc"
-    )
+    assert inputSimLines["releaseLine"]["file"] == dirName / "data" / "relThFieldTestFile.asc"
     assert inputSimLines["releaseLine"]["type"] == "Release from raster"
 
     # call function to be tested
-    inputSimFiles = {
-        "entResInfo": {"flagEnt": "No", "flagRes": "Yes", "flagSecondaryRelease": "No"}
-    }
+    inputSimFiles = {"entResInfo": {"flagEnt": "No", "flagRes": "Yes", "flagSecondaryRelease": "No"}}
     dirName = pathlib.Path(__file__).parents[0]
     avaDir = dirName / ".." / "data" / "avaParabola"
     relFile = avaDir / "Inputs" / "REL" / "release1PF.shp"
@@ -223,9 +210,7 @@ def test_prepareInputData(tmp_path):
     # )
 
     # setup required input data
-    inputSimFiles = {
-        "entResInfo": {"flagEnt": "No", "flagRes": "No", "flagSecondaryRelease": "No"}
-    }
+    inputSimFiles = {"entResInfo": {"flagEnt": "No", "flagRes": "No", "flagSecondaryRelease": "No"}}
     dirName = pathlib.Path(__file__).parents[0]
     avaDir = dirName / "data" / "avaTestRelTh"
     relFile = avaDir / "Inputs" / "REL" / "rel1.shp"
@@ -267,9 +252,7 @@ def test_prepareInputData(tmp_path):
     assert inputSimLines["releaseLine"]["initializedFrom"] == "raster"
 
     # setup requuired input data
-    inputSimFiles = {
-        "entResInfo": {"flagEnt": "No", "flagRes": "No", "flagSecondaryRelease": "Yes"}
-    }
+    inputSimFiles = {"entResInfo": {"flagEnt": "No", "flagRes": "No", "flagSecondaryRelease": "Yes"}}
     dirName = pathlib.Path(__file__).parents[0]
     avaDir = dirName / "data" / "avaTestRelTh"
     relFile = avaDir / "Inputs" / "REL" / "rel1.shp"
@@ -278,9 +261,7 @@ def test_prepareInputData(tmp_path):
     inputSimFiles["secondaryRelScenario"] = secrelFile
     inputSimFiles["demFile"] = avaDir / "Inputs" / "testDEM.asc"
     inputSimFiles["relThFile"] = None
-    inputSimFiles["secondaryRelThFile"] = (
-        avaDir / "Inputs" / "SECREL" / "testSecRel2.asc"
-    )
+    inputSimFiles["secondaryRelThFile"] = avaDir / "Inputs" / "SECREL" / "testSecRel2.asc"
     inputSimFiles["muFile"] = None
     inputSimFiles["xiFile"] = None
     inputSimFiles["kFile"] = None
@@ -309,24 +290,18 @@ def test_prepareInputData(tmp_path):
     assert demOri["header"]["nrows"] == 22
     assert inputSimLines["releaseLine"]["thickness"] == ["1.5", "0.7"]
     assert np.array_equal(inputSimLines["releaseLine"]["Start"], np.asarray([0.0, 9.0]))
-    assert np.array_equal(
-        inputSimLines["releaseLine"]["Length"], np.asarray([9.0, 5.0])
-    )
+    assert np.array_equal(inputSimLines["releaseLine"]["Length"], np.asarray([9.0, 5.0]))
     assert inputSimLines["releaseLine"]["Name"] == ["releaseNew1", "releaseNew2"]
     assert inputSimLines["releaseLine"]["ci95"] == ["0.4", "0.1"]
     assert inputSimLines["secondaryReleaseLine"]["Name"] == "from raster"
     assert inputSimLines["secondaryReleaseLine"]["thickness"] == "from raster"
     assert inputSimLines["secondaryReleaseLine"]["initializedFrom"] == "raster"
-    assert (
-        inputSimLines["secondaryReleaseLine"]["type"] == "Secondary release from raster"
-    )
+    assert inputSimLines["secondaryReleaseLine"]["type"] == "Secondary release from raster"
     assert inputSimLines["releaseLine"]["type"] == "Release"
     assert inputSimLines["releaseLine"]["initializedFrom"] == "shapefile"
 
     # setup requuired input data
-    inputSimFiles = {
-        "entResInfo": {"flagEnt": "No", "flagRes": "No", "flagSecondaryRelease": "No"}
-    }
+    inputSimFiles = {"entResInfo": {"flagEnt": "No", "flagRes": "No", "flagSecondaryRelease": "No"}}
     dirName = pathlib.Path(__file__).parents[0]
     avaDir = dirName / "data" / "avaTestRelTh"
     relFile = avaDir / "Inputs" / "REL" / "testRel2.asc"
@@ -376,10 +351,7 @@ def test_prepareInputData(tmp_path):
 
     with pytest.raises(AssertionError) as e:
         assert com1DFA.prepareInputData(inputSimFiles, cfg)
-    assert (
-        "One or more release features in relAlr2.shp have holes - check error plots in"
-        in str(e.value)
-    )
+    assert "One or more release features in relAlr2.shp have holes - check error plots in" in str(e.value)
 
     # setup required input data
     inputSimFiles = {"entResInfo": {"flagEnt": "No", "flagRes": "No", "flagSecondaryRelease": "No"}}
@@ -462,9 +434,7 @@ def test_prepareReleaseEntrainment(tmp_path):
     rel = pathlib.Path(tmp_path, "release1PF_test.shp")
 
     # call function to be tested
-    relName, inputSimLines, badName = com1DFA.prepareReleaseEntrainment(
-        cfg, rel, inputSimLines
-    )
+    relName, inputSimLines, badName = com1DFA.prepareReleaseEntrainment(cfg, rel, inputSimLines)
 
     assert relName == "release1PF_test"
     assert inputSimLines["entResInfo"]["flagSecondaryRelease"] == "Yes"
@@ -507,9 +477,7 @@ def test_prepareReleaseEntrainment(tmp_path):
     rel = pathlib.Path(tmp_path, "release1PF_test.shp")
 
     # call function to be tested
-    relName2, inputSimLines2, badName2 = com1DFA.prepareReleaseEntrainment(
-        cfg, rel, inputSimLines
-    )
+    relName2, inputSimLines2, badName2 = com1DFA.prepareReleaseEntrainment(cfg, rel, inputSimLines)
 
     assert relName2 == "release1PF_test"
     assert inputSimLines2["entResInfo"]["flagSecondaryRelease"] == "Yes"
@@ -553,9 +521,7 @@ def test_prepareReleaseEntrainment(tmp_path):
     rel = pathlib.Path(tmp_path, "release1PF_test.shp")
 
     # call function to be tested
-    relName2, inputSimLines2, badName2 = com1DFA.prepareReleaseEntrainment(
-        cfg, rel, inputSimLines
-    )
+    relName2, inputSimLines2, badName2 = com1DFA.prepareReleaseEntrainment(cfg, rel, inputSimLines)
 
     # print(
     #      "Test",
@@ -574,9 +540,7 @@ def test_prepareReleaseEntrainment(tmp_path):
 
     # call function to be tested
     cfg["GENERAL"]["secRelArea"] = "False"
-    relName3, inputSimLines3, badName3 = com1DFA.prepareReleaseEntrainment(
-        cfg, rel, inputSimLines
-    )
+    relName3, inputSimLines3, badName3 = com1DFA.prepareReleaseEntrainment(cfg, rel, inputSimLines)
 
     assert relName3 == "release1PF_test"
     assert inputSimLines3["entResInfo"]["flagSecondaryRelease"] == "No"
@@ -600,9 +564,7 @@ def test_prepareReleaseEntrainment(tmp_path):
     cfg["GENERAL"]["relTh"] = "1.32"
 
     # call function to test
-    relName4, inputSimLines4, badName4 = com1DFA.prepareReleaseEntrainment(
-        cfg, rel, inputSimLines
-    )
+    relName4, inputSimLines4, badName4 = com1DFA.prepareReleaseEntrainment(cfg, rel, inputSimLines)
 
     assert relName4 == "release1PF_test"
     assert inputSimLines4["entResInfo"]["flagSecondaryRelease"] == "No"
@@ -645,9 +607,7 @@ def test_prepareReleaseEntrainment(tmp_path):
         "id": ["0", "1"],
         "initializedFrom": "shapefile",
     }
-    relName5, inputSimLines5, badName5 = com1DFA.prepareReleaseEntrainment(
-        cfg, rel, inputSimLines
-    )
+    relName5, inputSimLines5, badName5 = com1DFA.prepareReleaseEntrainment(cfg, rel, inputSimLines)
 
     assert relName5 == "release1PF_test"
     assert inputSimLines5["entResInfo"]["flagSecondaryRelease"] == "No"
@@ -688,9 +648,7 @@ def test_setThickness():
 
     assert lineTh["thickness"] == [1.0, 1.0]
     assert lineTh["thicknessSource"] == ["ini file", "ini file"]
-    assert np.array_equal(
-        lineTh["x"], np.asarray([0, 10.0, 10.0, 0.0, 0.0, 20.0, 26.0, 26.0, 20.0, 20.0])
-    )
+    assert np.array_equal(lineTh["x"], np.asarray([0, 10.0, 10.0, 0.0, 0.0, 20.0, 26.0, 26.0, 20.0, 20.0]))
 
     # call function to be tested
     lineTh = {
@@ -707,9 +665,7 @@ def test_setThickness():
 
     assert lineTh["thickness"] == [1.0, 1.0]
     assert lineTh["thicknessSource"] == ["ini file", "ini file"]
-    assert np.array_equal(
-        lineTh["x"], np.asarray([0, 10.0, 10.0, 0.0, 0.0, 20.0, 26.0, 26.0, 20.0, 20.0])
-    )
+    assert np.array_equal(lineTh["x"], np.asarray([0, 10.0, 10.0, 0.0, 0.0, 20.0, 26.0, 26.0, 20.0, 20.0]))
 
     # call function to be tested
     cfg["GENERAL"]["entThFromFile"] = "True"
@@ -733,9 +689,7 @@ def test_setThickness():
 
     assert lineTh["thickness"] == [1.0, 0.7]
     assert lineTh["thicknessSource"] == ["shp file", "shp file"]
-    assert np.array_equal(
-        lineTh["x"], np.asarray([0, 10.0, 10.0, 0.0, 0.0, 20.0, 26.0, 26.0, 20.0, 20.0])
-    )
+    assert np.array_equal(lineTh["x"], np.asarray([0, 10.0, 10.0, 0.0, 0.0, 20.0, 26.0, 26.0, 20.0, 20.0]))
 
     # call function to be tested
     cfg["GENERAL"]["entThFromFile"] = "True"
@@ -755,9 +709,7 @@ def test_setThickness():
 
     assert lineTh["thickness"] == [1.2, 0.7]
     assert lineTh["thicknessSource"] == ["shp file", "shp file"]
-    assert np.array_equal(
-        lineTh["x"], np.asarray([0, 10.0, 10.0, 0.0, 0.0, 20.0, 26.0, 26.0, 20.0, 20.0])
-    )
+    assert np.array_equal(lineTh["x"], np.asarray([0, 10.0, 10.0, 0.0, 0.0, 20.0, 26.0, 26.0, 20.0, 20.0]))
 
 
 def test_createReportDict():
@@ -770,7 +722,11 @@ def test_createReportDict():
     inputSimLines = {
         "entrainmentArea": "entTest",
         "resistanceArea": "resTest",
-        "releaseLine": {"Name": "relTestFeature", "thickness": ["1.45"]},
+        "releaseLine": {
+            "Name": "relTestFeature",
+            "thickness": ["1.45"],
+            "timeDepRelValues": {"thickness": np.array([1, 2.1, 1])},
+        },
         "entLine": {"Name": ["entTest"], "thickness": ["1.1"]},
     }
     reportAreaInfo = {
@@ -791,12 +747,11 @@ def test_createReportDict():
         "frictModel": "samosAT",
         "entTh": "0.3",
         "rhoEnt": "100.0",
+        "timeDependentRelease": "False",
     }
 
     # call function to be tested
-    reportST = com1DFA.createReportDict(
-        avaDir, logName, relName, inputSimLines, cfg, reportAreaInfo
-    )
+    reportST = com1DFA.createReportDict(avaDir, logName, relName, inputSimLines, cfg, reportAreaInfo)
 
     assert "Simulation Parameters" in reportST
     assert "Program version" in reportST["Simulation Parameters"]
@@ -814,29 +769,41 @@ def test_createReportDict():
     assert reportST["Entrainment area"]["Entrainment area scenario"] == "entTest"
     assert "Projected Area [m2]" in reportST["Release Area"]
 
+    cfg["GENERAL"]["timeDependentRelease"] = "True"
+    # call function to be tested
+    reportST = com1DFA.createReportDict(avaDir, logName, relName, inputSimLines, cfg, reportAreaInfo)
+    assert reportST["Release Area"]["Release thickness (at timestep 0 s) [m]"] == ["1.45"]
+    assert reportST["Release Area"]["Release thickness (summed over timesteps) [m]"] == 4.1
+
 
 def test_reportAddTimeMassInfo():
     """test adding mass and time info to report dict"""
 
     # setup required input
     reportDict = {"Simulation Parameters": {"testItem": 1.0}}
+    cfg = configparser.ConfigParser()
+    cfg["GENERAL"] = {"timeDependentRelease": "False"}
     tcpuDFA = 400.0
     infoDict = {
         "initial mass": 400000.2345,
         "final mass": 400000.8345,
         "entrained mass": 0.8,
         "entrained volume": 0.2,
+        "detrained mass": 0.0,
+        "initialized mass": 400000.2345,
         "stopInfo": {"Stop criterion": "0.1 percent of PKE"},
     }
 
     # call function to be tested
-    reportDict = com1DFA.reportAddTimeMassInfo(reportDict, tcpuDFA, infoDict)
+    reportDict = com1DFA.reportAddTimeMassInfo(reportDict, tcpuDFA, infoDict, cfg)
 
     assert reportDict["Simulation Parameters"]["testItem"] == 1.0
     assert reportDict["Simulation Parameters"]["Initial mass [kg]"] == "400000.23"
     assert reportDict["Simulation Parameters"]["Final mass [kg]"] == "400000.83"
     assert reportDict["Simulation Parameters"]["Entrained mass [kg]"] == "0.80"
     assert reportDict["Simulation Parameters"]["Entrained volume [m3]"] == "0.20"
+    assert reportDict["Simulation Parameters"]["Detrained mass [kg]"] == "0.00"
+    assert reportDict["Simulation Parameters"]["Total initialized mass [kg]"] == "400000.23"
     assert reportDict["Simulation Parameters"]["Stop criterion"] == "0.1 percent of PKE"
 
 
@@ -1169,28 +1136,12 @@ def test_initializeMesh():
     assert np.all(np.isnan(dem["rasterData"][0:5, 4]))
     assert abs(dem["Nx"][2, 2]) == abs(dem["Nz"][2, 2])
     assert np.isclose(dem["areaRaster"][2, 2], demTest["areaRaster"][2, 2])
-    assert (
-        dem["headerNeighbourGrid"]["xllcenter"]
-        == demTest["headerNeighbourGrid"]["xllcenter"]
-    )
-    assert (
-        dem["headerNeighbourGrid"]["yllcenter"]
-        == demTest["headerNeighbourGrid"]["yllcenter"]
-    )
-    assert (
-        dem["headerNeighbourGrid"]["ncols"] == demTest["headerNeighbourGrid"]["ncols"]
-    )
-    assert (
-        dem["headerNeighbourGrid"]["nrows"] == demTest["headerNeighbourGrid"]["nrows"]
-    )
-    assert (
-        dem["headerNeighbourGrid"]["cellsize"]
-        == demTest["headerNeighbourGrid"]["cellsize"]
-    )
-    assert (
-        dem["headerNeighbourGrid"]["yllcenter"]
-        == demTest["headerNeighbourGrid"]["yllcenter"]
-    )
+    assert dem["headerNeighbourGrid"]["xllcenter"] == demTest["headerNeighbourGrid"]["xllcenter"]
+    assert dem["headerNeighbourGrid"]["yllcenter"] == demTest["headerNeighbourGrid"]["yllcenter"]
+    assert dem["headerNeighbourGrid"]["ncols"] == demTest["headerNeighbourGrid"]["ncols"]
+    assert dem["headerNeighbourGrid"]["nrows"] == demTest["headerNeighbourGrid"]["nrows"]
+    assert dem["headerNeighbourGrid"]["cellsize"] == demTest["headerNeighbourGrid"]["cellsize"]
+    assert dem["headerNeighbourGrid"]["yllcenter"] == demTest["headerNeighbourGrid"]["yllcenter"]
 
 
 def test_getSimTypeList():
@@ -1200,14 +1151,10 @@ def test_getSimTypeList():
     standardCfg = configparser.ConfigParser()
     standardCfg["GENERAL"] = {"secRelArea": "False"}
     simTypeList = ["ent", "res", "null", "available", "entres"]
-    inputSimFiles = {
-        "entResInfo": {"flagEnt": "Yes", "flagRes": "Yes", "flagSecondaryRelease": "No"}
-    }
+    inputSimFiles = {"entResInfo": {"flagEnt": "Yes", "flagRes": "Yes", "flagSecondaryRelease": "No"}}
 
     # call function to be tested
-    standardCfg, simTypeList = com1DFA.getSimTypeList(
-        standardCfg, simTypeList, inputSimFiles
-    )
+    standardCfg, simTypeList = com1DFA.getSimTypeList(standardCfg, simTypeList, inputSimFiles)
 
     # setup test result
     simTypeListTest = ["ent", "null", "res", "entres"]
@@ -1218,9 +1165,7 @@ def test_getSimTypeList():
     # call function to be tested
     simTypeList = ["ent", "null", "available"]
     inputSimFiles["entResInfo"]["flagRes"] = "No"
-    standardCfg2, simTypeList2 = com1DFA.getSimTypeList(
-        standardCfg, simTypeList, inputSimFiles
-    )
+    standardCfg2, simTypeList2 = com1DFA.getSimTypeList(standardCfg, simTypeList, inputSimFiles)
 
     # setup test result
     simTypeListTest2 = ["ent", "null"]
@@ -1234,9 +1179,7 @@ def test_getSimTypeList():
     simTypeList = ["res", "null", "available"]
     inputSimFiles["entResInfo"]["flagEnt"] = "No"
     inputSimFiles["entResInfo"]["flagRes"] = "Yes"
-    standardCfg3, simTypeList3 = com1DFA.getSimTypeList(
-        standardCfg, simTypeList, inputSimFiles
-    )
+    standardCfg3, simTypeList3 = com1DFA.getSimTypeList(standardCfg, simTypeList, inputSimFiles)
 
     # setup test result
     simTypeListTest3 = ["res", "null"]
@@ -1458,19 +1401,11 @@ def test_releaseSecRelArea():
 
     #    print("particles IN pytest socond", particles2)
     assert particles["nPart"] == 6
-    assert np.array_equal(
-        particles["x"], np.asarray([6.0, 7.0, 6.75, 7.25, 6.75, 7.25])
-    )
-    assert np.array_equal(
-        particles["totalEnthalpy"], np.asarray([6.0, 7.0, pEnt, pEnt, pEnt, pEnt])
-    )
-    assert np.array_equal(
-        particles["y"], np.asarray([6.0, 7.0, 6.75, 6.75, 7.25, 7.25])
-    )
+    assert np.array_equal(particles["x"], np.asarray([6.0, 7.0, 6.75, 7.25, 6.75, 7.25]))
+    assert np.array_equal(particles["totalEnthalpy"], np.asarray([6.0, 7.0, pEnt, pEnt, pEnt, pEnt]))
+    assert np.array_equal(particles["y"], np.asarray([6.0, 7.0, 6.75, 6.75, 7.25, 7.25]))
     assert np.array_equal(zPartArray0New, np.asarray([2, 3, 1.0, 1.0, 1.0, 1.0]))
-    assert np.array_equal(
-        particles["m"], np.asarray([1250.0, 1250.0, 50.0, 50.0, 50.0, 50.0])
-    )
+    assert np.array_equal(particles["m"], np.asarray([1250.0, 1250.0, 50.0, 50.0, 50.0, 50.0]))
     assert particles["mTot"] == 2700.0
     assert particles2["nPart"] == 11
     assert np.array_equal(
@@ -1481,14 +1416,10 @@ def test_releaseSecRelArea():
         particles2["y"],
         np.asarray([6.0, 7.0, 9.1, 6.75, 6.75, 7.25, 7.25, 8.75, 8.75, 9.25, 9.25]),
     )
-    assert np.array_equal(
-        zPartArray0New2, np.asarray([1, 2, 3, 1, 1, 1, 1, 1, 1, 1, 1])
-    )
+    assert np.array_equal(zPartArray0New2, np.asarray([1, 2, 3, 1, 1, 1, 1, 1, 1, 1, 1]))
     assert np.array_equal(
         particles2["m"],
-        np.asarray(
-            [1250.0, 1250.0, 1250.0, 50.0, 50.0, 50.0, 50.0, 25.0, 25.0, 25.0, 25.0]
-        ),
+        np.asarray([1250.0, 1250.0, 1250.0, 50.0, 50.0, 50.0, 50.0, 25.0, 25.0, 25.0, 25.0]),
     )
     assert particles2["mTot"] == 4050.0
 
@@ -1509,18 +1440,14 @@ def test_getRelThFromPart():
     relThField = ""
 
     # call function to be tested
-    relThFromPart = com1DFA.getRelThFromPart(
-        cfg["GENERAL"], inputSimLines["releaseLine"], relThField, "rel"
-    )
+    relThFromPart = com1DFA.getRelThFromPart(cfg["GENERAL"], inputSimLines["releaseLine"], relThField, "rel")
 
     assert relThFromPart == 1.5
 
     cfg["GENERAL"]["relThFromFile"] = "False"
     cfg["GENERAL"]["relTh"] = "2.0"
     # call function to be tested
-    relThFromPart = com1DFA.getRelThFromPart(
-        cfg["GENERAL"], inputSimLines["releaseLine"], relThField, "rel"
-    )
+    relThFromPart = com1DFA.getRelThFromPart(cfg["GENERAL"], inputSimLines["releaseLine"], relThField, "rel")
 
     assert relThFromPart == 2.0
 
@@ -1529,9 +1456,7 @@ def test_getRelThFromPart():
     relThField = np.zeros((10, 10))
     relThField[0:10, 1] = 10.0
     # call function to be tested
-    relThFromPart = com1DFA.getRelThFromPart(
-        cfg["GENERAL"], inputSimLines["releaseLine"], relThField, "rel"
-    )
+    relThFromPart = com1DFA.getRelThFromPart(cfg["GENERAL"], inputSimLines["releaseLine"], relThField, "rel")
 
     assert relThFromPart == 10.0
 
@@ -1968,9 +1893,7 @@ def test_exportFields(tmp_path):
     fieldsList = [fields1, fields2, fields3, fields4, fields5]
 
     # call function to be tested
-    com1DFA.exportFields(
-        cfg, 10.00, fields2, dem, outDir, logName, TSave="intermediate"
-    )
+    com1DFA.exportFields(cfg, 10.00, fields2, dem, outDir, logName, TSave="intermediate")
     com1DFA.exportFields(cfg, 40.00, fields5, dem, outDir, logName, TSave="final")
 
     # read fields
@@ -2006,15 +1929,9 @@ def test_exportFields(tmp_path):
     cfg["REPORT"] = {}
 
     com1DFA.exportFields(cfg, 0.00, fields1, dem, outDir2, logName, TSave="initial")
-    com1DFA.exportFields(
-        cfg, 10.00, fields2, dem, outDir2, logName, TSave="intermediate"
-    )
-    com1DFA.exportFields(
-        cfg, 15.00, fields3, dem, outDir2, logName, TSave="intermediate"
-    )
-    com1DFA.exportFields(
-        cfg, 25.00, fields4, dem, outDir2, logName, TSave="intermediate"
-    )
+    com1DFA.exportFields(cfg, 10.00, fields2, dem, outDir2, logName, TSave="intermediate")
+    com1DFA.exportFields(cfg, 15.00, fields3, dem, outDir2, logName, TSave="intermediate")
+    com1DFA.exportFields(cfg, 25.00, fields4, dem, outDir2, logName, TSave="intermediate")
     com1DFA.exportFields(cfg, 40.00, fields5, dem, outDir2, logName, TSave="final")
 
     # read fields
@@ -2505,9 +2422,9 @@ def test_prepareVarSimDict(tmp_path, caplog):
     testCfg["INPUT"]["DEM"] = "DEM_PF_Topo.asc"
     testCfg["INPUT"]["relThFile"] = ""
     testCfg["INPUT"]["timeDepRelCsv"] = str(pathlib.Path(avaDir, "Inputs", "REL", "release1PF.csv"))
-    testCfg["INPUT"]["timeDepRelTimeStep"] = str(np.array([0., 30., 60.]))
-    testCfg["INPUT"]["timeDepRelThickness"] = str(np.array([0.5, 1., 1.]))
-    testCfg["INPUT"]["timeDepRelVelocity"] = str(np.array([5., 3., 0.]))
+    testCfg["INPUT"]["timeDepRelTimeStep"] = str(np.array([0.0, 30.0, 60.0]))
+    testCfg["INPUT"]["timeDepRelThickness"] = str(np.array([0.5, 1.0, 1.0]))
+    testCfg["INPUT"]["timeDepRelVelocity"] = str(np.array([5.0, 3.0, 0.0]))
     testCfg["GENERAL"]["avalancheDir"] = str(avaDir)
 
     simHash = cfgUtils.cfgHash(testCfg)
@@ -2530,8 +2447,6 @@ def test_prepareVarSimDict(tmp_path, caplog):
     for section in testCfg.sections():
         for key in testCfg[section]:
             assert simDict[simName1]["cfgSim"][section][key] == testCfg[section][key]
-
-
 
 
 def test_initializeSimulation(tmp_path):
@@ -2848,9 +2763,7 @@ def test_runCom1DFA(tmp_path, caplog):
         "reportOneFile": "True",
         "debugPlot": "False",
     }
-    modCfg, modInfo = cfgUtils.getModuleConfig(
-        com1DFA, fileOverride=cfgFile, modInfo=True
-    )
+    modCfg, modInfo = cfgUtils.getModuleConfig(com1DFA, fileOverride=cfgFile, modInfo=True)
 
     dem, plotDict, reportDictList, simDF = com1DFA.com1DFAMain(cfgMain, cfgInfo=modCfg)
 
@@ -2941,26 +2854,16 @@ def test_runCom1DFA(tmp_path, caplog):
     #    print(simDF["simName"])
     outDir = avaDir / "Outputs" / "com1DFA"
     for ext in ["ppr", "pft", "pfv"]:
-        assert (
-            outDir / "peakFiles" / ("%s_%s.asc" % (simDF["simName"].iloc[0], ext))
-        ).is_file()
-        assert (
-            outDir / "peakFiles" / ("%s_%s.asc" % (simDF["simName"].iloc[1], ext))
-        ).is_file()
+        assert (outDir / "peakFiles" / ("%s_%s.asc" % (simDF["simName"].iloc[0], ext))).is_file()
+        assert (outDir / "peakFiles" / ("%s_%s.asc" % (simDF["simName"].iloc[1], ext))).is_file()
 
-    assert (
-        outDir / "configurationFiles" / ("%s.ini" % (simDF["simName"].iloc[0]))
-    ).is_file()
-    assert (
-        outDir / "configurationFiles" / ("%s.ini" % (simDF["simName"].iloc[1]))
-    ).is_file()
+    assert (outDir / "configurationFiles" / ("%s.ini" % (simDF["simName"].iloc[0]))).is_file()
+    assert (outDir / "configurationFiles" / ("%s.ini" % (simDF["simName"].iloc[1]))).is_file()
     assert (outDir / "configurationFiles" / ("allConfigurations.csv")).is_file()
 
     initProj.cleanModuleFiles(avaDir, com1DFA, deleteOutput=False)
     with caplog.at_level(logging.WARNING):
-        dem, plotDict, reportDictList, simDF = com1DFA.com1DFAMain(
-            cfgMain, cfgInfo=cfgFile
-        )
+        dem, plotDict, reportDictList, simDF = com1DFA.com1DFAMain(cfgMain, cfgInfo=cfgFile)
     assert "There is no simulation to be performed" in caplog.text
 
 
@@ -2977,9 +2880,7 @@ def test_runOrLoadCom1DFA(tmp_path, caplog):
     testDir = pathlib.Path(__file__).parents[0]
     avalancheDir = testDir / ".." / ".." / "benchmarks" / "avaHockeyChannelPytest"
     cfgMain = configparser.ConfigParser()
-    dem, simDF, resTypeList = com1DFA.runOrLoadCom1DFA(
-        avalancheDir, cfgMain, runDFAModule=False, cfgFile=""
-    )
+    dem, simDF, resTypeList = com1DFA.runOrLoadCom1DFA(avalancheDir, cfgMain, runDFAModule=False, cfgFile="")
     #    print(simDF.index)
     #    print(simDF.columns)
     assert "pft" in resTypeList
@@ -3018,9 +2919,7 @@ def test_fetchRelVolume(tmp_path):
     dem["rasterData"] = np.ones((10, 20))
     demPath = pathlib.Path(avaDir, "Inputs", "testDem.asc")
     fU.makeADir(pathlib.Path(avaDir, "Inputs"))
-    IOf.writeResultToRaster(
-        dem["header"], dem["rasterData"], demPath.parent / demPath.stem, flip=False
-    )
+    IOf.writeResultToRaster(dem["header"], dem["rasterData"], demPath.parent / demPath.stem, flip=False)
 
     # subprocess.run(["cat", demPath])
     # write relThField
@@ -3153,9 +3052,7 @@ def test_adaptDEM():
     dem = geoTrans.getNormalMesh(dem, num=cfg["GENERAL"].getfloat("methodMeshNormal"))
     dem = DFAtls.getAreaMesh(dem, cfg["GENERAL"].getfloat("methodMeshNormal"))
 
-    _, _, NzNormed = DFAtls.normalize(
-        dem["Nx"].copy(), dem["Ny"].copy(), dem["Nz"].copy()
-    )
+    _, _, NzNormed = DFAtls.normalize(dem["Nx"].copy(), dem["Ny"].copy(), dem["Nz"].copy())
 
     demInput = dem.copy()
     fieldsInput = fields.copy()
@@ -3296,15 +3193,11 @@ def test_tSteps_output_behavior(tmp_path, caplog):
     cfg["GENERAL"]["tSteps"] = ""
     cfg["GENERAL"]["tEnd"] = "10"  # Short simulation
     cfg["GENERAL"]["dt"] = "0.1"  # Single value, no variations
-    cfg["GENERAL"]["simTypeList"] = (
-        "null"  # Simple simulation, no entrainment/resistance
-    )
+    cfg["GENERAL"]["simTypeList"] = "null"  # Simple simulation, no entrainment/resistance
     with open(cfgFile1, "w") as f:
         cfg.write(f)
 
-    dem, plotDict, reportDictList, simDF = com1DFA.com1DFAMain(
-        cfgMain, cfgInfo=cfgFile1
-    )
+    dem, plotDict, reportDictList, simDF = com1DFA.com1DFAMain(cfgMain, cfgInfo=cfgFile1)
 
     # Check that only final timestep files exist in timeSteps directory
     timeStepsDir1 = avaDir1 / "Outputs" / "com1DFA" / "peakFiles" / "timeSteps"
@@ -3313,9 +3206,7 @@ def test_tSteps_output_behavior(tmp_path, caplog):
         # Should only have final timestep files (one per result type: ppr, pft, pfv)
         # Not initial timestep at t=0
         for tFile in tStepFiles1:
-            assert "_t0.0" not in tFile.stem, (
-                f"Found initial timestep file {tFile} but tSteps was empty"
-            )
+            assert "_t0.0" not in tFile.stem, f"Found initial timestep file {tFile} but tSteps was empty"
 
     # Test 2: Explicit tSteps with t=0 should export t=0 timestep
     avaDir2 = pathlib.Path(tmp_path, "testExplicitTSteps")
@@ -3329,23 +3220,17 @@ def test_tSteps_output_behavior(tmp_path, caplog):
     cfg2["GENERAL"]["tSteps"] = "0|5"
     cfg2["GENERAL"]["tEnd"] = "10"  # Short simulation
     cfg2["GENERAL"]["dt"] = "0.1"  # Single value, no variations
-    cfg2["GENERAL"]["simTypeList"] = (
-        "null"  # Simple simulation, no entrainment/resistance
-    )
+    cfg2["GENERAL"]["simTypeList"] = "null"  # Simple simulation, no entrainment/resistance
     with open(cfgFile2, "w") as f:
         cfg2.write(f)
 
-    dem2, plotDict2, reportDictList2, simDF2 = com1DFA.com1DFAMain(
-        cfgMain, cfgInfo=cfgFile2
-    )
+    dem2, plotDict2, reportDictList2, simDF2 = com1DFA.com1DFAMain(cfgMain, cfgInfo=cfgFile2)
 
     # Check that t=0 timestep files exist
     timeStepsDir2 = avaDir2 / "Outputs" / "com1DFA" / "peakFiles" / "timeSteps"
     assert timeStepsDir2.exists(), "timeSteps directory should exist"
     tStepFiles2 = list(timeStepsDir2.glob("*_t0.0*.asc"))
-    assert len(tStepFiles2) > 0, (
-        "Should have initial timestep files at t=0 when tSteps includes 0"
-    )
+    assert len(tStepFiles2) > 0, "Should have initial timestep files at t=0 when tSteps includes 0"
 
     # Test 3: exportData = False should trigger contour fetching in else block
     avaDir3 = pathlib.Path(tmp_path, "testExportDataFalse")
@@ -3364,22 +3249,16 @@ def test_tSteps_output_behavior(tmp_path, caplog):
     with open(cfgFile3, "w") as f:
         cfg3.write(f)
 
-    dem3, plotDict3, reportDictList3, simDF3 = com1DFA.com1DFAMain(
-        cfgMain, cfgInfo=cfgFile3
-    )
+    dem3, plotDict3, reportDictList3, simDF3 = com1DFA.com1DFAMain(cfgMain, cfgInfo=cfgFile3)
 
     # Check that contour data was generated (stored in reportDict) instead of exported files
-    assert len(reportDictList3) > 0, (
-        "Should have report dict even with exportData=False"
-    )
+    assert len(reportDictList3) > 0, "Should have report dict even with exportData=False"
     # Verify that timeSteps directory doesn't exist (no data exported)
     timeStepsDir3 = avaDir3 / "Outputs" / "com1DFA" / "peakFiles" / "timeSteps"
     if timeStepsDir3.exists():
         tStepFiles3 = list(timeStepsDir3.glob("*.asc"))
         # With exportData=False, intermediate timesteps should not be exported
-        assert len(tStepFiles3) == 0, (
-            "No timestep files should be exported when exportData=False"
-        )
+        assert len(tStepFiles3) == 0, "No timestep files should be exported when exportData=False"
 
 
 def test_getModuleNames():
@@ -3389,85 +3268,52 @@ def test_getModuleNames():
     # Test 1: Direct call from com1DFA module
     with patch("inspect.stack") as mock_stack:
         mock_stack.return_value = [
-            MagicMock(
-                frame=MagicMock(f_globals={"__name__": "avaframe.com1DFA.com1DFA"})
-            ),
+            MagicMock(frame=MagicMock(f_globals={"__name__": "avaframe.com1DFA.com1DFA"})),
             MagicMock(frame=MagicMock(f_globals={"__name__": "avaframe.com1DFA"})),
         ]
         result = com1DFA.getModuleNames(com1DFA)
-        assert result == ("com1DFA", "com1"), (
-            f"Expected ('com1DFA', 'com1'), got {result}"
-        )
+        assert result == ("com1DFA", "com1"), f"Expected ('com1DFA', 'com1'), got {result}"
 
     # Test 2: Call from wrapper module com5SnowSlide
     with patch("inspect.stack") as mock_stack:
         mock_stack.return_value = [
-            MagicMock(
-                frame=MagicMock(
-                    f_globals={"__name__": "avaframe.com5SnowSlide.com5SnowSlide"}
-                )
-            ),
-            MagicMock(
-                frame=MagicMock(f_globals={"__name__": "avaframe.com1DFA.com1DFA"})
-            ),
+            MagicMock(frame=MagicMock(f_globals={"__name__": "avaframe.com5SnowSlide.com5SnowSlide"})),
+            MagicMock(frame=MagicMock(f_globals={"__name__": "avaframe.com1DFA.com1DFA"})),
         ]
         result = com1DFA.getModuleNames(com1DFA)
-        assert result == ("com5SnowSlide", "com5"), (
-            f"Expected ('com5SnowSlide', 'com5'), got {result}"
-        )
+        assert result == ("com5SnowSlide", "com5"), f"Expected ('com5SnowSlide', 'com5'), got {result}"
 
     # Test 3: Call from wrapper module com6RockAvalanche
     with patch("inspect.stack") as mock_stack:
         mock_stack.return_value = [
             MagicMock(
-                frame=MagicMock(
-                    f_globals={
-                        "__name__": "avaframe.com6RockAvalanche.com6RockAvalanche"
-                    }
-                )
+                frame=MagicMock(f_globals={"__name__": "avaframe.com6RockAvalanche.com6RockAvalanche"})
             ),
-            MagicMock(
-                frame=MagicMock(f_globals={"__name__": "avaframe.com1DFA.com1DFA"})
-            ),
+            MagicMock(frame=MagicMock(f_globals={"__name__": "avaframe.com1DFA.com1DFA"})),
         ]
         result = com1DFA.getModuleNames(com1DFA)
-        assert result == ("com6RockAvalanche", "com6"), (
-            f"Expected ('com6RockAvalanche', 'com6'), got {result}"
-        )
+        assert result == (
+            "com6RockAvalanche",
+            "com6",
+        ), f"Expected ('com6RockAvalanche', 'com6'), got {result}"
 
     # Test 4: Call from wrapper module com8MoTPSA
     with patch("inspect.stack") as mock_stack:
         mock_stack.return_value = [
-            MagicMock(
-                frame=MagicMock(
-                    f_globals={"__name__": "avaframe.com8MoTPSA.com8MoTPSA"}
-                )
-            ),
-            MagicMock(
-                frame=MagicMock(f_globals={"__name__": "avaframe.com1DFA.com1DFA"})
-            ),
+            MagicMock(frame=MagicMock(f_globals={"__name__": "avaframe.com8MoTPSA.com8MoTPSA"})),
+            MagicMock(frame=MagicMock(f_globals={"__name__": "avaframe.com1DFA.com1DFA"})),
         ]
         result = com1DFA.getModuleNames(com1DFA)
-        assert result == ("com8MoTPSA", "com8"), (
-            f"Expected ('com8MoTPSA', 'com8'), got {result}"
-        )
+        assert result == ("com8MoTPSA", "com8"), f"Expected ('com8MoTPSA', 'com8'), got {result}"
 
     # Test 5: Call from wrapper module com9MoTVoellmy
     with patch("inspect.stack") as mock_stack:
         mock_stack.return_value = [
-            MagicMock(
-                frame=MagicMock(
-                    f_globals={"__name__": "avaframe.com9MoTVoellmy.com9MoTVoellmy"}
-                )
-            ),
-            MagicMock(
-                frame=MagicMock(f_globals={"__name__": "avaframe.com1DFA.com1DFA"})
-            ),
+            MagicMock(frame=MagicMock(f_globals={"__name__": "avaframe.com9MoTVoellmy.com9MoTVoellmy"})),
+            MagicMock(frame=MagicMock(f_globals={"__name__": "avaframe.com1DFA.com1DFA"})),
         ]
         result = com1DFA.getModuleNames(com1DFA)
-        assert result == ("com9MoTVoellmy", "com9"), (
-            f"Expected ('com9MoTVoellmy', 'com9'), got {result}"
-        )
+        assert result == ("com9MoTVoellmy", "com9"), f"Expected ('com9MoTVoellmy', 'com9'), got {result}"
 
     # Test 6: Non-com module (fallback to passed module)
     with patch("inspect.stack") as mock_stack:
@@ -3479,26 +3325,21 @@ def test_getModuleNames():
         mock_module = MagicMock()
         mock_module.__name__ = "avaframe.someModule"
         result = com1DFA.getModuleNames(mock_module)
-        assert result == ("someModule", "someModule"), (
-            f"Expected ('someModule', 'someModule'), got {result}"
-        )
+        assert result == ("someModule", "someModule"), f"Expected ('someModule', 'someModule'), got {result}"
 
     # Test 7: Module without "com" prefix in name (fallback)
     with patch("inspect.stack") as mock_stack:
         mock_stack.return_value = [
-            MagicMock(
-                frame=MagicMock(
-                    f_globals={"__name__": "avaframe.otherModule.otherModule"}
-                )
-            ),
+            MagicMock(frame=MagicMock(f_globals={"__name__": "avaframe.otherModule.otherModule"})),
         ]
         # Create a mock module object
         mock_module = MagicMock()
         mock_module.__name__ = "avaframe.otherModule"
         result = com1DFA.getModuleNames(mock_module)
-        assert result == ("otherModule", "otherModule"), (
-            f"Expected ('otherModule', 'otherModule'), got {result}"
-        )
+        assert result == (
+            "otherModule",
+            "otherModule",
+        ), f"Expected ('otherModule', 'otherModule'), got {result}"
 
     # Test 8: Deep call stack with multiple com modules (should pick first non-com1DFA.com1DFA)
     with patch("inspect.stack") as mock_stack:
@@ -3507,23 +3348,15 @@ def test_getModuleNames():
                 frame=MagicMock(f_globals={"__name__": "avaframe.com1DFA.com1DFA"})
             ),  # Should be skipped
             MagicMock(
-                frame=MagicMock(
-                    f_globals={"__name__": "avaframe.com5SnowSlide.com5SnowSlide"}
-                )
+                frame=MagicMock(f_globals={"__name__": "avaframe.com5SnowSlide.com5SnowSlide"})
             ),  # Should be picked
             MagicMock(
-                frame=MagicMock(
-                    f_globals={
-                        "__name__": "avaframe.com6RockAvalanche.com6RockAvalanche"
-                    }
-                )
+                frame=MagicMock(f_globals={"__name__": "avaframe.com6RockAvalanche.com6RockAvalanche"})
             ),  # Should be ignored
             MagicMock(frame=MagicMock(f_globals={"__name__": "avaframe.com1DFA"})),
         ]
         result = com1DFA.getModuleNames(com1DFA)
-        assert result == ("com5SnowSlide", "com5"), (
-            f"Expected ('com5SnowSlide', 'com5'), got {result}"
-        )
+        assert result == ("com5SnowSlide", "com5"), f"Expected ('com5SnowSlide', 'com5'), got {result}"
 
 
 def test_com1DFAMainWithPathCfgInfo(tmp_path, caplog):

--- a/avaframe/tests/test_generateReport.py
+++ b/avaframe/tests/test_generateReport.py
@@ -79,7 +79,7 @@ def test_writeReport(tmp_path):
 
     # Test
     assert lineVals[0] == '# This is my report title \n'
-    assert lineVals[2] == '### Avalanche directory: *data/avaTest* \n'
+    assert lineVals[2] == '### Simulation directory: *data/avaTest* \n'
     assert lineVals[4] == '### Date: 1/01/2021 12:46:56 \n'
     assert lineVals[11] == '| ---------- | ------ | \n'
     assert lineVals[12] == '| release area | release1HS2 | \n'
@@ -107,7 +107,7 @@ def test_writeReport(tmp_path):
 #        print('lineVals2', lineVals2)
 
         assert lineVals2[0] == '# This is my report title \n'
-        assert lineVals2[2] == '### Avalanche directory: *data/avaTest* \n'
+        assert lineVals2[2] == '### Simulation directory: *data/avaTest* \n'
         assert lineVals2[4] == '### Date: 1/01/2021 12:46:56 \n'
         assert lineVals2[11] == '| ---------- | ------ | \n'
         assert lineVals2[12] == '| release area | release1HS2 | \n'


### PR DESCRIPTION
- closes https://github.com/OpenNHM/DebrisFrame/issues/39
- closes https://github.com/OpenNHM/DebrisFrame/issues/47

When time dependent release is switched on the report looks like:
 
<img width="1278" height="1272" alt="Screenshot from 2026-02-16 18-22-53" src="https://github.com/user-attachments/assets/9f26f808-3e71-4f85-a70e-d5c95383cce1" />
 (added detrained mass, initialized mass, release thickness summed over time steps, and release volume summed over timesteps)