### PR TITLE
[doc]: standardize docs to pixi run commands

### DIFF
--- a/docs/develop.rst
+++ b/docs/develop.rst
@@ -237,7 +237,7 @@ as a next step, you need to add the benchmark results:
 
 Now, you are ready to go! Move to ``AvaFrame/avaframe`` and run: ::
 
-  python runStandardTestsCom1DFA.py
+  pixi run python runStandardTestsCom1DFA.py
 
 You can check out the markdown-style report of the comparison at:
 ``tests/reports/standardTestsReportPy.md``.

--- a/docs/developinstall.rst
+++ b/docs/developinstall.rst
@@ -14,6 +14,13 @@ Install `git <https://github.com/git-guides/install-git>`_ and `pixi <https://pi
 Some operating systems might require the python headers (e.g python-dev on ubuntu) or other supporting
 libraries/packages (e.g. Visual Studio on Windows needs the c++ compiler components).
 
+.. Note::
+   This documentation uses pixi environments. You can either prefix commands with ``pixi run <command>``,
+   which runs the command in the pixi environment without requiring you to activate it first, or you
+   can run ``pixi shell`` once to start an interactive environment and then run the commands without
+   the ``pixi run`` prefix (e.g. ``pixi run python script.py`` is equivalent to ``pixi shell`` then
+   ``python script.py``).
+
 
 Setup AvaFrame
 ^^^^^^^^^^^^^^
@@ -25,28 +32,28 @@ Clone the AvaFrame repository (in a directory of your choice: [YOURDIR]) and cha
   cd AvaFrame
 
 
-Run pixi::
-
-  pixi shell
-
 Compile the cython com1DFA part. You might also have to install a c-compiler (gcc or similar) through your systems
 package manager::
 
-  python setup.py build_ext --inplace
+  pixi run build
 
 .. Warning::
    You will have to do this compilation every time something changes in the cython code. We also suggest
-   to do this everytime updates from the repositories are pulled.
+   to do this everytime updates from the repositories are pulled. Use ``pixi run rebuild`` to clean
+   and rebuild in one step.
 
 All this installs avaframe in editable mode, so every time you import avaframe the
 current (local) version will be used.
 
-If you want to have the lastet stable release instead, run::
+Test it by running::
 
-  pixi shell --environment prod
+  pixi run python -c "import avaframe"
 
-Test it by starting ``python`` and do an ``import avaframe``. If no error comes
-up, you are good to go.
+If you want to use the lastet stable release instead, run::
+
+  pixi run --environment prod python -c "import avaframe"
+
+If no error comes up, you are good to go.
 
 To see the current version, you can use::
 

--- a/docs/developinstallwin.rst
+++ b/docs/developinstallwin.rst
@@ -15,6 +15,13 @@ Install `git <https://github.com/git-guides/install-git>`_ and `pixi <https://pi
 Install `Microsoft C++ compiler <https://wiki.python.org/moin/WindowsCompilers>`_.
 Follow the installation steps for the version corresponding to the installed python version.
 
+.. Note::
+   This documentation uses pixi environments. You can either prefix commands with ``pixi run <command>``,
+   which runs the command in the pixi environment without requiring you to activate it first, or you
+   can run ``pixi shell`` once to start an interactive environment and then run the commands without
+   the ``pixi run`` prefix (e.g. ``pixi run python script.py`` is equivalent to ``pixi shell`` then
+   ``python script.py``).
+
 Setup AvaFrame
 ^^^^^^^^^^^^^^
 
@@ -24,12 +31,6 @@ Clone the AvaFrame repository (in a directory of your choice: [YOURDIR]) and cha
   git clone https://github.com/OpenNHM/AvaFrame.git
   cd AvaFrame
 
-
-
-Run pixi::
-
-  pixi shell
-
 .. Note::
     If you get some access denied error in Powershell, you might need to run the command
 
@@ -37,39 +38,36 @@ Run pixi::
 
 Compile the cython com1DFA part::
 
-   python setup.py build_ext --inplace
+   pixi run build
 
 .. Warning::
    You will have to do this compilation every time something changes in the cython code. We also suggest
