### PR TITLE
[log]: add collection and summary of comparison warnings

### DIFF
--- a/avaframe/log2Report/generateCompareReport.py
+++ b/avaframe/log2Report/generateCompareReport.py
@@ -204,3 +204,81 @@ def writeCompareReport(reportFile, reportD, benchD, avaName, cfgRep):
         pfile.write(' \n')
 
     log.info('Standard tests performed - Report saved to: %s ' % reportFile)
+
+
+def collectComparisonWarnings(reportD, benchD, cfgRep):
+    """ Collect the comparison warnings that writeCompareReport flags in red.
+
+        Returns a structured list of warnings (one dict per flagged item) instead
+        of writing markdown. Mirrors the flag logic of writeCompareReport so the
+        summary stays consistent with the rendered report.
+
+        Parameters
+        ----------
+        reportD : dict
+            report dictionary with simulation info
+        benchD : dict
+            dictionary with reference simulation info
+        cfgRep : dict
+            dictionary with configuration info (uses GENERAL.diffLim and
+            GENERAL.perDiff)
+
+        Returns
+        -------
+        warnings : list[dict]
+            each dict has 'category' and 'field'; see categories below
+    """
+
+    diffLim = cfgRep['GENERAL'].getfloat('diffLim')
+    perDiff = cfgRep['GENERAL'].getfloat('perDiff')
+    warnings = []
+
+    # Parameter mismatches: skip metadata keys that are expected to differ
+    paramIgnore = ['type', 'Program version']
+    simParams = reportD['Simulation Parameters']
+    benchParams = benchD['Simulation Parameters']
+    for key in simParams:
+        if key in paramIgnore:
+            continue
+        refVal = benchParams.get(key, 'non existent')
+        if simParams[key] == '' and benchParams.get(key) is None:
+            continue
+        if refVal != simParams[key]:
+            warnings.append(
+                {'category': 'parameter', 'field': key, 'ref': refVal, 'sim': simParams[key]})
+
+    # Aimec percentage differences
+    aimecIgnore = ['type']
+    simAimec = reportD['Aimec analysis']
+    benchAimec = benchD['Aimec analysis']
+    for key in simAimec:
+        if key in aimecIgnore:
+            continue
+        refVal = float(benchAimec[key])
+        simVal = float(simAimec[key])
+        if refVal == 0.0 and simVal == 0.0:
+            diffPercent = 0.0
+        elif refVal == 0.0 or simVal == 0.0:
+            diffPercent = 'undefined'
+        else:
+            diffPercent = (refVal - simVal) / refVal
+        if diffPercent != 'undefined' and abs(diffPercent) >= perDiff:
+            warnings.append(
+                {'category': 'aimec', 'field': key, 'ref': refVal, 'sim': simVal,
+                 'diffPercent': diffPercent})
+
+    # Plot absolute differences (ppr/pft/pfv)
+    simDiff = reportD['Simulation Difference']
+    simStats = reportD['Simulation Stats']
+    for var in ['ppr', 'pft', 'pfv']:
+        if var not in simDiff:
+            continue
+        maxDiff, meanDiff, minDiff = (float(v) for v in simDiff[var])
+        maxVal = float(simStats[var][0])
+        # largest absolute deviation exceeds the tolerance
+        if max(abs(maxDiff), abs(minDiff)) > diffLim * maxVal:
+            warnings.append(
+                {'category': 'plot', 'field': var,
+                 'maxDiff': maxDiff, 'meanDiff': meanDiff, 'minDiff': minDiff, 'maxVal': maxVal})
+
+    return warnings

--- a/avaframe/runStandardTestsCom1DFA.py
+++ b/avaframe/runStandardTestsCom1DFA.py
@@ -256,8 +256,8 @@ if __name__ == "__main__":
     # valuesList = ["resistance"]
     filterType = "TAGS"
     valuesList = ["standardTest", "standardTestSnowGlide"]
-    #filterType = "NAME"
-    #valuesList = ["avaFlatPlaneNullTest"]
+    # filterType = "NAME"
+    # valuesList = ["avaFlatPlaneNullTest"]
 
     testList = tU.filterBenchmarks(testDictList, filterType, valuesList, condition="or")
 
@@ -371,6 +371,30 @@ if __name__ == "__main__":
             log.info("  - %s: %s" % (failure["name"], failure["error"]))
     else:
         log.info("All tests completed successfully!")
+
+    # Display comparison warnings per test
+    log.info("=" * 80)
+    log.info("COMPARISON WARNINGS SUMMARY")
+    log.info("=" * 80)
+    for testName, reportD, benchDict, avaName, cfgRep in results:
+        warnings = generateCompareReport.collectComparisonWarnings(reportD, benchDict, cfgRep)
+        if not warnings:
+            log.info("%s: no differences flagged" % testName)
+            continue
+        log.info("%s:" % testName)
+        for w in warnings:
+            if w["category"] == "parameter":
+                log.info("  [parameter] %s: ref='%s' sim='%s'" % (w["field"], w["ref"], w["sim"]))
+            elif w["category"] == "aimec":
+                log.info(
+                    "  [aimec] %s: ref=%.1f sim=%.1f (%.1f%%)"
+                    % (w["field"], w["ref"], w["sim"], 100.0 * w["diffPercent"])
+                )
+            elif w["category"] == "plot":
+                log.info(
+                    "  [plot] %s: maxDiff=%.2f meanDiff=%.2f minDiff=%.2f (maxVal=%.2f)"
+                    % (w["field"], w["maxDiff"], w["meanDiff"], w["minDiff"], w["maxVal"])
+                )
 
     # Clean up temporary test directory
     tmpTestsDirObj.cleanup()

