### PR TITLE
[com1]: Update report com1

### DIFF
--- a/avaframe/com1DFA/com1DFA.py
+++ b/avaframe/com1DFA/com1DFA.py
@@ -1219,8 +1219,8 @@ def initializeSimulation(cfg, outDir, demOri, inputSimLines, logName):
     relAreaActual = np.sum(relAreaActualList)
     reportAreaInfo = {
         "Release area info": {
-            "Projected Area [m2]": "%.2f" % (relAreaProjected),
-            "Actual Area [m2]": "%.2f" % (relAreaActual),
+            "Projected Area [m2] (raster-based)": "%.0f" % (relAreaProjected),
+            "Actual Area [m2] (raster-based)": "%.0f" % (relAreaActual),
         }
     }
 
@@ -1259,7 +1259,7 @@ def initializeSimulation(cfg, outDir, demOri, inputSimLines, logName):
         particles = DFAfunC.updateInitialVelocity(cfgGen, particles, dem, releaseLine["velocity"])
     particles, fields = initializeFields(cfg, dem, particles, releaseLine)
 
-    reportAreaInfo["Release area info"]["Model release volume [m3]"] = "%.2f" % (
+    reportAreaInfo["Release area info"]["Model release volume [m3]"] = "%.0f" % (
         particles["mTot"] / cfgGen.getfloat("rho")
     )
     if cfgGen.getboolean("timeDependentRelease"):

--- a/avaframe/tests/test_com1DFA.py
+++ b/avaframe/tests/test_com1DFA.py
@@ -2641,7 +2641,7 @@ def test_initializeSimulation(tmp_path):
     )
     assert particles["mTot"] == 450.0
     assert np.sum(particles["ux"]) == 0.0
-    assert reportAreaInfo["Release area info"]["Projected Area [m2]"] == "4.00"
+    assert reportAreaInfo["Release area info"]["Projected Area [m2] (raster-based)"] == "4"
     assert reportAreaInfo["entrainment"] == "Yes"
     assert reportAreaInfo["resistance"] == "No"
 
@@ -2695,7 +2695,7 @@ def test_initializeSimulation(tmp_path):
     assert particles2["mTot"] == 400.0
     assert particles2["massInitialized"] == 400.0
     assert np.sum(particles["ux"]) == 0.0
-    assert reportAreaInfo["Release area info"]["Projected Area [m2]"] == "4.00"
+    assert reportAreaInfo["Release area info"]["Projected Area [m2] (raster-based)"] == "4"
     assert reportAreaInfo["entrainment"] == "Yes"
     assert reportAreaInfo["resistance"] == "No"
     assert np.sum(particles2["secondaryReleaseInfo"]["rasterData"]) == 4.5


### PR DESCRIPTION
add info in com1DFA report that projected area and actual area are derived from the release raster and hence are an approximation of the polygon area (deviations are a function of mesh cell size) 

## PR Checklist

Please confirm before requesting review:

- [x] I ran `pytest` locally without fails
- [x] I added/updated tests where needed
- [x] I updated documentation where needed

Confirm before the final merge/rebase into master

- [x] Commits are sensibly squashed and rebased onto latest master
- [x] Standardtest run without difference (with recompiled cython code)