-   to do this everytime updates from the repositories are pulled.
+   to do this everytime updates from the repositories are pulled. Use ``pixi run rebuild`` to clean
+   and rebuild in one step.
 
-   **Before** compilation in Windows, make sure to delete ``AvaFrame/build`` directory, in addition to any .pyc, .c, and
-   .pycache files in ``AvaFrame/avaframe/com1DFA``
+   **Before** compilation in Windows, make sure to delete the ``AvaFrame/build`` directory.
 
 This installs avaframe in editable mode, so every time you import avaframe the
 current (local) version will be used.
 
-If you want to have the lastet stable release instead, run::
+Test it by running::
 
-  pixi shell --environment prod
+  pixi run python -c "import avaframe"
 
+If you want to use the lastet stable release instead, run::
 
-Test it by starting ``python`` and do an ``import avaframe``. If no error comes
-up, you are good to go.
+  pixi run --environment prod python -c "import avaframe"
+
+If no error comes up, you are good to go.
 
 Head over to :ref:`gettingstarted:First run` for the next steps.
 
-Using QGIS from with an advanced installation
-^^^^^^^^^^^^^^
+Using QGIS from within an script installation
+---------------------------------------------
 
-Assuming you followed the steps above, you should get a working QGis installation by running (it will take a while)::
+To run QGIS (this will install the environment on first use)::
 
-  pixi shell --environment qgis
-
-
-An to run QGIS::
-
-  qgis
+  pixi run --environment qgis qgis
 
 Depending on your mode of QGis installation (direct installer, conda, OSGeo4W...) your script AvaFrame installation
 might be overruled...

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -11,8 +11,8 @@
 First run
 ---------
 
-Follow these steps to run your first simulation (assuming you finished the advanced installation steps; if you come
-back later, make sure to run ``pixi shell`` again to activate the environment):
+Follow these steps to run your first simulation (assuming you finished the complex usage installation steps). The commands
+below use ``pixi run``, so you do not need to activate the environment via ``pixi shell`` first:
 
 * change into your ``AvaFrame`` directory (replace [YOURDIR]
   with your path from the installation steps)::
@@ -22,7 +22,7 @@ back later, make sure to run ``pixi shell`` again to activate the environment):
 * run:
   ::
 
-    python runCom1DFA.py
+    pixi run python runCom1DFA.py
 
 * a similar output should show up:
   ::
@@ -76,7 +76,7 @@ variable ``avalancheDir``.
 
 Then run ::
 
-  python runScripts/runInitializeProject.py
+  pixi run python runScripts/runInitializeProject.py
 
 This will create a new directory with the input required by AvaFrame structured as described
 in :ref:`moduleIn3Utils:Initialize Project`.

--- a/docs/moduleAna1Tests.rst
+++ b/docs/moduleAna1Tests.rst
@@ -127,8 +127,8 @@ analytical solution. In order to run the test example:
 
 * in ``AvaFrame/avaframe`` run::
 
-    python3 runScripts/runDamBreak.py
-    python3 runScripts/runAnalyzeDamBreak.py
+    pixi run python runScripts/runDamBreak.py
+    pixi run python runScripts/runAnalyzeDamBreak.py
 
 
 

--- a/docs/moduleAna3AIMEC.rst
+++ b/docs/moduleAna3AIMEC.rst
@@ -96,7 +96,7 @@ To run
 *  enter path to the desired ``NameOfAvalanche/`` folder in your local copy of ``avaframeCfg.ini``
 *  run::
 
-      python3 runScripts/runAna3AIMEC.py
+      pixi run python runScripts/runAna3AIMEC.py
 
 .. Note:: 
    In the default configuration, the analysis is performed on the simulation result files located in ``NameOfAvalanche/Outputs/anaMod/peakFiles``, where anaMod is specified in the aimecCfg.ini. There is also the option to directly provide a path to an input directory to the :py:func:`ana3AIMEC.ana3AIMEC.fullAimecAnalysis`. However, the peak field file names need to have a specific format: *A_B_C_D_E.*, where:

--- a/docs/moduleAna4Stats.rst
+++ b/docs/moduleAna4Stats.rst
@@ -61,7 +61,7 @@ In order to run this example:
 * copy ``ana4Stats/probAnaCfg.ini`` to ``ana4Stats/local_probAnaCfg.ini`` and optionally adjust variation settings
 * run::
 
-      python3 runAna4ProbAna.py
+      pixi run python runAna4ProbAna.py
 
 
 It is also possible to generate the probability maps for already existing simulations. The settings for the probability map
@@ -87,11 +87,11 @@ In order to run:
 * copy ``ana4Stats/probAnaCfg.ini`` to ``ana4Stats/local_probAnaCfg.ini`` and optionally adjust GENERAL and PLOT settings
 * for simulations generated with **com1DFA** run::
 
-      python3 runProbAnalysisOnly.py
+      pixi run python runProbAnalysisOnly.py
 
 * all other models run::
 
-     python3 runProbAnalysisOnly.py *pathToAvalancheDirectory* *comMod*
+     pixi run python runProbAnalysisOnly.py *pathToAvalancheDirectory* *comMod*
 
 Another example on how to generate probability maps for avalanche simulations performed with :py:mod:`com1DFA`
 is given in :py:mod:`runScripts.runProbAna`, where for *avaHockeyChannel* simulations are performed with
@@ -107,7 +107,7 @@ In order to run this example:
 * uncomment ``'FILTER'`` section in ``local_probAnaCfg.ini`` and insert filter parameters if you want to first filter simulations
 * run::
 
-      python3 runScripts/runProbAna.py
+      pixi run python runScripts/runProbAna.py
 
 
 .. figure:: _static/avaHockeyChannel_probMap_lim1.0.png
@@ -150,7 +150,7 @@ additionally an :ref:`moduleAna3AIMEC:ana3AIMEC: Aimec` analysis is performed.
 * uncomment ``'FILTER'`` section in ``ana4Stats/local_getStatsCfg.ini`` and insert filter parameters if you want to first filter simulations
 * run::
 
-      python3 runScripts/runStatsExample.py
+      pixi run python runScripts/runStatsExample.py
 
 
 .. figure:: _static/Scatter_pft_vs_pfv_dist_test.png

--- a/docs/moduleAna5Utils.rst
+++ b/docs/moduleAna5Utils.rst
@@ -62,7 +62,7 @@ To run
     and edit (if not, default values are used)
 3.  run::
 
-        python runAna5DFAPathGeneration.py
+        pixi run python runAna5DFAPathGeneration.py
 
 
 Theory

--- a/docs/moduleCom1DFA.rst
+++ b/docs/moduleCom1DFA.rst
@@ -370,7 +370,7 @@ To run
 * run:
   ::
 
-    python3 runCom1DFA.py
+    pixi run python runCom1DFA.py
 
 
 Theory

--- a/docs/moduleCom1DFAOrig.rst
+++ b/docs/moduleCom1DFAOrig.rst
@@ -120,7 +120,7 @@ To run
 * run:
   ::
 
-    python3 com1DFAOrig/runCom1DFA.py
+    pixi run python com1DFAOrig/runCom1DFA.py
 
 
 Theory

--- a/docs/moduleCom2AB.rst
+++ b/docs/moduleCom2AB.rst
@@ -40,7 +40,7 @@ To run
 * enter the path to the desired dataset in ``local_avaframeCfg.ini``
 * run::
 
-      python3 runCom2AB.py
+      pixi run python runCom2AB.py
 
 
 Theory

--- a/docs/moduleCom3Hybrid.rst
+++ b/docs/moduleCom3Hybrid.rst
@@ -44,7 +44,7 @@ To run
 * enter the path to the desired dataset in ``local_avaframeCfg.ini``
 * run::
 
-      python3 runScripts/runCom3Hybrid.py
+      pixi run python runScripts/runCom3Hybrid.py
 
 
 Procedure

--- a/docs/moduleCom4FlowPy.rst
+++ b/docs/moduleCom4FlowPy.rst
@@ -34,10 +34,9 @@ Running the code
 ----------------
 
 Generate an environment as described in :ref:`developinstall:Script Installation (Linux)` or
