### PR TITLE
[in3Utils]: cfgUtils handling of `nan`

### DIFF
--- a/avaframe/in3Utils/cfgUtils.py
+++ b/avaframe/in3Utils/cfgUtils.py
@@ -948,7 +948,7 @@ def setStrnanToNan(simDF, simDFTest, name):
         updated pandas dataframe with np.nan values where string nan or none was
     """
 
-    nanIndex = simDFTest.str.match("nan|none", flags=re.IGNORECASE)
+    nanIndex = simDFTest.astype(str).str.lower().isin(["nan", "none"])
     simIndex = simDF.index.values
     # loop over each row and use iloc to avoid duplicate index issues
     for index, nanInd in enumerate(nanIndex):


### PR DESCRIPTION
When using the OpenNHM-QGIS-Connector on Windows, `in3Utils/cfgUtils.py/convertDF2numerics` could not handle `nan`.

<img width="901" height="831" alt="grafik" src="https://github.com/user-attachments/assets/e7dbba30-61a4-4ad0-9a61-b10c1ca41530" />


