### PR TITLE
[com6]: add support for `spatialVoellmy` friction model

### DIFF
--- a/avaframe/in3Utils/spatialVoellmyInputs.py
+++ b/avaframe/in3Utils/spatialVoellmyInputs.py
@@ -16,9 +16,9 @@ log = logging.getLogger(__name__)
 
 
 def generateMuXsiRasters(avaDir, cfg):
-    """Generate mu and xi raster files from polygon shapefiles.
+    """Generate mu and xi raster files from a polygon shapefile.
 
-    Reads polygon shapefiles with "mu" and "xsi" attribute fields,
+    Reads a polygon shapefile with "mu" and "xsi" attribute fields,
     rasterizes the attribute values onto a grid matching the DEM extent
     and resolution, and writes the rasters to Inputs/RASTERS/.
 
@@ -26,7 +26,7 @@ def generateMuXsiRasters(avaDir, cfg):
     ----------
     avaDir : pathlib.Path
         Path to avalanche directory containing Inputs/DEM and
-        Inputs/POLYGONS/ with *_mu.shp and *_xsi.shp shapefiles.
+        Inputs/POLYGONS/ with *_spatialVoellmy.shp shapefile.
     cfg : configparser.ConfigParser
         Configuration with [DEFAULTS] section containing
         default_mu and default_xsi values for uncovered areas.
@@ -40,17 +40,15 @@ def generateMuXsiRasters(avaDir, cfg):
     demPath = getDEMPath(avaDir)
     demSuffix = demPath.suffix
 