-:ref:`developinstallwin:Script Installation (Windows)`. Once you have a working ``pixi shell``, you can run the
-model via::
+:ref:`developinstallwin:Script Installation (Windows)`. Run the model via::
 
-    python runCom4FlowPy.py
+    pixi run python runCom4FlowPy.py
      
 
 Configuration

--- a/docs/moduleCom5SnowSlide.rst
+++ b/docs/moduleCom5SnowSlide.rst
@@ -99,4 +99,4 @@ To run
 * run:
   ::
 
-    python3 runCom5SnowSlide.py
+    pixi run python runCom5SnowSlide.py

--- a/docs/moduleCom6RockAvalanche.rst
+++ b/docs/moduleCom6RockAvalanche.rst
@@ -27,7 +27,7 @@ To run
 * run:
   ::
 
-    python runCom6RockAvalanche.py
+    pixi run python runCom6RockAvalanche.py
 
 
 Scarp Calculation
@@ -90,4 +90,4 @@ configuration settings
 
 If all the data is provided successfully, start the script by running::
 
-    python runCom6Scarp.py
+    pixi run python runCom6Scarp.py

--- a/docs/moduleCom7Regional.rst
+++ b/docs/moduleCom7Regional.rst
@@ -196,7 +196,7 @@ To Run - Script based
 
 .. code-block:: bash
 
-    python runScripts/runSplitInputs.py
+    pixi run python runScripts/runSplitInputs.py
 
 ---------------
 
@@ -317,4 +317,4 @@ To Run
 
 .. code-block:: bash
 
-    python runCom7Regional.py
+    pixi run python runCom7Regional.py

--- a/docs/moduleCom8MoTPSA.rst
+++ b/docs/moduleCom8MoTPSA.rst
@@ -25,7 +25,7 @@ To run
 * enter the path to the desired dataset in ``local_avaframeCfg.ini``
 * run::
 
-      python3 runCom8MoTPSA.py
+      pixi run python runCom8MoTPSA.py
 
 
 Theory

--- a/docs/moduleCom9MoTVoellmy.rst
+++ b/docs/moduleCom9MoTVoellmy.rst
@@ -87,5 +87,5 @@ To run
 * enter the path to the desired dataset in ``local_avaframeCfg.ini``
 * run::
 
-      python3 runCom9MoTVoellmy.py
+      pixi run python runCom9MoTVoellmy.py
 