--- a/avaframe/tests/test_generateCompareReport.py
+++ b/avaframe/tests/test_generateCompareReport.py
@@ -149,3 +149,75 @@ def test_writeCompareReport(tmp_path):
     assert lineVals[34] == '![ppr](testplot.png) \n'
     assert lineVals[37] == '##### Figure:   Aimec comparison of mean and max values along path \n'
     assert lineVals[39] == '![Aimec comparison of mean and max values along path](testplot.png) \n'
+
+
+def test_collectComparisonWarnings_empty(tmp_path):
+    """ no warnings when sim and ref match within tolerance """
+
+    cfg = configparser.ConfigParser()
+    cfg['GENERAL'] = {'diffLim': '0.01', 'perDiff': '0.01'}
+    reportD = {
+        'Simulation Parameters': {
+            'type': 'list', 'Program version': '1.11', 'Friction model': 'samosAT',
+            'Density [kgm-3]': '200'},
+        'Aimec analysis': {
+            'type': 'list', 'runout [m]': 100.0, 'max peak pressure [kPa]': 360.0},
+        'Simulation Difference': {
+            'ppr': [0.0, 0.0, 0.0], 'pft': [0.0, 0.0, 0.0], 'pfv': [0.0, 0.0, 0.0]},
+        'Simulation Stats': {'ppr': [360.0, 0.0], 'pft': [5.0, 0.0], 'pfv': [42.0, 0.0]}}
+    benchD = {
+        'Simulation Parameters': {
+            'type': 'list', 'Program version': '1.10', 'Friction model': 'samosAT',
+            'Density [kgm-3]': '200'},
+        'Aimec analysis': {
+            'type': 'list', 'runout [m]': 100.0, 'max peak pressure [kPa]': 360.0}}
+
+    warnings = gR.collectComparisonWarnings(reportD, benchD, cfg)
+
+    assert warnings == []
+
+
+def test_collectComparisonWarnings_all(tmp_path):
+    """ parameter, aimec and plot warnings are all collected """
+
+    cfg = configparser.ConfigParser()
+    cfg['GENERAL'] = {'diffLim': '0.01', 'perDiff': '0.01'}
+    reportD = {
+        'Simulation Parameters': {
+            'type': 'list', 'Program version': 'development', 'Friction model': 'samosATMedium',
+            'Density [kgm-3]': '200'},
+        'Aimec analysis': {
+            'type': 'list', 'runout [m]': 110.0, 'max peak pressure [kPa]': 360.0},
+        'Simulation Difference': {
+            'ppr': [243.0, -2.2, -166.0], 'pft': [0.0, 0.0, 0.0], 'pfv': [0.0, 0.0, 0.0]},
+        'Simulation Stats': {'ppr': [364.0, 0.0], 'pft': [5.0, 0.0], 'pfv': [42.0, 0.0]}}
+    benchD = {
+        'Simulation Parameters': {
+            'type': 'list', 'Program version': '1.11', 'Friction model': 'samosAT',
+            'Density [kgm-3]': '200'},
+        'Aimec analysis': {
+            'type': 'list', 'runout [m]': 100.0, 'max peak pressure [kPa]': 360.0}}
+
+    warnings = gR.collectComparisonWarnings(reportD, benchD, cfg)
+
+    # parameter: Friction model differs; Program version is excluded; Density matches
+    paramWarnings = [w for w in warnings if w['category'] == 'parameter']
+    assert len(paramWarnings) == 1
+    assert paramWarnings[0] == {
+        'category': 'parameter', 'field': 'Friction model',
+        'ref': 'samosAT', 'sim': 'samosATMedium'}
+
+    # aimec: runout differs by 10% (>= 1%); max peak pressure matches
+    # diffPercent is a fraction (matches report convention): (ref - sim) / ref
+    aimecWarnings = [w for w in warnings if w['category'] == 'aimec']
+    assert len(aimecWarnings) == 1
+    assert aimecWarnings[0] == {
+        'category': 'aimec', 'field': 'runout [m]',
+        'ref': 100.0, 'sim': 110.0, 'diffPercent': -0.1}
+
+    # plot: ppr exceeds tolerance (maxDiff 243 vs 1% of 364); pft/pfv do not
+    plotWarnings = [w for w in warnings if w['category'] == 'plot']
+    assert len(plotWarnings) == 1
+    assert plotWarnings[0] == {
+        'category': 'plot', 'field': 'ppr',
+        'maxDiff': 243.0, 'meanDiff': -2.2, 'minDiff': -166.0, 'maxVal': 364.0}


### PR DESCRIPTION
- Introduced `collectComparisonWarnings` to identify and structure flagged differences between simulated, benchmark, and configuration data.

Add a per-test comparison-warnings summary to runStandardTestsCom1DFA.py, surfacing the differences the markdown report flags in red (parameter mismatches excluding Program version, aimec percentage-difference flags, and ppr/pft/pfv plot abs-diff warnings) directly in the run log, without modifying the report itself.