### PR TITLE
[out3Plot]: Add option for increased contrast in hillshades

### DIFF
--- a/avaframe/out3Plot/plotUtils.py
+++ b/avaframe/out3Plot/plotUtils.py
@@ -104,6 +104,8 @@ azimuthDegree = cfg.getfloat("azimuthDegree")
 elevationDegree = cfg.getfloat("elevationDegree")
 vertExag = cfg.getfloat("vertExag")
 hillshadeContLevs = cfg.getint("hillshadeContLevs")
+hsContrastDiff = cfg.getfloat("hsContrastDiff")
+hsContrastMult = cfg.getfloat("hsContrastMult")
 
 # define settings for colormaps creation
 discreteLevels = cfg.getint("discreteLevels")
@@ -882,8 +884,14 @@ def addHillShadeContours(
         else:
             extentPlot = extent
 
+        hs = ls.hillshade(data, vert_exag=vertExag, dx=data.shape[1], dy=data.shape[0])
+        # normalize hillshade and increase the contrast
+        if np.nanmin(hs) != np.nanmax(hs):
+            hs = (hs - np.nanmin(hs)) / (np.nanmax(hs) - np.nanmin(hs))
+            hs = np.clip((hs - hsContrastDiff) * hsContrastMult, 0, 1)
+
         im1 = ax.imshow(
-            ls.hillshade(data, vert_exag=vertExag, dx=data.shape[1], dy=data.shape[0]),
+            hs,
             cmap="gray",
             extent=extentPlot,
             origin="lower",

--- a/avaframe/out3Plot/plotUtilsCfg.ini
+++ b/avaframe/out3Plot/plotUtilsCfg.ini
@@ -56,6 +56,10 @@ azimuthDegree = 315
 elevationDegree = 15
 vertExag = 10
 hillshadeContLevs = 15
+# to switch off increased contrast: hsContrastDiff = 0, hsContrastMult = 1
+# to switch on increased contrast, suggested values are: hsContrastDiff = 0.25, hsContrastMult = 2.2
+hsContrastDiff = 0
+hsContrastMult = 1
 
 
 [CONSTANTS]


### PR DESCRIPTION
Add option for increased contrast for hillshade plots.
Default setting: no increased contrast, so the differences in the plots are small:

before (avaKot example):
<img width="729" height="876" alt="VORHER_relKot_3eb91ab506_com1_C_L_null_dfa_pfv" src="https://github.com/user-attachments/assets/38cb46f3-85fa-4d8f-a8af-513dbd3039b7" />

with changes, default setup (no increased contrast):
<img width="729" height="876" alt="relKot_f69eb91152_com1_C_L_null_dfa_pfv" src="https://github.com/user-attachments/assets/e3ae08fb-aae0-4142-a3fc-985268804742" />

with changes, suggested setup ( increased contrast):
<img width="729" height="876" alt="relKot_0f77fc4aca_com1_C_L_null_dfa_pfv" src="https://github.com/user-attachments/assets/8d1dba2a-b87c-4785-a717-ecfffdc14a2e" />