--- a/docs/moduleIn1Data.rst
+++ b/docs/moduleIn1Data.rst
@@ -49,4 +49,4 @@ distribution can be generated, is provided by :py:mod:`runScripts/runComputeDist
   ``avaframeCfg.ini``
 * run::
 
-      python3 runScripts/runComputeDist.py
+      pixi run python runScripts/runComputeDist.py

--- a/docs/moduleIn3Utils.rst
+++ b/docs/moduleIn3Utils.rst
@@ -52,7 +52,7 @@ To run generateTopo
   (if not, the default values are used)
 * run::
 
-	python3 runScripts/runGenerateTopo.py
+	pixi run python runScripts/runGenerateTopo.py
 
 
 Theory
@@ -146,7 +146,7 @@ Following these steps, you can generate an avalanche test case including a DEM a
   and ``in3Utils/local_getReleaseAreaCfg.ini`` and set desired parameter values (if not, the default values are used)
 * run::
 
-	python3 runGenProjTopoRelease.py
+	pixi run python runGenProjTopoRelease.py
 
 **Parameters:**
 
@@ -196,7 +196,7 @@ To run
 * copy ``avaframeCfg.ini`` to ``local_avaframeCfg.ini`` and set your desired avalanche directory name
 * run::
 	
-			python3 runInitializeProject.py
+			pixi run python runInitializeProject.py
 
 
 ..

--- a/docs/moduleOut3Plot.rst
+++ b/docs/moduleOut3Plot.rst
@@ -103,7 +103,7 @@ in :py:mod:`runScript/runQuickPlotSimple`
 * specifiy input directory, default is ``data/NameOfAvalanche/Work/simplePlot``
 * run::
 
-    python3 runScripts/runQuickPlotSimple.py
+    pixi run python runScripts/runQuickPlotSimple.py
 
 
 generateOnePlot
@@ -137,7 +137,7 @@ is provided in :py:mod:`runScript/runQuickPlotOne`
 *  copy ``out3Plot/outQuickPlotCfg.ini`` to ``out3Plot/local_outQuickPlotCfg.ini`` and optionally specify input directory
 *  run::
 
-    python3 runScripts/runQuickPlotOne.py
+    pixi run python runScripts/runQuickPlotOne.py
 
 
 in1DataPlots
@@ -240,7 +240,7 @@ To run
 * run:
   ::
 
-    python3 runScripts/runParticleAnalysis.py
+    pixi run python runScripts/runParticleAnalysis.py
 
 
 

--- a/docs/operational.rst
+++ b/docs/operational.rst
@@ -35,13 +35,13 @@ Setup AvaFrame
 
     .. code-block::
 
-      python3 -m pip install --user avaframe
+      python -m pip install --user avaframe
 
 #. To avoid a numpy error (see note at bottom of page), update numpy and pandas:
 
     .. code-block::
      
-      python3 -m pip install --user --upgrade numpy pandas
+      python -m pip install --user --upgrade numpy pandas
 
 
 Setup QGis and run
@@ -76,13 +76,13 @@ Update Avaframe to a new release
 
     .. code-block::
 
-      python3 -m pip install -U --user avaframe
+      python -m pip install -U --user avaframe
 
 #. To avoid a numpy error (see note at bottom of page), update numpy and pandas:
 
     .. code-block::
      
-      python3 -m pip install --user --upgrade numpy pandas
+      python -m pip install --user --upgrade numpy pandas
 
 
 #. Restart/Open QGis from your start menu and go to Plugins -> Manage and Install Plugins
@@ -99,6 +99,6 @@ Update Avaframe to a new release
    run the following in OSGeo4W shell (the *py3_env* command is not needed on newer versions of QGis, skip it)::
 
      py3_env
-     python3 -m pip install --user --upgrade numpy pandas
+     python -m pip install --user --upgrade numpy pandas
 
    and restart QGis.

--- a/docs/operationalGerman.rst
+++ b/docs/operationalGerman.rst
@@ -35,13 +35,13 @@ Setup AvaFrame
 
     .. code-block::
 
-      python3 -m pip install --user avaframe
+      python -m pip install --user avaframe
 
 #. Um einen potentiellen Fehler zu vermeiden (siehe Note unten), numpy und pandas mittels folgendem Befehl updaten:
 
     .. code-block::
      
-      python3 -m pip install --user --upgrade numpy pandas
+      python -m pip install --user --upgrade numpy pandas
 
 
 Setup QGis 
@@ -76,13 +76,13 @@ Update Avaframe
 
     .. code-block::
 
-      python3 -m pip install -U --user avaframe
+      python -m pip install -U --user avaframe
 
 #. Um einen potentiellen Fehler zu vermeiden (siehe Note unten), numpy und pandas mittels folgendem Befehl updaten:
 
     .. code-block::
      
-      python3 -m pip install --user --upgrade numpy pandas
+      python -m pip install --user --upgrade numpy pandas
 
 #. Starten Sie QGis neu/öffnen Sie es über Ihr Startmenü und gehen Sie zu Plugins -> Plugins verwalten und installieren
 
@@ -99,7 +99,7 @@ Update Avaframe
    nicht benötigt, überspringen Sie ihn)::
 
      py3_env
-     python3 -m pip install --user --upgrade numpy pandas
+     python -m pip install --user --upgrade numpy pandas
 
    und starten Sie QGis neu.
 


### PR DESCRIPTION
This PR updates the documentation to consistently use Pixi workflows for running AvaFrame commands.

Changes:
- Replace `python ...` run instructions with `pixi run python ...` across getting started, module pages, and developer docs.
- Replace manual Cython build command (`python setup.py build_ext --inplace`) with Pixi tasks (`pixi run build`, with `pixi run rebuild` suggested for clean rebuilds).
- Clarify `pixi run` vs `pixi shell`, and remove redundant `pixi install` steps since `pixi run` installs environments on first use.

Breaking changes: none (documentation-only).