### PR TITLE
docs(com1DFA): clarify time-stepping configuration in docs and config file

### DIFF
--- a/avaframe/com1DFA/com1DFACfg.ini
+++ b/avaframe/com1DFA/com1DFACfg.ini
@@ -158,9 +158,9 @@ timeStepDistance = 5
 dt = 0.1
 # End time [s]
 tEnd = 400
-# to use a variable time step (time step depends on kernel radius)
+# to use a time step that is consistent with the kernel radius (i.e. time step depends on kernel radius)
 sphKernelRadiusTimeStepping = False
-# Upper time step limit coefficient if option sphKernelRadiusTimeStepping is chosen.
+# if option sphKernelRadiusTimeStepping is True, cMax and the sphKernelRadius define the computational time step
 cMax = 0.02
 # stopCriterion (based on massFlowing or kinEnergy)
 stopCritType = kinEnergy

--- a/docs/com1DFAAlgorithm.rst
+++ b/docs/com1DFAAlgorithm.rst
@@ -200,8 +200,8 @@ The mass and momentum equations described in :ref:`theoryCom1DFA:Governing Equat
 in time using an operator splitting method. The different forces involved are sequentially added to update the velocity
 (see :ref:`DFAnumerics:Adding forces`).
 Position is then updated using a centered Euler scheme.
-The time step can either be fixed or dynamically computed using the Courant–Friedrichs–Lewy (CFL) condition
-(in the second case one must set ``cflTimeStepping`` to ``True`` and set the desired CFL coefficient).
+The time step can either be fixed or computed to be consistent with the SPH kernel size (see
+``sphKernelRadiusTimeStepping`` in the com1DFA configuration).
 
 Go back to :ref:`com1DFAAlgorithm:Algorithm graph`
 


### PR DESCRIPTION
- Updated comment in `com1DFACfg.ini` to clarify `sphKernelRadiusTimeStepping` behavior.
- Revised documentation in `com1DFAAlgorithm.rst` to explain time-stepping options, including kernel size consistency.
fixes #1285 