-    # Find shapefiles
-    muShpPath, muAvailable, _ = getAndCheckInputFiles(
-        inputDir, "POLYGONS", "mu shapefile", fileExt="shp", fileSuffix="_mu"
+    # Find shapefile
+    shpPath, shpAvailable, _ = getAndCheckInputFiles(
+        inputDir, "POLYGONS", "spatialVoellmy shapefile", fileExt="shp",
+        fileSuffix="_spatialVoellmy"
     )
-    if muAvailable == "No":
-        raise FileNotFoundError("No *_mu.shp found in %s/POLYGONS/" % inputDir)
-    xsiShpPath, xsiAvailable, _ = getAndCheckInputFiles(
-        inputDir, "POLYGONS", "xsi shapefile", fileExt="shp", fileSuffix="_xsi"
-    )
-    if xsiAvailable == "No":
-        raise FileNotFoundError("No *_xsi.shp found in %s/POLYGONS/" % inputDir)
+    if shpAvailable == "No":
+        raise FileNotFoundError(
+            "No *_spatialVoellmy.shp found in %s/POLYGONS/" % inputDir
+        )
 
     # Read DEM header
     demHeader = readRasterHeader(demPath)
@@ -61,13 +59,22 @@ def generateMuXsiRasters(avaDir, cfg):
     defaultMu = cfg["DEFAULTS"].getfloat("default_mu")
     defaultXsi = cfg["DEFAULTS"].getfloat("default_xsi")
 
-    # Rasterize mu
-    log.info("Rasterizing mu shapefile: %s", muShpPath)
-    muRaster = _rasterizeShapefile(muShpPath, defaultMu, "mu", demShape, demTransform)
+    # Validate required fields
+    with shapefile.Reader(str(shpPath)) as sf:
+        fieldNames = [f[0].lower() for f in sf.fields[1:]]
+    for field in ["mu", "xsi"]:
+        if field not in fieldNames:
+            raise KeyError(
+                "Field '%s' not found in %s. Available fields: %s"
+                % (field, shpPath.name, fieldNames)
+            )
 
-    # Rasterize xsi
-    log.info("Rasterizing xsi shapefile: %s", xsiShpPath)
-    xsiRaster = _rasterizeShapefile(xsiShpPath, defaultXsi, "xsi", demShape, demTransform)
+    # Rasterize mu and xsi from the same shapefile
+    log.info("Rasterizing mu from: %s", shpPath)
+    muRaster = _rasterizeShapefile(shpPath, defaultMu, "mu", demShape, demTransform)
+
+    log.info("Rasterizing xsi from: %s", shpPath)
+    xsiRaster = _rasterizeShapefile(shpPath, defaultXsi, "xsi", demShape, demTransform)
 
     # Determine output driver
     if demSuffix == ".asc":

--- a/avaframe/runCom6RockAvalanche.py
+++ b/avaframe/runCom6RockAvalanche.py
@@ -69,31 +69,33 @@ def runCom6RockAvalanche(avalancheDir="", calibration="voellmy"):
 
         muRasters = list((avaDir / "Inputs" / "RASTERS").glob("*_mu.*"))
         xiRasters = list((avaDir / "Inputs" / "RASTERS").glob("*_xi.*"))
-        muShps = list((avaDir / "Inputs" / "POLYGONS").glob("*_mu.shp"))
-        xsiShps = list((avaDir / "Inputs" / "POLYGONS").glob("*_xsi.shp"))
+        spatialShps = list(
+            (avaDir / "Inputs" / "POLYGONS").glob("*_spatialVoellmy.shp")
+        )
 
         rastersExist = bool(muRasters and xiRasters)
-        shapefilesExist = bool(muShps and xsiShps)
+        shpExists = bool(spatialShps)
 
-        if rastersExist and shapefilesExist:
+        if rastersExist and shpExists:
             raise RuntimeError(
                 "spatialVoellmy friction model: both rasters in Inputs/RASTERS/"
-                " and polygon shapefiles in Inputs/POLYGONS/ found - ambiguous input"
+                " and *_spatialVoellmy.shp in Inputs/POLYGONS/ found"
+                " - ambiguous input"
             )
-        elif shapefilesExist and not rastersExist:
+        elif shpExists:
             spatialVoellmyCfg = cfgUtils.getModuleConfig(spatialVoellmyInputs)
             # set default fill values from rock avalanche Voellmy defaults
             overrideParams = rockAvalancheCfg["com1DFA_com1DFA_override"]
             spatialVoellmyCfg["DEFAULTS"]["default_mu"] = overrideParams["muvoellmy"]
             spatialVoellmyCfg["DEFAULTS"]["default_xsi"] = overrideParams["xsivoellmy"]
             spatialVoellmyInputs.generateMuXsiRasters(avaDir, spatialVoellmyCfg)
-        elif rastersExist and not shapefilesExist:
+        elif rastersExist:
             log.info("spatialVoellmy: using existing mu/xi rasters from Inputs/RASTERS/")
         else:
             raise FileNotFoundError(
                 "spatialVoellmy friction model: no *_mu and *_xi rasters found in"
-                " Inputs/RASTERS/ and no *_mu.shp and *_xsi.shp polygon shapefiles"
-                " found in Inputs/POLYGONS/"
+                " Inputs/RASTERS/ and no *_spatialVoellmy.shp found in"
+                " Inputs/POLYGONS/"
             )
 
     # perform com1DFA simulation with rock avalanche settings

--- a/avaframe/runCom6RockAvalanche.py
+++ b/avaframe/runCom6RockAvalanche.py
@@ -15,15 +15,18 @@ from avaframe.in3Utils import fileHandlerUtils as fU
 
 # import computation modules
 from avaframe.com6RockAvalanche import com6RockAvalanche
+from avaframe.in3Utils import spatialVoellmyInputs
 
 
-def runCom6RockAvalanche(avalancheDir=""):
-    """Run com1DFA with rock avalanche parameters with only an avalanche directory as input
+def runCom6RockAvalanche(avalancheDir="", calibration="voellmy"):
+    """Run com1DFA with rock avalanche parameters
 
     Parameters
     ----------
     avalancheDir: str
         path to avalanche directory (setup e.g. with init scripts)
+    calibration: str
+        friction model: voellmy (default) or spatialVoellmy
 
     Returns
     -------
@@ -54,14 +57,49 @@ def runCom6RockAvalanche(avalancheDir=""):
     # Clean input directory(ies) of old work files
     initProj.cleanSingleAvaDir(avalancheDir, deleteOutput=False)
 
+    # pathlib version of avalanche dir
+    avaDir = pathlib.Path(avalancheDir)
+
     # load rock avalanche config
     rockAvalancheCfg = cfgUtils.getModuleConfig(com6RockAvalanche, avalancheDir)
+
+    # override friction model if spatialVoellmy calibration is requested
+    if calibration == "spatialVoellmy":
+        rockAvalancheCfg["com1DFA_com1DFA_override"]["frictModel"] = "spatialVoellmy"
+
+        muRasters = list((avaDir / "Inputs" / "RASTERS").glob("*_mu.*"))
+        xiRasters = list((avaDir / "Inputs" / "RASTERS").glob("*_xi.*"))
+        muShps = list((avaDir / "Inputs" / "POLYGONS").glob("*_mu.shp"))
+        xsiShps = list((avaDir / "Inputs" / "POLYGONS").glob("*_xsi.shp"))
+
+        rastersExist = bool(muRasters and xiRasters)
+        shapefilesExist = bool(muShps and xsiShps)
+
+        if rastersExist and shapefilesExist:
+            raise RuntimeError(
+                "spatialVoellmy friction model: both rasters in Inputs/RASTERS/"
+                " and polygon shapefiles in Inputs/POLYGONS/ found - ambiguous input"
+            )
+        elif shapefilesExist and not rastersExist:
+            spatialVoellmyCfg = cfgUtils.getModuleConfig(spatialVoellmyInputs)
+            # set default fill values from rock avalanche Voellmy defaults
+            overrideParams = rockAvalancheCfg["com1DFA_com1DFA_override"]
+            spatialVoellmyCfg["DEFAULTS"]["default_mu"] = overrideParams["muvoellmy"]
+            spatialVoellmyCfg["DEFAULTS"]["default_xsi"] = overrideParams["xsivoellmy"]
+            spatialVoellmyInputs.generateMuXsiRasters(avaDir, spatialVoellmyCfg)
+        elif rastersExist and not shapefilesExist:
+            log.info("spatialVoellmy: using existing mu/xi rasters from Inputs/RASTERS/")
+        else:
+            raise FileNotFoundError(
+                "spatialVoellmy friction model: no *_mu and *_xi rasters found in"
+                " Inputs/RASTERS/ and no *_mu.shp and *_xsi.shp polygon shapefiles"
+                " found in Inputs/POLYGONS/"
+            )
 
     # perform com1DFA simulation with rock avalanche settings
     _, plotDict, reportDictList, _ = com6RockAvalanche.com6RockAvalancheMain(cfgMain, rockAvalancheCfg)
 
     # Get peakfiles to return to QGIS
-    avaDir = pathlib.Path(avalancheDir)
     inputDir = avaDir / "Outputs" / "com1DFA" / "peakFiles"
     peakFilesDF = fU.makeSimDF(inputDir, avaDir=avaDir)
 
@@ -77,6 +115,14 @@ if __name__ == "__main__":
     parser.add_argument(
         "avadir", metavar="avadir", type=str, nargs="?", default="", help="the avalanche directory"
     )
+    parser.add_argument(
+        "-fc",
+        "--friction_calibration",
+        choices=["voellmy", "spatialVoellmy"],
+        type=str,
+        default="voellmy",
+        help="friction model: voellmy (default) or spatialVoellmy",
+    )
 
     args = parser.parse_args()
-    runCom6RockAvalanche(str(args.avadir))
+    runCom6RockAvalanche(str(args.avadir), str(args.friction_calibration))

--- a/avaframe/runScripts/runSpatialVoellmyInputs.py
+++ b/avaframe/runScripts/runSpatialVoellmyInputs.py
@@ -13,7 +13,7 @@ from avaframe.in3Utils import spatialVoellmyInputs
 
 
 def runSpatialVoellmyInputs(avaDir=""):
-    """Run generation of mu and xi rasters from shapefiles.
+    """Run generation of mu and xi rasters from shapefile.
 
     Parameters
     ----------

--- a/avaframe/tests/test_spatialVoellmyInputs.py
+++ b/avaframe/tests/test_spatialVoellmyInputs.py
@@ -49,8 +49,22 @@ def _makeSyntheticShapefile(shpPath, fieldName, featureCoordsValues):
             w.record(value)
 
 
+def _makeSpatialVoellmyShapefile(shpPath, features):
+    """Create a *_spatialVoellmy.shp with 'mu' and 'xsi' fields.
+
+    features: list of (coords_list, mu_value, xsi_value) tuples.
+    coords_list is list of (x, y) tuples forming a clockwise ring.
+    """
+    with shapefile.Writer(shpPath, shapeType=shapefile.POLYGON) as w:
+        w.field("mu", "F", decimal=6)
+        w.field("xsi", "F", decimal=6)
+        for coords, muVal, xsiVal in features:
+            w.poly([coords])
+            w.record(muVal, xsiVal)
+
+
 def test_generateMuXsiRasters_asc():
-    """Test raster generation with .asc DEM and shapefiles."""
+    """Test raster generation with .asc DEM and shapefile."""
     tmpDir = pathlib.Path(tempfile.mkdtemp())
     try:
         # Setup: DEM
@@ -60,29 +74,17 @@ def test_generateMuXsiRasters_asc():
         shutil.move(str(demPath), str(inputsDir / "DEM.asc"))
         demPath = inputsDir / "DEM.asc"
 
-        # Setup: mu shapefile with two polygons
+        # Setup: spatialVoellmy shapefile with two polygons, each with mu and xsi
         # Polygon 1: geographic (2..5, 7..9) -> rows 1-3, cols 2-5
         # Polygon 2: geographic (6..9, 2..5) -> rows 5-8, cols 6-9
         polyDir = inputsDir / "POLYGONS"
         polyDir.mkdir()
-        muShp = polyDir / "zones_mu.shp"
-        _makeSyntheticShapefile(
-            muShp,
-            "mu",
+        shpPath = polyDir / "zones_spatialVoellmy.shp"
+        _makeSpatialVoellmyShapefile(
+            shpPath,
             [
-                ([(2, 7), (5, 7), (5, 9), (2, 9), (2, 7)], 0.300),
-                ([(6, 2), (9, 2), (9, 5), (6, 5), (6, 2)], 0.500),
-            ],
-        )
-
-        # Setup: xsi shapefile (same geometry, different values)
-        xsiShp = polyDir / "zones_xsi.shp"
-        _makeSyntheticShapefile(
-            xsiShp,
-            "xsi",
-            [
-                ([(2, 7), (5, 7), (5, 9), (2, 9), (2, 7)], 3000.0),
-                ([(6, 2), (9, 2), (9, 5), (6, 5), (6, 2)], 5000.0),
+                ([(2, 7), (5, 7), (5, 9), (2, 9), (2, 7)], 0.300, 3000.0),
+                ([(6, 2), (9, 2), (9, 5), (6, 5), (6, 2)], 0.500, 5000.0),
             ],
         )
 
@@ -135,10 +137,11 @@ def test_generateMuXsiRasters_tif():
 
         polyDir = inputsDir / "POLYGONS"
         polyDir.mkdir()
-        muShp = polyDir / "zones_mu.shp"
-        _makeSyntheticShapefile(muShp, "mu", [([(2, 7), (5, 7), (5, 9), (2, 9), (2, 7)], 0.300)])
-        xsiShp = polyDir / "zones_xsi.shp"
-        _makeSyntheticShapefile(xsiShp, "xsi", [([(2, 7), (5, 7), (5, 9), (2, 9), (2, 7)], 3000.0)])
+        shpPath = polyDir / "zones_spatialVoellmy.shp"
+        _makeSpatialVoellmyShapefile(
+            shpPath,
+            [([(2, 7), (5, 7), (5, 9), (2, 9), (2, 7)], 0.300, 3000.0)],
+        )
 
         import configparser
 
@@ -169,13 +172,13 @@ def test_missingMuFieldRaises():
         shutil.move(str(demPath), str(inputsDir / "DEM.asc"))
         polyDir = inputsDir / "POLYGONS"
         polyDir.mkdir()
-        # Shapefile with wrong field name
-        _makeSyntheticShapefile(
-            polyDir / "zones_mu.shp", "friction_mu", [([(2, 7), (5, 7), (5, 9), (2, 9), (2, 7)], 0.3)]
-        )
-        _makeSyntheticShapefile(
-            polyDir / "zones_xsi.shp", "xsi", [([(2, 7), (5, 7), (5, 9), (2, 9), (2, 7)], 3000.0)]
-        )
+        # Shapefile with wrong field name instead of 'mu'
+        shpPath = polyDir / "zones_spatialVoellmy.shp"
+        with shapefile.Writer(shpPath, shapeType=shapefile.POLYGON) as w:
+            w.field("friction_mu", "F", decimal=6)
+            w.field("xsi", "F", decimal=6)
+            w.poly([[(2, 7), (5, 7), (5, 9), (2, 9), (2, 7)]])
+            w.record(0.3, 3000.0)
 
         import configparser
 

--- a/docs/moduleCom6RockAvalanche.rst
+++ b/docs/moduleCom6RockAvalanche.rst
@@ -23,6 +23,12 @@ To run
 * copy ``avaframeCfg.ini`` to ``local_avaframeCfg.ini`` and set your desired avalanche directory name
 * create an avalanche directory with required input files - for this task you can use :ref:`moduleIn3Utils:Initialize Project`
 * copy ``com6RockAvalanche/com6RockAvalancheCfg.ini`` to ``com6RockAvalanche/local_com6RockAvalancheCfg.ini`` and if desired change configuration settings
+* optionally, the ``spatialVoellmy`` friction model can be selected with
+  ``--friction_calibration spatialVoellmy``. When using the QGis Connector,
+  a  shapefile with ``mu`` and ``xsi`` attributes
+  can be provided and the required rasters will
+  be generated automatically. See
+  :ref:`moduleIn3Utils:Spatial Voellmy inputs` for details.
 * if you are on a develop installation, make sure you have an updated compilation, see :ref:`complexUsage:Update AvaFrame`
 * run:
   ::

--- a/docs/moduleIn3Utils.rst
+++ b/docs/moduleIn3Utils.rst
@@ -14,16 +14,17 @@ Spatial Voellmy inputs
 ======================
 
 The :py:mod:`in3Utils.spatialVoellmyInputs` module generates raster files
-for the Voellmy friction parameters :math:`\mu` and :math:`\xi` from polygon
-shapefiles. This is required when using the ``spatialVoellmy`` friction model
-in com1DFA (see :ref:`moduleCom1DFA:Input`).
+for the Voellmy friction parameters :math:`\mu` and :math:`\xi` from a
+polygon shapefile. This is required when using the ``spatialVoellmy``
+friction model in com1DFA (see :ref:`moduleCom1DFA:Input`).
 
-Provide polygon shapefiles with ``mu`` and ``xsi`` attribute fields in
-``Inputs/POLYGONS/``, with file names ending in ``_mu.shp`` and ``_xsi.shp``.
-The DEM must be placed in ``Inputs/``. The generated rasters are written to
-``Inputs/RASTERS/`` with the same file format as the DEM.
+Provide a polygon shapefile with ``mu`` and ``xsi`` attribute fields in
+``Inputs/POLYGONS/``, with a file name ending in ``_spatialVoellmy.shp``.
+Each polygon feature must include both a ``mu`` and an ``xsi`` attribute
+value. The DEM must be placed in ``Inputs/``. The generated rasters are
+written to ``Inputs/RASTERS/`` with the same file format as the DEM.
 
-Default values for areas not covered by the polygon shapefiles are set in
+Default values for areas not covered by the polygons are set in
 ``avaframe/in3Utils/spatialVoellmyInputsCfg.ini``.
 
 
@@ -35,7 +36,7 @@ To run
   ``in3Utils/local_spatialVoellmyInputsCfg.ini`` and set desired
   ``default_mu`` and ``default_xsi`` values (if not, the default values
   are used)
-* ensure the DEM and shapefiles are in the avalanche directory as
+* ensure the DEM and shapefile are in the avalanche directory as
   described above
 * run::
 


### PR DESCRIPTION
 - Add --friction_calibration flag to runCom6RockAvalanche.py (voellmy | spatialVoellmy)          
 - Auto-generate mu/xi rasters from *_spatialVoellmy.shp when spatialVoellmy selected             
 - Fill default values from rock avalanche Voellmy config (mu=0.035, xi=700)                      
 - Error if rasters and shapefile both present (ambiguous)                                        
 - Consolidate two-shapefile input (*_mu.shp / *_xsi.shp) into single *_spatialVoellmy.shp with   
   mu and xsi attributes across spatialVoellmyInputs and runSpatialVoellmyInputs                  
 - Update tests and docs  

## PR Checklist

Please confirm before requesting review:

- [x] I ran `pytest` locally without fails
- [x] I added/updated tests where needed
- [x] I updated documentation where needed

Confirm before the final merge/rebase into master

- [ ] Commits are sensibly squashed and rebased onto latest master
- [ ] Standardtest run without difference (with recompiled cython code)
